### PR TITLE
JIRA: IZPACK-880: Support a "izpack.windowsinstall.8" for Windows 8 installations

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -522,6 +522,7 @@ public class RulesEngineImpl implements RulesEngine
         createPlatformCondition("izpack.windowsinstall.2003", platform, Platforms.WINDOWS_2003);
         createPlatformCondition("izpack.windowsinstall.vista", platform, Platforms.WINDOWS_VISTA);
         createPlatformCondition("izpack.windowsinstall.7", platform, Platforms.WINDOWS_7);
+        createPlatformCondition("izpack.windowsinstall.8", platform, Platforms.WINDOWS_8);
         createPlatformCondition("izpack.linuxinstall", platform, Platforms.LINUX);
         createPlatformCondition("izpack.solarisinstall", platform, Platforms.SUNOS);
         createPlatformCondition("izpack.macinstall", platform, Platforms.MAC);

--- a/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
@@ -99,6 +99,11 @@ public class RulesEngineImplTest
     private static final String WINDOWS_7_INSTALL = "izpack.windowsinstall.7";
 
     /**
+     * Windows 8 install condition identifier.
+     */
+
+    private static final String WINDOWS_8_INSTALL = "izpack.windowsinstall.8";
+    /**
      * Linux install condition identifier.
      */
     private static final String LINUX_INSTALL = "izpack.linuxinstall";
@@ -132,7 +137,7 @@ public class RulesEngineImplTest
      * All install condition identifiers.
      */
     private static final String INSTALL_CONDITIONS[] = {AIX_INSTALL, WINDOWS_INSTALL, WINDOWS_XP_INSTALL,
-            WINDOWS_2003_INSTALL, WINDOWS_VISTA_INSTALL, WINDOWS_7_INSTALL, LINUX_INSTALL, SOLARIS_INSTALL,
+            WINDOWS_2003_INSTALL, WINDOWS_VISTA_INSTALL, WINDOWS_7_INSTALL, WINDOWS_8_INSTALL, LINUX_INSTALL, SOLARIS_INSTALL,
             SOLARIS_X86_INSTALL, SOLARIS_SPARC_INSTALL, MAC_INSTALL, MAC_OSX_INSTALL};
 
 
@@ -542,6 +547,7 @@ public class RulesEngineImplTest
         checkPlatformCondition(Platforms.WINDOWS_2003, WINDOWS_2003_INSTALL, WINDOWS_INSTALL);
         checkPlatformCondition(Platforms.WINDOWS_VISTA, WINDOWS_VISTA_INSTALL, WINDOWS_INSTALL);
         checkPlatformCondition(Platforms.WINDOWS_7, WINDOWS_7_INSTALL, WINDOWS_INSTALL);
+        checkPlatformCondition(Platforms.WINDOWS_8, WINDOWS_8_INSTALL, WINDOWS_INSTALL);
         checkPlatformCondition(Platforms.LINUX, LINUX_INSTALL);
         checkPlatformCondition(Platforms.SUNOS, SOLARIS_INSTALL);
         checkPlatformCondition(Platforms.SUNOS_X86, SOLARIS_X86_INSTALL, SOLARIS_INSTALL);

--- a/izpack-tools/src/main/java/com/izforge/izpack/util/OsVersionConstants.java
+++ b/izpack-tools/src/main/java/com/izforge/izpack/util/OsVersionConstants.java
@@ -146,6 +146,11 @@ public interface OsVersionConstants
     public final static String WINDOWS_7_VERSION = "6.1";
 
     /**
+     * Windows 8
+     */
+    public final static String WINDOWS_8_VERSION = "6.2";
+
+    /**
      * REDHAT  = "RedHat"
      */
     public final static String REDHAT = "RedHat";

