### PR TITLE
Simplified registry access

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/os/RegistryDefaultHandler.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/os/RegistryDefaultHandler.java
@@ -1,5 +1,5 @@
 /*
- * IzPack - Copyright 2001-2013 Julien Ponge, All Rights Reserved.
+ * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
  * 
  * http://izpack.org/
  * http://izpack.codehaus.org/
@@ -21,33 +21,24 @@
 
 package com.izforge.izpack.core.os;
 
-import java.util.List;
+import com.izforge.izpack.util.TargetFactory;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.coi.tools.os.win.RegDataContainer;
-import com.izforge.izpack.api.exception.NativeLibException;
-import com.izforge.izpack.util.TargetFactory;
-
 /**
- * This class provides a wrapper around {@link RegistryHandler} that delegates to a platform specific implementation
- * if registry access is supported, or a no-op implementation if it is not.
+ * This class provides on windows a registry handler. All classes which needs registry access should
+ * be use only one handler.
  *
  * @author Klaus Bartz
- * @author Tim Anderson
  */
-public class RegistryDefaultHandler extends RegistryHandler
+public class RegistryDefaultHandler
 {
 
     /**
-     * The registry handler to delegate to.
+     * The registry handler.
      */
-    private RegistryHandler handler;
-
-    /**
-     * A no-op handler, for use when the registry is not supported.
-     */
-    private static final RegistryHandler NOOP_HANDLER = new RegistryHandler();
+    private RegistryHandler registryHandler;
 
     /**
      * The factory for creating {@link RegistryHandler} instances for the current platform.
@@ -55,7 +46,7 @@ public class RegistryDefaultHandler extends RegistryHandler
     private TargetFactory factory;
 
     /**
-     * True if an attempt has been made to initialise {@link #handler}.
+     * True if an attempt has been made to initialise {@link #registryHandler}.
      */
     private boolean initialized = false;
 
@@ -65,7 +56,7 @@ public class RegistryDefaultHandler extends RegistryHandler
     private static final Logger log = Logger.getLogger(RegistryDefaultHandler.class.getName());
 
     /**
-     * Constructs a {@code RegistryDefaultHandler}.
+     * Constructs a <tt>RegistryDefaultHandler</tt>.
      *
      * @param factory the factory for creating {@link RegistryHandler} instances for the current platform
      */
@@ -74,401 +65,22 @@ public class RegistryDefaultHandler extends RegistryHandler
         this.factory = factory;
     }
 
