### PR TITLE
IZPACK-743: Uninstall data written on quit from CheckedHelloPanel

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloPanel.java
@@ -22,10 +22,12 @@ package com.izforge.izpack.panels.checkedhello;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.exception.NativeLibException;
 import com.izforge.izpack.api.handler.AbstractUIHandler;
 import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
@@ -142,6 +144,10 @@ public class CheckedHelloPanel extends HelloPanel
                     setUniqueUninstallKey();
                     abortInstallation = false;
                     parent.unlockNextButton();
+                } else {
+                	installData.getInfo().setUninstallerPath(null);
+                	installData.getInfo().setUninstallerName(null);
+                	installData.getInfo().setUninstallerCondition("uninstaller.nowrite");
                 }
             }
             catch (Exception exception)


### PR DESCRIPTION
This solution sets all uninstaller information in the installData instance to null or false values. It's kind of overkill. The method UninstallerDataWriter.isUninstallRequired(), which is called from InstallerFrame.writeUninstallData(), checks that
- uninstaller path is not null
  AND 
- the string identifying the shouldWrite condition is null OR is empty OR refers to a condition that evaluates to true.

This solution sets uninstaller path and name to null, and sets the condition to a fake id (uninstaller.nowrite). The isUninstallRequired() test fails as desired at the first hurdle - uninstaller path is null. It just seemed like a good idea to be thorough. If the test for the condition "uninstaller.nowrite" was actually executed, it would generate a WARNING-level message that the condition ID could not be found.
