### PR TITLE
Fix for IZPACK-959

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
@@ -204,6 +204,24 @@ public class Config
     }
 
     /**
+     * Returns the named attribute value without replacing any variables present.
+     *
+     * @param element      the element
+     * @param name         the attribute name
+     * @param defaultValue the default value if the attribute isn't set
+     * @return the corresponding value
+     */
+    public String getRawString(IXMLElement element, String name, String defaultValue)
+    {
+        String value = element.getAttribute(name);
+        if (value == null)
+        {
+            value = defaultValue;
+        }
+        return value;
+    }
+
+    /**
      * Returns a localised version of a string.
      *
      * @param value the string value

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -182,7 +182,11 @@ public abstract class Field
      */
     public String getDefaultValue()
     {
-        return set;
+        if (set != null)
+        {
+            return installData.getVariables().replace(set);
+        }
+        return null;
     }
 
     /**
@@ -356,9 +360,9 @@ public abstract class Field
     }
 
     /**
-     * Returns the value of the 'set' attribute.
+     * Returns the raw value of the 'set' attribute.
      *
-     * @return the value of the 'set' attribute
+     * @return the raw value of the 'set' attribute
      */
     protected String getSet()
     {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldReader.java
@@ -108,6 +108,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      * @return the 'variable' attribute, or {@code null} if the variable is optional but not present
      * @throws IzPackException if the 'variable' attribute is mandatory but not present
      */
+    @Override
     public String getVariable()
     {
         return getConfig().getAttribute(getField(), VARIABLE);
@@ -118,6 +119,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return the list of pack names
      */
+    @Override
     public List<String> getPacks()
     {
         return getPacks(field);
@@ -128,21 +130,23 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return the operating systems, or an empty list if the field applies to all operating systems
      */
+    @Override
     public List<OsModel> getOsModels()
     {
         return getOsModels(field);
     }
 
     /**
-     * Returns the default value of the field.
+     * Returns the default value of the field without replacing variables.
      * <p/>
      * This is obtained from the 'set' attribute of the 'spec' element.
      *
      * @return the default value. May be {@code null}
      */
+    @Override
     public String getDefaultValue()
     {
-        return (spec != null) ? getConfig().getString(spec, "set", null) : null;
+        return (spec != null) ? getConfig().getRawString(spec, "set", null) : null;
     }
 
     /**
@@ -150,6 +154,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return the field size, or {@code -1} if no size is specified, or the specified size is invalid
      */
+    @Override
     public int getSize()
     {
         int result = -1;
@@ -165,6 +170,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return the validators for the field
      */
+    @Override
     public List<FieldValidator> getValidators()
     {
         List<FieldValidator> result = new ArrayList<FieldValidator>();
@@ -183,6 +189,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return the field processor, or {@code null} if none exists
      */
+    @Override
     public FieldProcessor getProcessor()
     {
         IXMLElement element = (spec != null) ? spec.getFirstChildNamed("processor") : null;
@@ -194,6 +201,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return the field description. May be @{code null}
      */
+    @Override
     public String getDescription()
     {
         return getText(field.getFirstChildNamed("description"));
@@ -204,6 +212,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return the field label. May be {@code null}
      */
+    @Override
     public String getLabel()
     {
         return getText(getSpec());
@@ -214,6 +223,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return {@code true} if the field triggers revalidation
      */
+    @Override
     public boolean getRevalidate()
     {
         return (spec != null) && getConfig().getBoolean(spec, "revalidate", false);
@@ -224,6 +234,7 @@ public class FieldReader extends ElementReader implements FieldConfig
      *
      * @return the condition. May be {@code null}
      */
+    @Override
     public String getCondition()
     {
         return getConfig().getString(getField(), "conditionid", null);


### PR DESCRIPTION
IZPACK-959: izPack 5 crashes when input field initialized with variable with a colon 