--- a/izpack-tools/src/main/java/com/izforge/izpack/util/Platforms.java
+++ b/izpack-tools/src/main/java/com/izforge/izpack/util/Platforms.java
@@ -154,12 +154,17 @@ public class Platforms
     public static Platform WINDOWS_7 = new Platform(Name.WINDOWS, "WINDOWS_7", OsVersionConstants.WINDOWS_7_VERSION);
 
     /**
+     * Windows 7 platform.
+     */
+    public static Platform WINDOWS_8 = new Platform(Name.WINDOWS, "WINDOWS_8", OsVersionConstants.WINDOWS_8_VERSION);
+
+    /**
      * Known platforms.
      */
     public static Platform[] PLATFORMS = {AIX, DEBIAN_LINUX, FEDORA_LINUX, FREEBSD, HP_UX, LINUX, MAC, MAC_OSX,
             MANDRAKE_LINUX, MANDRIVA_LINUX, OS_2, RED_HAT_LINUX, SUNOS, SUNOS_X86,
             SUNOS_SPARC, SUSE_LINUX, UBUNTU_LINUX, UNIX, WINDOWS, WINDOWS_XP,
-            WINDOWS_2003, WINDOWS_VISTA, WINDOWS_7};
+            WINDOWS_2003, WINDOWS_VISTA, WINDOWS_7, WINDOWS_8};
 
     /**
      * Cached linux name.

--- a/izpack-tools/src/test/java/com/izforge/izpack/util/PlatformTest.java
+++ b/izpack-tools/src/test/java/com/izforge/izpack/util/PlatformTest.java
@@ -60,6 +60,10 @@ public class PlatformTest extends AbstractPlatformTest
         Platform win7 = new Platform(Name.WINDOWS, "windows_7", OsVersionConstants.WINDOWS_7_VERSION);
         checkPlatform(new Platform(win7, Arch.X64), Name.WINDOWS, "windows_7", OsVersionConstants.WINDOWS_7_VERSION,
                       Arch.X64);
+
+        Platform win8 = new Platform(Name.WINDOWS, "windows_8", OsVersionConstants.WINDOWS_8_VERSION);
+        checkPlatform(new Platform(win8, Arch.X64), Name.WINDOWS, "windows_8", OsVersionConstants.WINDOWS_8_VERSION,
+                      Arch.X64);
     }
 
     /**
@@ -118,6 +122,7 @@ public class PlatformTest extends AbstractPlatformTest
         Platform unix = new Platform(Name.UNIX);
         Platform windows = new Platform(Name.WINDOWS);
         Platform windows7 = new Platform(Name.WINDOWS, OsVersionConstants.WINDOWS_7_VERSION);
+        Platform windows8 = new Platform(Name.WINDOWS, OsVersionConstants.WINDOWS_8_VERSION);
         Platform windows64 = new Platform(Name.WINDOWS, Arch.X64);
         Platform vista32 = new Platform(Name.WINDOWS, OsVersionConstants.WINDOWS_VISTA_VERSION, Arch.X86);
         Platform vista64 = new Platform(Name.WINDOWS, OsVersionConstants.WINDOWS_VISTA_VERSION, Arch.X64);
@@ -132,6 +137,10 @@ public class PlatformTest extends AbstractPlatformTest
         assertTrue(windows7.isA(windows7));
         assertTrue(windows7.isA(windows));
         assertFalse(windows.isA(windows7));
+
+        assertTrue(windows8.isA(windows8));
+        assertTrue(windows8.isA(windows));
+        assertFalse(windows.isA(windows8));
 
         assertTrue(windows64.isA(windows64));
         assertTrue(windows64.isA(windows));

--- a/izpack-tools/src/test/java/com/izforge/izpack/util/PlatformsTest.java
+++ b/izpack-tools/src/test/java/com/izforge/izpack/util/PlatformsTest.java
@@ -111,6 +111,20 @@ public class PlatformsTest extends AbstractPlatformTest
         assertEquals("6.1", windows7x64.getVersion());
     }
 
+	/**
+     * Tests the {@link Platforms#getCurrentPlatform(String, String, String)} method with windows 8.
+     */
+    @Test
+    public void testGetWin8PlatformByNameArchVersion()
+    {
+        Platforms platforms = new Platforms();
+        Platform windows8x64 = platforms.getCurrentPlatform("Windows 8", OsVersionConstants.AMD64,
+                OsVersionConstants.WINDOWS_8_VERSION);
+        assertEquals(Name.WINDOWS, windows8x64.getName());
+        assertEquals("WINDOWS_8", windows8x64.getSymbolicName());
+        assertEquals(Arch.X64, windows8x64.getArch());
+        assertEquals("6.2", windows8x64.getVersion());
+    }
     /**
      * Tests the {@link Platforms#getPlatform(String, String)} method.
      */
@@ -122,6 +136,8 @@ public class PlatformsTest extends AbstractPlatformTest
         checkPlatform(new Platform(Platforms.WINDOWS, Arch.X86), platforms.getPlatform("windows", "i386"));
         checkPlatform(Platforms.WINDOWS_7, platforms.getPlatform("windows_7", null));
         checkPlatform(new Platform(Platforms.WINDOWS_7, Arch.X64), platforms.getPlatform("windows_7", "x64"));
+        checkPlatform(Platforms.WINDOWS_8, platforms.getPlatform("windows_8", null));
+        checkPlatform(new Platform(Platforms.WINDOWS_8, Arch.X64), platforms.getPlatform("windows_8", "x64"));
 
         checkPlatform(Platforms.LINUX, platforms.getPlatform("linux", null));
     }
@@ -136,8 +152,10 @@ public class PlatformsTest extends AbstractPlatformTest
         checkPlatform(Platforms.WINDOWS, platforms.getPlatform("windows", null, null));
         checkPlatform(new Platform(Platforms.WINDOWS_7, Arch.X86), platforms.getPlatform("windows", "i386",
                 OsVersionConstants.WINDOWS_7_VERSION));
+        checkPlatform(new Platform(Platforms.WINDOWS_8, Arch.X86), platforms.getPlatform("windows", "i386",
+                OsVersionConstants.WINDOWS_8_VERSION));
 
-        checkPlatform(new Platform(Platforms.DEBIAN_LINUX, Arch.X64), platforms.getPlatform("debian_linux", "x64",
+				checkPlatform(new Platform(Platforms.DEBIAN_LINUX, Arch.X64), platforms.getPlatform("debian_linux", "x64",
                 null));
     }
 


### PR DESCRIPTION
Adds\Tests the Windows 8 Platform and the izpack.windowsinstall.8 flag 