-    /**
-     * Sets the given contents to the given registry value. If a sub key or the registry value does
-     * not exist, it will be created.
-     *
-     * @param key      the registry key which should be used or created
-     * @param value    the registry value into which the contents should be set
-     * @param contents the contents for the value
-     * @throws NativeLibException for any native library error
-     */
-    @Override
-    public void setValue(String key, String value, String contents) throws NativeLibException
-    {
-        getHandler().setValue(key, value, contents);
-    }
-
-    /**
-     * Sets the given contents to the given registry value. If a sub key or the registry value does
-     * not exist, it will be created.
-     *
-     * @param key      the registry key which should be used or created
-     * @param value    the registry value into which the contents should be set
-     * @param contents the contents for the value
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void setValue(String key, String value, String[] contents) throws NativeLibException
-    {
-        getHandler().setValue(key, value, contents);
-    }
-
-    /**
-     * Sets the given contents to the given registry value. If a sub key or the registry value does
-     * not exist, it will be created.
-     *
-     * @param key      the registry key which should be used or created
-     * @param value    the registry value into which the contents should be set
-     * @param contents the contents for the value
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void setValue(String key, String value, byte[] contents) throws NativeLibException
-    {
-        getHandler().setValue(key, value, contents);
-    }
-
-    /**
-     * Sets the given contents to the given registry value. If a sub key or the registry value does
-     * not exist, it will be created.
-     *
-     * @param key      the registry key which should be used or created
-     * @param value    the registry value into which the contents should be set
-     * @param contents the contents for the value
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void setValue(String key, String value, long contents) throws NativeLibException
-    {
-        getHandler().setValue(key, value, contents);
-    }
-
-    /**
-     * Returns the contents of the key/value pair if value exist, else the given default value.
-     *
-     * @param key        the registry key which should be used
-     * @param value      the registry value from which the contents should be requested
-     * @param defaultVal value to be used if no value exist in the registry
-     * @return requested value if exist, else the default value
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public RegDataContainer getValue(String key, String value, RegDataContainer defaultVal) throws NativeLibException
-    {
-        return getHandler().getValue(key, value, defaultVal);
-    }
-
-    /**
-     * Returns whether a key exist or not.
-     *
-     * @param key key to be evaluated
-     * @return whether a key exist or not
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public boolean keyExist(String key) throws NativeLibException
-    {
-        return getHandler().keyExist(key);
-    }
-
-    /**
-     * Returns whether a the given value under the given key exist or not.
-     *
-     * @param key   key to be used as path for the value
-     * @param value value name to be evaluated
-     * @return whether a the given value under the given key exist or not
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public boolean valueExist(String key, String value) throws NativeLibException
-    {
-        return getHandler().valueExist(key, value);
-    }
-
-    /**
-     * Returns all keys which are defined under the given key.
-     *
-     * @param key key to be used as path for the sub keys
-     * @return all keys which are defined under the given key
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public String[] getSubkeys(String key) throws NativeLibException
-    {
-        return getHandler().getSubkeys(key);
-    }
-
-    /**
-     * Returns all value names which are defined under the given key.
-     *
-     * @param key key to be used as path for the value names
-     * @return all value names which are defined under the given key
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public String[] getValueNames(String key) throws NativeLibException
-    {
-        return getHandler().getValueNames(key);
-    }
-
-    /**
-     * Returns the contents of the key/value pair if value exist, else an exception is raised.
-     *
-     * @param key   the registry key which should be used
-     * @param value the registry value from which the contents should be requested
-     * @return requested value if exist, else an exception
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public RegDataContainer getValue(String key, String value) throws NativeLibException
-    {
-        return getHandler().getValue(key, value);
-    }
-
-    /**
-     * Creates the given key in the registry.
-     *
-     * @param key key to be created
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void createKey(String key) throws NativeLibException
-    {
-        getHandler().createKey(key);
-    }
-
-    /**
-     * Deletes the given key if exist, else throws an exception.
-     *
-     * @param key key to be deleted
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void deleteKey(String key) throws NativeLibException
-    {
-        getHandler().deleteKey(key);
-    }
-
-    /**
-     * Deletes a key under the current root if it is empty, else do nothing.
-     *
-     * @param key key to be deleted
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void deleteKeyIfEmpty(String key) throws NativeLibException
-    {
-        getHandler().deleteKeyIfEmpty(key);
-    }
-
-    /**
-     * Deletes a value.
-     *
-     * @param key   key of the value which should be deleted
-     * @param value value name to be deleted
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void deleteValue(String key, String value) throws NativeLibException
-    {
-        getHandler().deleteValue(key, value);
-    }
-
-    /**
-     * Sets the root for the next registry access.
-     * <p/>
-     * TODO - this doesn't support multi-threaded access
-     *
-     * @param i an integer which refers to a HKEY
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void setRoot(int i) throws NativeLibException
-    {
-        getHandler().setRoot(i);
-    }
-
-    /**
-     * Return the root as integer (HKEY_xxx).
-     *
-     * @return the root as integer
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public int getRoot() throws NativeLibException
-    {
-        return getHandler().getRoot();
-    }
-
-    /**
-     * Sets up whether or not previous contents of registry values will
-     * be logged by the 'setValue()' method.  When registry values are
-     * overwritten by repeated installations, the desired behavior can
-     * be to have the registry value removed rather than rewound to the
-     * last-set contents (achieved via 'false').  If this method is not
-     * called then the flag wll default to 'true'.
-     *
-     * @param flagVal true to have the previous contents of registry
-     *                values logged by the 'setValue()' method.
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void setLogPrevSetValueFlag(boolean flagVal) throws NativeLibException
-    {
-        getHandler().setLogPrevSetValueFlag(flagVal);
-    }
-
-    /**
-     * Determines whether or not previous contents of registry values
-     * will be logged by the 'setValue()' method.
-     *
-     * @return true if the previous contents of registry values will be
-     *         logged by the 'setValue()' method.
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public boolean getLogPrevSetValueFlag() throws NativeLibException
-    {
-        return getHandler().getLogPrevSetValueFlag();
-    }
-
-    /**
-     * Activates logging of registry changes.
-     *
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void activateLogging() throws NativeLibException
-    {
-        getHandler().activateLogging();
-    }
-
-    /**
-     * Suspends logging of registry changes.
-     *
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void suspendLogging() throws NativeLibException
-    {
-        getHandler().suspendLogging();
-    }
-
-    /**
-     * Resets logging of registry changes.
-     *
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void resetLogging() throws NativeLibException
-    {
-        getHandler().resetLogging();
-    }
-
-    /**
-     * Returns a copy of the collected logging information.
-     *
-     * @return a copy of the collected logging information
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public List<Object> getLoggingInfo() throws NativeLibException
-    {
-        return getHandler().getLoggingInfo();
-    }
-
-    /**
-     * Registers logging information. This replaces any existing logging information.
-     *
-     * @param info the logging information
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void setLoggingInfo(List info) throws NativeLibException
-    {
-        getHandler().setLoggingInfo(info);
-    }
-
-    /**
-     * Adds logging information.
-     *
-     * @param info the logging information
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void addLoggingInfo(List info) throws NativeLibException
-    {
-        getHandler().addLoggingInfo(info);
-    }
-
-    /**
-     * Rewinds all logged actions.
-     *
-     * @throws NativeLibException for any registry error
-     */
-    @Override
-    public void rewind() throws NativeLibException
-    {
-        getHandler().rewind();
-    }
-
-    /**
-     * Returns the uninstall name.
-     *
-     * @return the uninstall name. May be {@code null}
-     */
-    @Override
-    public String getUninstallName()
-    {
-        return getHandler().getUninstallName();
-    }
-
-    /**
-     * Sets the uninstall name.
-     *
-     * @param name the uninstall name. May be {@code null}
-     */
-    @Override
-    public void setUninstallName(String name)
-    {
-        getHandler().setUninstallName(name);
-    }
-
-    /**
-     * Returns the underlying handler.
-     *
-     * @return the underlying handler, or {@code null} if it is not supported for the current platform
-     * @deprecated no longer required now that RegistryDefaultHandler extends RegistryHandler
-     */
-    @Deprecated
-    public RegistryHandler getInstance()
-    {
-        return getHandler().equals(NOOP_HANDLER) ? null : handler;
-    }
-
-    /**
-     * Determines if registry access is supported on the current platform.
-     *
-     * @return {@code true} if registry access is supported, otherwise {@code false}
-     */
-    @Override
-    public boolean isSupported()
-    {
-        return getHandler().isSupported();
-    }
-
-    /**
-     * Returns the handler, creating it if required.
-     *
-     * @return the handler, or {@code null} if it can't be created
-     */
-    private synchronized RegistryHandler getHandler()
+    public synchronized RegistryHandler getInstance()
     {
         if (!initialized)
         {
             try
             {
                 // Load the system dependant handler.
-                handler = factory.makeObject(RegistryHandler.class);
+                registryHandler = factory.makeObject(RegistryHandler.class);
             }
             catch (Throwable exception)
             {
                 log.log(Level.WARNING, "Failed to create RegistryHandler: " + exception.getMessage(), exception);
-                handler = NOOP_HANDLER;
             }
             initialized = true;
         }
-        return handler;
+
+        return (registryHandler);
     }
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/os/RegistryHandler.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/os/RegistryHandler.java
@@ -378,14 +378,4 @@ public class RegistryHandler implements MSWinConstants
         uninstallName = name;
     }
 
