### PR TITLE
[IZPACK-937] - Swing installer - focus gets accidentally lost in UserInp...

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -190,6 +190,10 @@ public class UserInputPanel extends IzPanel
                 validate();
             }
         }
+        // Focus the first panel component according to the default traversal
+        // policy avoiding forcing the user to click into that field first
+        parent.setFocusCycleRoot(true);
+        parent.requestFocus();
     }
 
     /**
@@ -321,9 +325,9 @@ public class UserInputPanel extends IzPanel
                 if (!view.isDisplayed())
                 {
                     view.setDisplayed(true);
-                    for (Component components : view.getComponents())
+                    for (Component component : view.getComponents())
                     {
-                        panel.add(components.getComponent(), components.getConstraints());
+                        panel.add(component.getComponent(), component.getConstraints());
                     }
                 }
             }
@@ -396,14 +400,8 @@ public class UserInputPanel extends IzPanel
             this.eventsActivated = false;
             if (readInput(LoggingPrompt.INSTANCE)) // read from the input fields, but don't display a prompt for errors
             {
-                // read input
-                // and update elements
-                init();
                 updateVariables();
                 updateUIElements();
-                buildUI();
-                validate();
-                repaint();
             }
             this.eventsActivated = true;
         }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -392,18 +392,26 @@ public abstract class Field
     private void addExistsCondition()
     {
         RulesEngine rules = getRules();
+        final String conditionId = "izpack.input." + variable;
         if (rules != null)
         {
-            ExistsCondition existsCondition = new ExistsCondition();
-            existsCondition.setContentType(ExistsCondition.ContentType.VARIABLE);
-            existsCondition.setContent(variable);
-            existsCondition.setId("izpack.input." + variable);
-            existsCondition.setInstallData(installData);
-            rules.addCondition(existsCondition);
+            if (rules.getCondition(conditionId) == null)
+            {
+                ExistsCondition existsCondition = new ExistsCondition();
+                existsCondition.setContentType(ExistsCondition.ContentType.VARIABLE);
+                existsCondition.setContent(variable);
+                existsCondition.setId(conditionId);
+                existsCondition.setInstallData(installData);
+                rules.addCondition(existsCondition);
+            }
+            else
+            {
+                logger.fine("Condition '" + conditionId + "' for variable '" + variable + "' already exists");
+            }
         }
         else
         {
-            logger.fine("Cannot add exist condition for variable: '" + variable + "'. Rules not supplied");
+            logger.fine("Cannot add  condition '" + conditionId + "' for variable '" + variable + "'. Rules not supplied");
         }
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
@@ -184,6 +184,7 @@ public abstract class GUIField extends AbstractFieldView
 
             // Not editable, but still selectable.
             label.setEditable(false);
+            label.setFocusable(false);
 
             // If html tags are present enable html rendering, otherwise the JTextPane
             // looks exactly like MultiLineLabel.


### PR DESCRIPTION
This should solve it. Further added auto-selection of text in text input fields, if they get focus.
Yeah, and removed these silly warnings of already existing conditions of type "izpack.input.*" during navigating or re-entering a panel.
