### PR TITLE
IZPACK-297 

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/htmllicence/HTMLLicencePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/htmllicence/HTMLLicencePanel.java
@@ -21,12 +21,16 @@ package com.izforge.izpack.panels.htmllicence;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.net.URL;
 
 import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
+import javax.swing.KeyStroke;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.text.Document;
@@ -74,7 +78,7 @@ public class HTMLLicencePanel extends IzPanel implements HyperlinkListener, Acti
      * @param resources   the resources
      * @param log         the log
      */
-    public HTMLLicencePanel(Panel panel, InstallerFrame parent, GUIInstallData installData, Resources resources,
+    public HTMLLicencePanel(Panel panel, final InstallerFrame parent, GUIInstallData installData, Resources resources,
                             Log log)
     {
         super(panel, parent, installData, new IzPanelLayout(log), resources);
@@ -92,6 +96,22 @@ public class HTMLLicencePanel extends IzPanel implements HyperlinkListener, Acti
             textArea.addHyperlinkListener(this);
             JScrollPane scroller = new JScrollPane(textArea);
             textArea.setPage(loadLicence());
+
+            // register a listener to trigger the default button if enter is pressed whilst the text area has the focus
+            ActionListener fireDefault = new ActionListener()
+            {
+                @Override
+                public void actionPerformed(ActionEvent e)
+                {
+                    JButton defaultButton = parent.getRootPane().getDefaultButton();
+                    if (defaultButton != null && defaultButton.isEnabled())
+                    {
+                        defaultButton.doClick();
+                    }
+                }
+            };
+            textArea.registerKeyboardAction(fireDefault, null, KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+                                            JComponent.WHEN_FOCUSED);
             add(scroller, NEXT_LINE);
         }
         catch (Exception err)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/LicencePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/LicencePanel.java
@@ -23,11 +23,15 @@ package com.izforge.izpack.panels.licence;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 
 import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.KeyStroke;
 
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.Panel;
@@ -72,7 +76,8 @@ public class LicencePanel extends IzPanel implements ActionListener
      * @param resources   the resources
      * @param log         the log
      */
-    public LicencePanel(Panel panel, InstallerFrame parent, GUIInstallData installData, Resources resources, Log log)
+    public LicencePanel(Panel panel, final InstallerFrame parent, GUIInstallData installData, Resources resources,
+                        Log log)
     {
         super(panel, parent, installData, new IzPanelLayout(log), resources);
         // We load the licence
@@ -91,6 +96,22 @@ public class LicencePanel extends IzPanel implements ActionListener
         JScrollPane scroller = new JScrollPane(textArea);
         scroller.setAlignmentX(LEFT_ALIGNMENT);
         add(scroller, NEXT_LINE);
+
+        // register a listener to trigger the default button if enter is pressed whilst the text area has the focus
+        ActionListener fireDefault = new ActionListener()
+        {
+            @Override
+            public void actionPerformed(ActionEvent e)
+            {
+                JButton defaultButton = parent.getRootPane().getDefaultButton();
+                if (defaultButton != null && defaultButton.isEnabled())
+                {
+                    defaultButton.doClick();
+                }
+            }
+        };
+        textArea.registerKeyboardAction(fireDefault, null, KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+                                        JComponent.WHEN_FOCUSED);
 
         ButtonGroup group = new ButtonGroup();
 


### PR DESCRIPTION
Fix for IZPACK-297 Izpack Enter Key Behaviour on License Agreement Screen

The default button is now triggered if enter is pressed whilst the text area has the focus.
Change has been applied to both the HTMLLicencePanel and LicencePanel