-    /**
-     * Determines if registry access is supported on the current platform.
-     *
-     * @return {@code true} if registry access is supported, otherwise {@code false}
-     */
-    public boolean isSupported()
-    {
-        return false;
-    }
-
 }

--- a/izpack-event/src/main/java/com/izforge/izpack/event/RegistryUninstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/RegistryUninstallerListener.java
@@ -33,6 +33,7 @@ import com.izforge.izpack.api.exception.ResourceNotFoundException;
 import com.izforge.izpack.api.exception.WrappedNativeLibException;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 
 /**
@@ -48,7 +49,7 @@ public class RegistryUninstallerListener extends AbstractUninstallerListener
     /**
      * The registry handler.
      */
-    private final RegistryHandler registry;
+    private final RegistryHandler handler;
 
     /**
      * The resources.
@@ -68,13 +69,13 @@ public class RegistryUninstallerListener extends AbstractUninstallerListener
     /**
      * Constructs a <tt>RegistryUninstallerListener</tt>.
      *
-     * @param registry  the registry
+     * @param handler   the handler
      * @param resources the resources
      * @param messages  the messages
      */
-    public RegistryUninstallerListener(RegistryHandler registry, Resources resources, Messages messages)
+    public RegistryUninstallerListener(RegistryDefaultHandler handler, Resources resources, Messages messages)
     {
-        this.registry = registry;
+        this.handler = handler.getInstance();
         this.resources = resources;
         this.messages = messages;
     }
