### PR TITLE
Adding a new variable to get the selected locale

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/AutomatedInstallData.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/AutomatedInstallData.java
@@ -342,6 +342,7 @@ public class AutomatedInstallData implements InstallData
         getXmlData().setAttribute("langpack", locale);
         // We load the langpack
         setVariable(ScriptParserConstant.ISO3_LANG, getLocaleISO3());
+        setVariable(ScriptParserConstant.ISO2_LANG, getLocaleISO3());
         setMessages(localeDatabase);
     }
 
@@ -361,6 +362,12 @@ public class AutomatedInstallData implements InstallData
     public String getLocaleISO3()
     {
         return getVariable(ScriptParserConstant.ISO3_LANG);
+    }
+    
+    @Override
+    public String getLocaleISO2()
+    {
+        return getVariable(ScriptParserConstant.ISO2_LANG);
     }
 
     @Deprecated
@@ -389,6 +396,10 @@ public class AutomatedInstallData implements InstallData
         this.locale = locale;
         getXmlData().setAttribute("langpack", code.toLowerCase());
         setVariable(ScriptParserConstant.ISO3_LANG, code.toLowerCase());
+        if(locale != null) 
+        {
+            setVariable(ScriptParserConstant.ISO2_LANG, locale.getLanguage());
+        }
     }
 
     /**

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/InstallData.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/InstallData.java
@@ -159,6 +159,13 @@ public interface InstallData
      * @return the current locale's ISO3 language code. May be {@code null}
      */
     String getLocaleISO3();
+    
+     /**
+     * Returns the current locale's ISO2 language code.
+     *
+     * @return the current locale's ISO2 language code. May be {@code null}
+     */
+    String getLocaleISO2();
 
     /**
      * Returns the localised messages.

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/ScriptParserConstant.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/ScriptParserConstant.java
@@ -65,6 +65,11 @@ public class ScriptParserConstant
      * The language IS03 code.
      */
     public static final String ISO3_LANG = "ISO3_LANG";
+    
+    /**
+     * The language IS0 code.
+     */
+    public static final String ISO2_LANG = "ISO2_LANG";
     /**
      * The language code as _ll_CC like used with ResourceBoundle.
      */

--- a/src/doc-reST/installation-files.txt
+++ b/src/doc-reST/installation-files.txt
@@ -137,6 +137,7 @@ The following variables are built-in :
 -   ``$APP_URL`` : the application URL
 -   ``$APP_VER`` : the application version
 -   ``$ISO3_LANG`` : the ISO3 language code of the selected langpack.
+-   ``$ISO2_LANG`` : the ISO2 language code of the selected langpack.
 -   ``$IP_ADDRESS`` : the IP Address of the local machine.
 -   ``$HOST_NAME`` : the HostName of the local machine.
 -   ``$FILE_SEPARATOR`` : the file separator on the installation system


### PR DESCRIPTION
Add a new automatic variable ISO2_LANG with the lang in Java 'classical' format thus enabling the filtering of packs with the selected lang.
