### PR TITLE
[IZPACK-885] Remove parsing of panel.order attribute in userInputSpec.xml, require panel.id instead

### DIFF
--- a/izpack-dist/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-dist/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -142,8 +142,7 @@
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>
-                        <xs:attribute name="order" type="xs:unsignedByte" use="required"/>
-                        <xs:attribute name="id" type="xs:string" use="optional"/>
+                        <xs:attribute name="id" type="xs:string" use="required"/>
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>


### PR DESCRIPTION
In the code, this has been already fixed with IZPACK-884. Adapted the XSD schema for user input panel definitions, also.
