### PR TITLE
IZPACK-807: Replace hard-coded uninstaller path in RegistryInstallerListener

### DIFF
--- a/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
@@ -515,8 +515,9 @@ public class RegistryInstallerListener extends NativeInstallerListener implement
             return;
         }
         String keyName = RegistryHandler.UNINSTALL_ROOT + uninstallName;
+        String uninstallerPath = IoHelper.translatePath(installData.getInfo().getUninstallerPath(), installData.getVariables()); 
         String cmd = "\"" + installData.getVariable("JAVA_HOME") + "\\bin\\javaw.exe\" -jar \""
-                + installData.getVariable("INSTALL_PATH") + "\\uninstaller\\uninstaller.jar\"";
+                + uninstallerPath + "\\" + installData.getInfo().getUninstallerName() + "\"";
         String appVersion = installData.getVariable("APP_VER");
         String appUrl = installData.getVariable("APP_URL");
 

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsHelper.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsHelper.java
@@ -8,6 +8,7 @@ import java.io.File;
 
 import javax.swing.SwingUtilities;
 
+import com.coi.tools.os.win.RegDataContainer;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.exception.NativeLibException;
 import com.izforge.izpack.core.os.RegistryDefaultHandler;
@@ -89,6 +90,30 @@ public class WindowsHelper
         assertNotNull(registry);
         registry.setRoot(RegistryHandler.HKEY_LOCAL_MACHINE);
         return registry.keyExist(key);
+    }
+    
+    /**
+     * Asserts that a registry key REG_SZ value exists, and exactly matches the given value.
+     * 
+     * @param handler the registry handler
+     * @param key	  the key to check
+     * @param name	  the name of the value to check
+     * @param expected	  the value to match
+     * @throws NativeLibException for any registry error
+     */
+    public static void registryValueStringEquals(RegistryDefaultHandler handler, String key, String name, String expected) throws NativeLibException
+    {
+    	//Registry key exists
+    	RegistryHandler registry = handler.getInstance();
+        assertNotNull(registry);
+        registry.setRoot(RegistryHandler.HKEY_LOCAL_MACHINE);
+        assertTrue(registry.keyExist(key));
+        //Value exists as a REG_SZ
+        assertTrue(registry.valueExist(key, name));
+        RegDataContainer value = registry.getValue(key, name);
+        assertEquals("Registry key value " + name + " is not type REG_SZ", RegDataContainer.REG_SZ, value.getType());
+        //Value matches expected string
+        assertEquals(expected, registry.getValue(key, name).getStringData());
     }
 
     /**

--- a/izpack-test/src/test/resources/samples/windows/consoleinstall_alt_uninstall.xml
+++ b/izpack-test/src/test/resources/samples/windows/consoleinstall_alt_uninstall.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
+<installation version="1.0">
+    <info>
+        <appname>IzPack Windows Console Installation Test</appname>
+        <!-- TODO - this can be replaced with windows/install.xml when a PacksPanel, ShortcutPanel and SimpleFinishPanel
+                    console implementation is developed -->
+        <appversion>1.0</appversion>
+        <uninstaller path="${INSTALL_PATH}" name="uninstallme.jar">yes</uninstaller>
+    </info>
+
+    <guiprefs width="600" height="480" resizable="yes"/>
+
+    <locale>
+        <langpack iso3="eng" />
+    </locale>
+
+    <resources>
+        <res id="shortcutSpec.xml" src="shortcutSpec.xml"/>
+    </resources>
+
+    <panels>
+        <panel classname="CheckedHelloPanel"/>
+        <panel classname="InfoPanel"/>
+        <panel classname="TargetPanel"/>
+        <panel classname="InstallPanel"/>
+        <panel classname="FinishPanel" />
+    </panels>
+
+    <!-- The listeners section for CustomActions -->
+    <listeners>
+        <listener classname="SummaryLoggerInstallerListener" stage="install"/>
+        <listener classname="RegistryInstallerListener" stage="install">
+            <os family="windows"/>
+        </listener>
+        <listener classname="RegistryUninstallerListener" stage="uninstall">
+            <os family="windows"/>
+        </listener>
+    </listeners>
+
+    <packs>
+        <pack name="Base" required="yes">
+            <description>The base files</description>
+        </pack>
+    </packs>
+
+    <!-- NOTE - the following stage attributes are only applicable for testing purposes -->
+    <natives>
+        <native type="izpack" name="ShellLink.dll" stage="install"/>
+        <native type="izpack" name="ShellLink_x64.dll" stage="install"/>
+        <native type="izpack" name="WinSetupAPI.dll" stage="both"/>
+        <native type="izpack" name="WinSetupAPI_x64.dll" stage="both"/>
+        <native type="3rdparty" name="COIOSHelper.dll" stage="uninstall"/>
+        <native type="3rdparty" name="COIOSHelper_x64.dll" stage="uninstall"/>
+    </natives>
+</installation>


### PR DESCRIPTION
- Changed RegistryInstallerListener to get the uninstaller path and name from the install data. 
- Added a new test case in WindowsConsoleInstallationTest with a new install XML that specifies a non-default uninstaller path and name.
- Added a helper method in WindowsHelper for testing registry string values.
