### PR TITLE
Fix for [IZPACK-926]

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -151,7 +151,7 @@ public class DynamicVariableImpl implements DynamicVariable
             {
                 throw e;
             }
-            logger.log(Level.WARNING,
+            logger.log(Level.FINE,
                        "Error evaluating dynamic variable '" + getName() + "': " + e,
                        e);
         }


### PR DESCRIPTION
Console installer output gets a mess of log lines when dynamic variables cannot be evaluated
