### PR TITLE
Invalid size computation in the TreePacksPanel (negative number)

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -1007,7 +1007,7 @@ class CheckTreeController extends MouseAdapter
         initTotalSize(root, true);
 
         // must override the bytes being computed at packsModel
-        treePacksPanel.setBytes((int) root.getTotalSize());
+        treePacksPanel.setBytes(root.getTotalSize());
         treePacksPanel.showSpaceRequired();
         tree.treeDidChange();
     }


### PR DESCRIPTION
Size computation in the TreePacksPanel can give negative numbers due to a cast of a long into an int.
This has been reproduced with an installer with 5 nodes (139.43 Mb, 24.54 Mb, 2.81 Mb, 3.65Mb and 1.88 Gb): selecting all the nodes give the result of -2095174524 bytes for the "Total space required" instead of 2.05 Gb.
