### PR TITLE
Fix for [IZPACK-968]

### DIFF
--- a/izpack-dist/pom.xml
+++ b/izpack-dist/pom.xml
@@ -88,7 +88,7 @@
                 <executions>
                     <execution>
                         <id>Unpack izpack utils</id>
-                        <phase>process-resources</phase>
+                        <phase>pre-package</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
@@ -100,7 +100,7 @@
                     </execution>
                     <execution>
                         <id>Copy libs</id>
-                        <phase>process-resources</phase>
+                        <phase>pre-package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>

--- a/izpack-test/pom.xml
+++ b/izpack-test/pom.xml
@@ -81,7 +81,7 @@
                         <!-- copies sources from izpack-dist to test-classes/samples/izpack -->
                         <!-- for IzpackGenerationTest, IzpackInstallationTest               -->
                         <id>Unpack izpack installer files</id>
-                        <phase>process-resources</phase>
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
@@ -94,7 +94,7 @@
                     </execution>
                     <execution>
                         <id>Copy test listeners to samples/event/lib</id>
-                        <phase>process-resources</phase>
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
@@ -106,7 +106,7 @@
                     </execution>
                     <execution>
                         <id>Copy test listeners to samples/packaging</id>
-                        <phase>process-resources</phase>
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -525,7 +525,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>2.5</version>
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>


### PR DESCRIPTION
This is a fix for build failures in izpack-dist and izpack-test due to badly chosen execution phases of the maven-dependency-plugin. 'mvn compile' and 'mvn verify' works now as expected.
