### PR TITLE
Fix extending the PackagerBase from another jar

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -460,7 +460,7 @@ public abstract class PackagerBase implements IPackager
     protected void writeManifest() throws IOException
     {
         // Add splash screen configuration
-        List<String> lines = IOUtils.readLines(getClass().getResourceAsStream("MANIFEST.MF"));
+        List<String> lines = IOUtils.readLines(PackagerBase.class.getResourceAsStream("MANIFEST.MF"));
         if (splashScreenImage != null)
         {
             String destination = String.format("META-INF/%s", splashScreenImage.getName());


### PR DESCRIPTION
In case we have:
http://pastebin.com/cq0iWsSJ
And in this dependency we have some class for extending the PackagerBase - we unable to build setup.jar.
