### PR TITLE
Fix for IZPACK-487 - Processor available for all field types

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -224,6 +224,7 @@ public abstract class Field
      */
     public void setValue(String value)
     {
+    	value = process(value);
         if (logger.isLoggable(Level.FINE))
         {
             logger.fine("Field setting variable=" + variable + " to value=" + value);


### PR DESCRIPTION
Calling process() from Field.setValue() enables support for Processor for all Field types.

eg:

```
    <field type="dir" variable="selectedFolder">
        <spec create="true" mustExist="false" set="C:/default/folder" size="25" txt="Select a folder">
            <processor class="my.project.izpack.PathProcessor"/>
        </spec>
    </field>
```

Custom class to replace back-slashes with forward-slashes (a &lt;jar> element needs to be added to install.xml):

```
public class PathProcessor implements Processor {
    @Override
    public String process(ProcessingClient client) {
        return client.getText().replaceAll("\\\\", "/");
    }
}
```