@@ -120,13 +121,13 @@ public class RegistryUninstallerListener extends AbstractUninstallerListener
             return;
         }
 
-        if (registry.isSupported())
+        if (handler != null)
         {
             try
             {
-                registry.activateLogging();
-                registry.setLoggingInfo(actions);
-                registry.rewind();
+                handler.activateLogging();
+                handler.setLoggingInfo(actions);
+                handler.rewind();
             }
             catch (NativeLibException e)
             {

--- a/izpack-event/src/test/java/com/izforge/izpack/event/RegistryInstallerListenerTest.java
+++ b/izpack-event/src/test/java/com/izforge/izpack/event/RegistryInstallerListenerTest.java
@@ -54,6 +54,7 @@ import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.core.data.DefaultVariables;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.core.substitutor.VariableSubstitutorImpl;
 import com.izforge.izpack.installer.data.UninstallData;
@@ -121,6 +122,11 @@ public class RegistryInstallerListenerTest
     private Housekeeper housekeeper;
 
     /**
+     * The registry handler.
+     */
+    private RegistryDefaultHandler handler;
+
+    /**
      * The registry.
      */
     private RegistryHandler registry;
@@ -160,10 +166,12 @@ public class RegistryInstallerListenerTest
         uninstallData = new UninstallData();
         rules = Mockito.mock(RulesEngine.class);
         housekeeper = Mockito.mock(Housekeeper.class);
+        handler = Mockito.mock(RegistryDefaultHandler.class);
         TargetFactory factory = Mockito.mock(TargetFactory.class);
         Mockito.when(factory.getNativeLibraryExtension()).thenReturn("dll");
         Librarian librarian = new TestLibrarian(factory, housekeeper);
         registry = new Win_RegistryHandler(librarian);
+        Mockito.when(handler.getInstance()).thenReturn(registry);
     }
 
     /**
@@ -198,7 +206,7 @@ public class RegistryInstallerListenerTest
 
         // initialise the listener
         RegistryInstallerListener listener = new RegistryInstallerListener(
-                unpacker, replacer, installData, uninstallData, resources, rules, housekeeper, registry);
+                unpacker, replacer, installData, uninstallData, resources, rules, housekeeper, handler);
         listener.initialise();
 
         // run the listener

--- a/izpack-installer/src/main/java/com/izforge/izpack/util/os/Win_RegistryHandler.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/util/os/Win_RegistryHandler.java
@@ -367,17 +367,6 @@ public class Win_RegistryHandler extends RegistryHandler
     }
 
     /**
-     * Determines if registry access is supported on the current platform.
-     *
-     * @return {@code true}
-     */
-    @Override
-    public boolean isSupported()
-    {
-        return true;
-    }
-
-    /**
      * Returns the registry, creating it if necessary.
      *
      * @return the registry

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloPanel.java
@@ -26,7 +26,7 @@ import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.exception.NativeLibException;
 import com.izforge.izpack.api.handler.AbstractUIHandler;
 import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.core.os.RegistryHandler;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
@@ -69,15 +69,15 @@ public class CheckedHelloPanel extends HelloPanel
      * @param parent      the parent frame
      * @param installData the installation data
      * @param resources   the resources
-     * @param registry    the registry
+     * @param handler     the registry handler instance
      * @param log         the log
      * @throws Exception if it cannot be determined if the application is registered
      */
     public CheckedHelloPanel(Panel panel, InstallerFrame parent, GUIInstallData installData, Resources resources,
-                             RegistryHandler registry, Log log) throws Exception
+                             RegistryDefaultHandler handler, Log log) throws Exception
     {
         super(panel, parent, installData, resources, log);
-        registryHelper = new RegistryHelper(registry, installData);
+        registryHelper = new RegistryHelper(handler, installData);
         abortInstallation = isRegistered();
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloPanelConsole.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloPanelConsole.java
@@ -33,7 +33,7 @@ import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.NativeLibException;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.resource.Messages;
-import com.izforge.izpack.core.os.RegistryHandler;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.panels.hello.HelloPanelConsoleHelper;
 import com.izforge.izpack.util.Console;
 
@@ -68,15 +68,15 @@ public class CheckedHelloPanelConsole extends HelloPanelConsoleHelper
     /**
      * Constructs a <tt>CheckedHelloPanelConsole</tt>.
      *
-     * @param registry    the registry
+     * @param handler     the registry handler
      * @param installData the installation data
      * @param prompt      the prompt
      * @throws NativeLibException for any native library error
      */
-    public CheckedHelloPanelConsole(RegistryHandler registry, InstallData installData, Prompt prompt)
+    public CheckedHelloPanelConsole(RegistryDefaultHandler handler, InstallData installData, Prompt prompt)
             throws NativeLibException
     {
-        registryHelper = new RegistryHelper(registry, installData);
+        registryHelper = new RegistryHelper(handler, installData);
         this.prompt = prompt;
         registered = registryHelper.isRegistered();
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/RegistryHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/RegistryHelper.java
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.NativeLibException;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.util.IoHelper;
 
@@ -37,7 +38,6 @@ import com.izforge.izpack.util.IoHelper;
 public class RegistryHelper
 {
 
-    private static final String INSTALL_PATH = "$INSTALL_PATH";
     /**
      * The registry handler, or {@code null} if the registry isn't supported on the current platform.
      */
@@ -58,6 +58,11 @@ public class RegistryHelper
      */
     private static final String UNINSTALL_STRING = "UninstallString";
 
+    /**
+     * Install path variable.
+     */
+    private static final String INSTALL_PATH = "$INSTALL_PATH";
+
 
     /**
      * Constructs a {@code RegistryHelper}.
@@ -65,9 +70,9 @@ public class RegistryHelper
      * @param handler     the registry handler
      * @param installData the installation data
      */
-    public RegistryHelper(RegistryHandler handler, InstallData installData)
+    public RegistryHelper(RegistryDefaultHandler handler, InstallData installData)
     {
-        this.handler = handler;
+        this.handler = handler.getInstance();
         this.installData = installData;
     }
 
@@ -81,7 +86,7 @@ public class RegistryHelper
     public boolean isRegistered() throws NativeLibException
     {
         boolean result = false;
-        if (handler.isSupported())
+        if (handler != null)
         {
             String uninstallName = getUninstallName();
             if (uninstallName != null)
@@ -104,7 +109,7 @@ public class RegistryHelper
      */
     public String getUninstallName()
     {
-        return handler.isSupported() ? handler.getUninstallName() : null;
+        return (handler != null) ? handler.getUninstallName() : null;
     }
 
     /**
@@ -168,7 +173,7 @@ public class RegistryHelper
     public String getUninstallCommand() throws NativeLibException
     {
         String result = null;
-        if (handler.isSupported())
+        if (handler != null)
         {
             String uninstallName = handler.getUninstallName();
             if (uninstallName == null)
@@ -199,7 +204,7 @@ public class RegistryHelper
     public String updateUninstallName() throws NativeLibException
     {
         String result = null;
-        if (handler.isSupported())
+        if (handler != null)
         {
             String uninstallName = handler.getUninstallName();
             if (uninstallName == null)

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/IzpackInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/IzpackInstallationTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.exception.NativeLibException;
 import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerController;
@@ -64,18 +65,18 @@ public class IzpackInstallationTest
     private InstallerFrame installerFrame;
     private GUIInstallData installData;
     private InstallerController installerController;
-    private RegistryHandler registry;
+    private RegistryDefaultHandler handler;
     private Panels panels;
 
     public IzpackInstallationTest(LanguageDialog languageDialog, InstallerFrame installerFrame,
                                   GUIInstallData installData, InstallerController installerController,
-                                  RegistryHandler registry, Panels panels)
+                                  RegistryDefaultHandler handler, Panels panels)
     {
         this.installerController = installerController;
         this.languageDialog = languageDialog;
         this.installData = installData;
         this.installerFrame = installerFrame;
-        this.registry = registry;
+        this.handler = handler;
         this.panels = panels;
     }
 
@@ -87,7 +88,8 @@ public class IzpackInstallationTest
     @Before
     public void setUp() throws NativeLibException
     {
-        if (registry.isSupported())
+        RegistryHandler registry = handler.getInstance();
+        if (registry != null)
         {
             // remove any existing uninstall key
             String uninstallName = registry.getUninstallName();

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsConsoleInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsConsoleInstallationTest.java
@@ -42,6 +42,7 @@ import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.NativeLibException;
 import com.izforge.izpack.compiler.container.TestConsoleInstallationContainer;
 import com.izforge.izpack.compiler.container.TestConsoleInstallerContainer;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.event.RegistryInstallerListener;
 import com.izforge.izpack.event.RegistryUninstallerListener;
@@ -89,9 +90,9 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
     private final TestConsoleInstaller installer;
 
     /**
-     * The registry.
+     * The registry handler.
      */
-    private final RegistryHandler registry;
+    private final RegistryDefaultHandler handler;
 
     /**
      * The app name.
@@ -126,17 +127,17 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
      * @param container   the container
      * @param installer   the installer
      * @param installData the installation date
-     * @param registry    the registry
+     * @param handler     the registry handler
      * @throws Exception for any error
      */
     public WindowsConsoleInstallationTest(TestConsoleInstallerContainer container, TestConsoleInstaller installer,
-                                          AutomatedInstallData installData, RegistryHandler registry)
+                                          AutomatedInstallData installData, RegistryDefaultHandler handler)
             throws Exception
     {
         super(installData);
         this.container = container;
         this.installer = installer;
-        this.registry = registry;
+        this.handler = handler;
     }
 
 
@@ -184,14 +185,14 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
     {
         // run the install
         checkInstall(container, APP_NAME);
-        assertTrue(registryKeyExists(registry, DEFAULT_UNINSTALL_KEY));
+        assertTrue(registryKeyExists(handler, DEFAULT_UNINSTALL_KEY));
 
         // run the uninstaller and verify that uninstall key is removed
         File uninstaller = getUninstallerJar();
         assertTrue(uninstaller.exists());
         UninstallHelper.consoleUninstall(uninstaller);
 
-        assertFalse(registryKeyExists(registry, DEFAULT_UNINSTALL_KEY));
+        assertFalse(registryKeyExists(handler, DEFAULT_UNINSTALL_KEY));
     }
 
     /**
@@ -219,14 +220,14 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
         console2.addScript("PacksPanel", "1");
         console2.addScript("ShortcutPanel", "N");
 
-        assertFalse(registryKeyExists(registry, UNINSTALL_KEY2));
+        assertFalse(registryKeyExists(handler, UNINSTALL_KEY2));
         checkInstall(installer2, installData2);
 
         // verify the UNINSTALL_NAME has been updated
         assertEquals(APP_NAME + "(1)", installData2.getVariable("UNINSTALL_NAME"));
 
         // verify a second key is created
-        assertTrue(registryKeyExists(registry, UNINSTALL_KEY2));
+        assertTrue(registryKeyExists(handler, UNINSTALL_KEY2));
     }
 
     /**
@@ -244,7 +245,7 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
 
         ConsoleInstallerContainer container2 = new TestConsoleInstallerContainer();
         TestConsoleInstaller installer2 = container2.getComponent(TestConsoleInstaller.class);
-        RegistryHandler handler2 = container2.getComponent(RegistryHandler.class);
+        RegistryDefaultHandler handler2 = container2.getComponent(RegistryDefaultHandler.class);
         InstallData installData2 = container2.getComponent(InstallData.class);
 
         TestConsole console2 = installer2.getConsole();
@@ -274,7 +275,7 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
     @InstallFile("samples/windows/consoleinstall_alt_uninstall.xml")
     public void testNonDefaultUninstaller() throws Exception
     {
-        assertFalse(registryKeyExists(registry, DEFAULT_UNINSTALL_KEY));
+        assertFalse(registryKeyExists(handler, DEFAULT_UNINSTALL_KEY));
 
         TestConsole console = installer.getConsole();
         console.addScript("CheckedHelloPanel", "1");
@@ -290,10 +291,10 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
         assertTrue(new File(installPath, "/uninstallme.jar").exists());
 
         //check that the registry key has the correct value
-        assertTrue(registryKeyExists(registry, DEFAULT_UNINSTALL_KEY));
+        assertTrue(registryKeyExists(handler, DEFAULT_UNINSTALL_KEY));
         String command = "\"" + installData.getVariable("JAVA_HOME") + "\\bin\\javaw.exe\" -jar \"" + installPath
                 + "\\uninstallme.jar\"";
-        registryValueStringEquals(registry, DEFAULT_UNINSTALL_KEY, UNINSTALL_CMD_VALUE, command);
+        registryValueStringEquals(handler, DEFAULT_UNINSTALL_KEY, UNINSTALL_CMD_VALUE, command);
     }
 
     /**
@@ -306,7 +307,7 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
         // UNINSTALL_NAME should be null prior to display of CheckedHelloPanel
         InstallData installData = container.getComponent(InstallData.class);
         TestConsoleInstaller installer = container.getComponent(TestConsoleInstaller.class);
-        RegistryHandler handler = container.getComponent(RegistryHandler.class);
+        RegistryDefaultHandler handler = container.getComponent(RegistryDefaultHandler.class);
 
         assertNull(installData.getVariable("UNINSTALL_NAME"));
 
@@ -349,7 +350,7 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
     {
         for (String key : UNINSTALL_KEYS)
         {
-            registryDeleteUninstallKey(registry, key);
+            registryDeleteUninstallKey(handler, key);
         }
     }
 }

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsHelper.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsHelper.java
@@ -32,6 +32,7 @@ import javax.swing.SwingUtilities;
 import com.coi.tools.os.win.RegDataContainer;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.exception.NativeLibException;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.util.Librarian;
 import com.izforge.izpack.util.os.ShellLink;
@@ -99,14 +100,15 @@ public class WindowsHelper
     /**
      * Determines if a key exists in the registry.
      *
-     * @param registry the registry handler
+     * @param handler the registry handler
      * @param key      the key to check
      * @return <tt>true</tt> if the key exists, otherwise <tt>false</tt>
      * @throws NativeLibException for any registry error
      */
-    public static boolean registryKeyExists(RegistryHandler registry, String key) throws NativeLibException
+    public static boolean registryKeyExists(RegistryDefaultHandler handler, String key) throws NativeLibException
     {
-        assertTrue(registry.isSupported());
+        RegistryHandler registry = handler.getInstance();
+        assertNotNull(registry);
         registry.setRoot(RegistryHandler.HKEY_LOCAL_MACHINE);
         return registry.keyExist(key);
     }
@@ -114,17 +116,18 @@ public class WindowsHelper
     /**
      * Asserts that a registry key REG_SZ value exists, and exactly matches the given value.
      *
-     * @param registry the registry handler
+     * @param handler the registry handler
      * @param key      the key to check
      * @param name     the name of the value to check
      * @param expected the value to match
      * @throws NativeLibException for any registry error
      */
-    public static void registryValueStringEquals(RegistryHandler registry, String key, String name,
+    public static void registryValueStringEquals(RegistryDefaultHandler handler, String key, String name,
                                                  String expected) throws NativeLibException
     {
         //Registry key exists
-        assertTrue(registry.isSupported());
+    	RegistryHandler registry = handler.getInstance();
+        assertNotNull(registry);
         registry.setRoot(RegistryHandler.HKEY_LOCAL_MACHINE);
         assertTrue(registry.keyExist(key));
         //Value exists as a REG_SZ
@@ -138,12 +141,13 @@ public class WindowsHelper
     /**
      * Deletes an uninstallation registry key.
      *
-     * @param registry the registry handler
+     * @param handler the registry handler
      * @param key      the key to delete
      * @throws NativeLibException for any registry error
      */
-    public static void registryDeleteUninstallKey(RegistryHandler registry, String key) throws NativeLibException
+    public static void registryDeleteUninstallKey(RegistryDefaultHandler handler, String key) throws NativeLibException
     {
+        RegistryHandler registry = handler.getInstance();
         assertNotNull(registry);
         if (!key.matches(".*\\\\Uninstall\\\\.+"))
         {

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsInstallationTest.java
@@ -42,6 +42,7 @@ import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.exception.NativeLibException;
 import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.event.RegistryInstallerListener;
 import com.izforge.izpack.event.RegistryUninstallerListener;
@@ -98,9 +99,9 @@ public class WindowsInstallationTest extends AbstractDestroyerTest
     private final Librarian librarian;
 
     /**
-     * The registry.
+     * The registry handler.
      */
-    private final RegistryHandler registry;
+    private final RegistryDefaultHandler handler;
 
     /**
      * The house keeper.
@@ -125,18 +126,18 @@ public class WindowsInstallationTest extends AbstractDestroyerTest
      * @param controller  the installer controller
      * @param installData the installation data
      * @param librarian   the librarian
-     * @param registry    the registry
+     * @param handler     the registry handler
      * @param housekeeper the house-keeper
      */
     public WindowsInstallationTest(InstallerFrame frame, InstallerController controller,
                                    AutomatedInstallData installData, Librarian librarian,
-                                   RegistryHandler registry, TestHousekeeper housekeeper)
+                                   RegistryDefaultHandler handler, TestHousekeeper housekeeper)
     {
         super(installData);
         this.frame = frame;
         this.controller = controller;
         this.librarian = librarian;
-        this.registry = registry;
+        this.handler = handler;
         this.housekeeper = housekeeper;
     }
 
@@ -223,7 +224,7 @@ public class WindowsInstallationTest extends AbstractDestroyerTest
         File uninstaller = getUninstallerJar();
 
         // make sure there is an Uninstall entry for the installation
-        assertTrue(registryKeyExists(registry, UNINSTALL_KEY));
+        assertTrue(registryKeyExists(handler, UNINSTALL_KEY));
 
         // make sure a shortcut to the uninstaller exists
         File shortcut = checkShortcut(ShellLink.PROGRAM_MENU, ShellLink.ALL_USERS, "IzPack Windows Installation Test",
@@ -233,7 +234,7 @@ public class WindowsInstallationTest extends AbstractDestroyerTest
         UninstallHelper.guiUninstall(uninstaller);
 
         // make sure the Uninstall entry has been removed
-        assertFalse(registryKeyExists(registry, UNINSTALL_KEY));
+        assertFalse(registryKeyExists(handler, UNINSTALL_KEY));
 
         // verify the shortcut no longer exists
         assertFalse(shortcut.exists());
@@ -247,7 +248,7 @@ public class WindowsInstallationTest extends AbstractDestroyerTest
      */
     private void destroyRegistryEntries() throws NativeLibException
     {
-        registryDeleteUninstallKey(registry, UNINSTALL_KEY);
+        registryDeleteUninstallKey(handler, UNINSTALL_KEY);
     }
 
 }


### PR DESCRIPTION
RegistryDefaultHandler now extends RegistryHandler. This means that it no longer needs to be referenced directly in code, with the exception of container registration.

RegistryDefaultHandler now delegates to a platform specific implementation of RegistryHandler, if registry access is supported, or a no-op implementation of RegistryHandler if it isn't.
The RegistryDefaultHandler.getInstance() method is now deprecated.
