### PR TITLE
fix for adding multiple archives with same folders

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1463,7 +1463,7 @@ public class CompilerConfig extends Thread
         for (String dirName : allDirList)
         {
             File tmp = new File(dirName);
-            if (!tmp.mkdirs() & !tmp.exists())
+            if (!tmp.mkdirs() && !tmp.exists())
             {
                 throw new CompilerException("Failed to create directory: " + tmp);
             }


### PR DESCRIPTION
when adding different (zip)archives with same folders, but different os constraints, an error is thrown.
example:
<file src="${packages.dir}/windows.zip" unpack="true" targetdir="$INSTALL_PATH/test">
                <os family="windows"/>
            </file>
            <file src="${packages.dir}//linux.zip" unpack="true" targetdir="$INSTALL_PATH/test">
                <os family="unix"/>
            </file>

in booth archives are the same folders and files, but for different operating systems.

during adding of the second zip, mkdirs() returns false, because the folder exists.
