### PR TITLE
InstallPanel: move noOfPacks check from c-tor to startAction method

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanel.java
@@ -122,10 +122,6 @@ public class InstallPanel extends IzPanel implements ProgressListener
 
         overallProgressBar = new JProgressBar();
         overallProgressBar.setStringPainted(true);
-        if (noOfPacks == 1)
-        {
-            overallProgressBar.setIndeterminate(true);
-        }
         overallProgressBar.setString("");
         overallProgressBar.setValue(0);
         add(this.overallProgressBar, IzPanelLayout.getDefaultConstraint(FULL_LINE_CONTROL_CONSTRAINT));
@@ -157,6 +153,10 @@ public class InstallPanel extends IzPanel implements ProgressListener
                 // figure out how many packs there are to install
                 overallProgressBar.setMinimum(0);
                 overallProgressBar.setMaximum(noOfPacks);
+                if (noOfPacks == 1)
+                {
+                    overallProgressBar.setIndeterminate(true);
+                }
                 overallProgressBar.setString("0 / " + Integer.toString(noOfPacks));
             }
         });


### PR DESCRIPTION
Hi,

The issue http://jira.codehaus.org/browse/IZPACK-155 was still happening to us with version 4.3.5, and this change fixed it. You can see in the code that when number of packs was tested in the constructor, it contained the initial value (0) so the test always came back negative. By moving the test to startAction method, I saw the progress bar actually becoming indeterminate. Please review the fix and consider merging.

Thanks,
  Yardena.
