### PR TITLE
IZPACK-812: Incorrect display of 'product already exists' message in CheckedHelloPanel

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloPanel.java
@@ -97,7 +97,7 @@ public class CheckedHelloPanel extends HelloPanel
             path = "<not found>";
         }
         String noLuck = getString("CheckedHelloPanel.productAlreadyExist0") + path + " . "
-                + getString("CheckedHelloPanel.prouctAlreadyExist1");
+                + getString("CheckedHelloPanel.productAlreadyExist1");
         return (askQuestion(getString("installer.error"), noLuck,
                             AbstractUIHandler.CHOICES_YES_NO) == AbstractUIHandler.ANSWER_YES);
     }


### PR DESCRIPTION
Fixed the typo in an i18n key in CheckedHelloPanel.
