### PR TITLE
IZPACK-822: IconsDatabase should be used to get installer JFrameIcon

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/GUIInstallerContainer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/GUIInstallerContainer.java
@@ -13,8 +13,8 @@ import org.picocontainer.injectors.ProviderAdapter;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.ContainerException;
 import com.izforge.izpack.api.resource.Messages;
-import com.izforge.izpack.core.resource.ResourceManager;
 import com.izforge.izpack.gui.GUIPrompt;
+import com.izforge.izpack.gui.IconsDatabase;
 import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.container.provider.GUIInstallDataProvider;
 import com.izforge.izpack.installer.container.provider.IconsProvider;
@@ -100,11 +100,10 @@ public class GUIInstallerContainer extends InstallerContainer
 
     private JFrame initFrame()
     {
-        ResourceManager resourceManager = getComponent(ResourceManager.class);
+        IconsDatabase icons = getComponent(IconsDatabase.class);
         // Dummy Frame
         JFrame frame = new JFrame();
-        ImageIcon imageIcon;
-        imageIcon = resourceManager.getImageIcon("JFrameIcon", "/com/izforge/izpack/img/JFrameIcon.png");
+        ImageIcon imageIcon = icons.get("JFrameIcon");
         frame.setIconImage(imageIcon.getImage());
 
         Dimension frameSize = frame.getSize();

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -317,7 +317,7 @@ public class InstallerFrame extends JFrame implements InstallerView
     public void buildGUI()
     {
         this.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-        ImageIcon jframeIcon = resourceManager.getImageIcon("JFrameIcon", "/com/izforge/izpack/img/JFrameIcon.png");
+        ImageIcon jframeIcon = getIcons().get("JFrameIcon");
         setIconImage(jframeIcon.getImage());
         // Prepares the glass pane to block the gui interaction when needed
         JPanel glassPane = (JPanel) getGlassPane();

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/InstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/InstallationTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.compiler.container.TestInstallationContainer;
-import com.izforge.izpack.core.resource.ResourceManager;
+import com.izforge.izpack.gui.IconsDatabase;
 import com.izforge.izpack.installer.container.impl.InstallerContainer;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerController;
@@ -40,19 +40,20 @@ public class InstallationTest
     @Rule
     public TestRule globalTimeout = new Timeout(HelperTestMethod.TIMEOUT);
     private FrameFixture installerFrameFixture;
-    private ResourceManager resourceManager;
+    private IconsDatabase icons;
     private LanguageDialog languageDialog;
     private InstallerFrame installerFrame;
     private GUIInstallData installData;
     private InstallerController installerController;
     private InstallerContainer installerContainer;
 
-    public InstallationTest(ResourceManager resourceManager, LanguageDialog languageDialog,
+    public InstallationTest(IconsDatabase icons, LanguageDialog languageDialog,
                             InstallerFrame installerFrame, GUIInstallData installData,
                             InstallerController installerController, InstallerContainer installerContainer)
     {
         this.installerController = installerController;
-        this.resourceManager = resourceManager;
+//        this.resourceManager = resourceManager;
+        this.icons = icons;
         this.languageDialog = languageDialog;
         this.installData = installData;
         this.installerFrame = installerFrame;
@@ -73,7 +74,7 @@ public class InstallationTest
     @InstallFile("samples/helloAndFinish.xml")
     public void testHelloAndFinishPanels() throws Exception
     {
-        Image image = resourceManager.getImageIcon("/com/izforge/izpack/img/JFrameIcon.png").getImage();
+    	Image image = icons.get("JFrameIcon").getImage();
         assertThat(image, IsNull.<Object>notNullValue());
 
         languageDialog.initLangPack();


### PR DESCRIPTION
Updated InstallerFrame, GUIInstallerContainer (for language selection dialog) and InstallationTest.
