### PR TITLE
Added version number to installer title (and stripped space after "Insta...

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/GUIInstallerContainer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/GUIInstallerContainer.java
@@ -124,7 +124,7 @@ public class GUIInstallerContainer extends InstallerContainer
         // message equal to key -> no message defined.
         if (message.equals(key))
         {
-            message = messages.get("installer.title") + " " + installData.getInfo().getAppName();
+            message = messages.get("installer.title") + installData.getInfo().getAppName() + " " + installData.getInfo().getAppVersion();
         }
         else
         {


### PR DESCRIPTION
All of the values defined for "installer.title" in [izpack-core](https://github.com/izpack/izpack/tree/master/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer) include a trailing space.

Also, it may be useful to see the application version along-side the application name in the installer's title area.
