### PR TITLE
IZPACK-811: TRACE mode throws NullPointerException when language selection dialog isn't displayed

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/debugger/Debugger.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/debugger/Debugger.java
@@ -123,7 +123,9 @@ public class Debugger
     {
         conditionhistoryrenderer.clearState();
         updateChangedConditions(
-                "changed after panel switch from " + lastpanelmetadata.getPanelid() + " to " + nextpanelmetadata.getPanelid());
+                "changed after panel switch" + 
+                (lastpanelmetadata == null ? "" : "from " + lastpanelmetadata.getPanelid()) +
+                " to " + nextpanelmetadata.getPanelid());
     }
 
     private void updateChangedConditions(String comment)


### PR DESCRIPTION
Added an inline null check on a 'last panel' object in Debugger.
