### PR TITLE
Fix for IZPACK-371 Memory options not transferred to sub-process

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/JVMHelper.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/JVMHelper.java
@@ -52,6 +52,7 @@ class JVMHelper
     {
         List<String> result = new ArrayList<String>();
         List<String> inputArguments = getInputArguments();
+        inputArguments = join(inputArguments);
         for (String arg : inputArguments)
         {
             if (!arg.startsWith("-Dself.mod.") && !arg.equals("-Xdebug") && !arg.startsWith("-Xrunjdwp")
@@ -73,6 +74,33 @@ class JVMHelper
     {
         RuntimeMXBean bean = ManagementFactory.getRuntimeMXBean();
         return bean.getInputArguments();
+    }
+
+    /**
+     * Joins any arguments that have been split as a workaround for
+     * <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6459832">Bug ID 6459832</a>
+     * <p/>
+     * This looks for arguments that aren't prefixed with a '-', concatenating them to the previous argument with a
+     * space.
+     *
+     * @param arguments the arguments
+     * @return the arguments, with any split arguments joined
+     */
+    protected List<String> join(List<String> arguments)
+    {
+        List<String> result = new ArrayList<String>();
+        for (int i = 0; i < arguments.size(); )
+        {
+            String arg = arguments.get(i);
+            ++i;
+            while (i < arguments.size() && !arguments.get(i).startsWith("-"))
+            {
+                arg = arg + " " + arguments.get(i);
+                ++i;
+            }
+            result.add(arg);
+        }
+        return result;
     }
 
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/PrivilegedRunner.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/PrivilegedRunner.java
@@ -98,6 +98,11 @@ public class PrivilegedRunner
         boolean result;
         if (platform.isA(WINDOWS))
         {
+            if (path != null)
+            {
+                // use the parent path, as that needs to be written to in order to delete the tree
+                path = new File(path).getParent();
+            }
             if (path == null || path.trim().length() == 0)
             {
                 path = getProgramFiles();

--- a/izpack-util/src/test/java/com/izforge/izpack/util/JVMHelperTest.java
+++ b/izpack-util/src/test/java/com/izforge/izpack/util/JVMHelperTest.java
@@ -72,4 +72,35 @@ public class JVMHelperTest
         assertTrue(args.contains("-Xms64M"));
         assertTrue(args.contains("-XX:MaxPermSize=64m"));
     }
+
+
+    /**
+     * Tests {@link JVMHelper#getJVMArguments()} for arguments that contain spaces.
+     * <p/>
+     * Due to a bug in {@link java.lang.management.RuntimeMXBean#getInputArguments()}, arguments with spaces are
+     * split. See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6459832 for more details.
+     */
+    @Test
+    public void testArgumentWithSpaces()
+    {
+        JVMHelper helper = new JVMHelper()
+        {
+            @Override
+            protected List<String> getInputArguments()
+            {
+                return Arrays.asList("-Dsomepath=C:\\Program",
+                                     "Files\\IzPack",
+                                     "-Dsomeotherpath=C:\\Program",
+                                     "Files",
+                                     "(x86)\\MyApp",
+                                     "5.0");
+            }
+        };
+        // verify that java debug, SelfModifier and PrivilegedRunner properties are excluded.
+        List<String> args = helper.getJVMArguments();
+        assertEquals(2, args.size());
+        assertTrue(args.contains("-Dsomepath=C:\\Program Files\\IzPack"));
+        assertTrue(args.contains("-Dsomeotherpath=C:\\Program Files (x86)\\MyApp 5.0"));
+    }
+
 }


### PR DESCRIPTION
Added workaround for http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6459832 by concatenating arguments to the previous argument if they don't start with a '-'. Arguments are concatenated with a space separating them.
