### PR TITLE
IZPACK-815: Sub menus are not created in Gnome3

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
@@ -1387,28 +1387,36 @@ public class ShortcutPanelLogic implements CleanupClient, IShortcutPanelLogic
             String menuFile = createXDGMenu(desktopFileNames, groupName);
             String dirFile = createXDGDirectory(groupName, icon, comment);
             String menuFolder;
+            String gnome3MenuFolder;
             String directoryFolder;
             if (userType == Shortcut.ALL_USERS)
             {
                 menuFolder = "/etc/xdg/menus/applications-merged/";
+                gnome3MenuFolder = "/etc/xdg/menus/applications-gnome-merged/";
                 directoryFolder = "/usr/share/desktop-directories/";
             }
             else
             {
                 menuFolder = System.getProperty("user.home") + File.separator
                         + ".config/menus/applications-merged/";
+                gnome3MenuFolder = System.getProperty("user.home") + File.separator
+                        + ".config/menus/applications-gnome-merged/";
                 directoryFolder = System.getProperty("user.home") + File.separator
                         + ".local/share/desktop-directories/";
             }
             File menuFolderFile = new File(menuFolder);
+            File gnome3MenuFolderFile = new File(gnome3MenuFolder);
             File directoryFolderFile = new File(directoryFolder);
             String menuFilePath = menuFolder + groupName + ".menu";
+            String gnome3MenuFilePath = gnome3MenuFolder + groupName + ".menu";
             // Ubuntu can't handle spaces in the directory file name
             String dirFilePath = directoryFolder + groupName.replaceAll(" ", "-")
                     + "-izpack.directory";
             menuFolderFile.mkdirs();
+            gnome3MenuFolderFile.mkdirs();
             directoryFolderFile.mkdirs();
             writeString(menuFile, menuFilePath);
+            writeString(menuFile, gnome3MenuFilePath);
             writeString(dirFile, dirFilePath);
         }
     }


### PR DESCRIPTION
Related: http://lists.fedoraproject.org/pipermail/devel/2011-August/155342.html

Gnome3 does not follow the freedesktop specifications anymore! There is a
mismatch between the path that gnome3 looks for the menu and the path defined in
the freedesktop specification. That's why it worked fine in Gnome2 (and KDE 4.x)
but not in Gnome3.

Solution is to write the .menu file in ~/.config/menus/application-gnome-merged/

Thanks to Jyoti Tripathi for the help!
