### PR TITLE
IZPACK-793 Missing i18n string "installer.help.close"

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
@@ -44,6 +44,7 @@
     <str id="installer.cancel" txt="Cancelar"/>
     <str id="installer.error" txt="Erro"/>
     <str id="installer.help" txt="Ajuda"/>
+    <str id="installer.help.close" txt="Fechar"/>
     <str id="installer.step" txt="Passo"/>
     <str id="installer.of" txt="de"/>
     <str id="installer.Message" txt="Menssagem"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
@@ -51,6 +51,7 @@
     <str id="installer.cancel" txt="Abbruch"/>
     <str id="installer.error" txt="Fehler"/>
     <str id="installer.help" txt="Hilfe"/>
+    <str id="installer.help.close" txt="Schließen"/>
     <str id="installer.step" txt="Schritt"/>
     <str id="installer.of" txt="von"/>
     <str id="installer.Message" txt="Meldung"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -51,6 +51,7 @@
     <str id="installer.cancel" txt="Cancel"/>
     <str id="installer.error" txt="Error"/>
     <str id="installer.help" txt="Help"/>
+    <str id="installer.help.close" txt="Close"/>
     <str id="installer.step" txt="Step"/>
     <str id="installer.of" txt="of"/>
     <str id="installer.Message" txt="Message"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1" standalone="yes" ?>
 
-<!-- The English langpack -->
+<!-- The Basque langpack -->
 
 <izpack:langpack version="5.0"
                  xmlns:izpack="http://izpack.org/schema/langpack"
@@ -47,6 +47,7 @@
     <str id="installer.cancel" txt="Ezeztatu"/>
     <str id="installer.error" txt="Errorea"/>
     <str id="installer.help" txt="Laguntza"/>
+    <str id="installer.help.close" txt="Itxi"/>
     <str id="installer.step" txt="Pausua"/>
     <str id="installer.of" txt=" - "/>
     <str id="installer.Message" txt="Mezua"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 
-<!-- The English langpack -->
+<!-- The Persian langpack -->
 
 <izpack:langpack version="5.0"
                  xmlns:izpack="http://izpack.org/schema/langpack"
@@ -44,6 +44,7 @@
     <str id="installer.cancel" txt="لغو"/>
     <str id="installer.error" txt="خطا"/>
     <str id="installer.help" txt="راهنمایی"/>
+    <str id="installer.help.close" txt="بستن"/>
     <str id="installer.step" txt="گام"/>
     <str id="installer.of" txt=" "/>
     <str id="installer.Message" txt="پیغام"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
@@ -52,6 +52,7 @@
     <str id="installer.cancel" txt="Peruuta"/>
     <str id="installer.error" txt="Virhe"/>
     <str id="installer.help" txt="Apua"/>
+    <str id="installer.help.close" txt="Sulje"/>
     <str id="installer.step" txt="Vaihe"/>
     <str id="installer.of" txt="/"/>
     <str id="installer.Message" txt="Viesti"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
@@ -46,6 +46,7 @@
     <str id="installer.cancel" txt="Annuler"/>
     <str id="installer.error" txt="Erreur"/>
     <str id="installer.help" txt="Aide"/>
+    <str id="installer.help.close" txt="Fermer"/>
     <str id="installer.step" txt="Etape"/>
     <str id="installer.of" txt="sur"/>
     <str id="installer.Message" txt="Message"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
@@ -51,6 +51,7 @@
     <str id="installer.cancel" txt="Cancelar"/>
     <str id="installer.error" txt="Erro"/>
     <str id="installer.help" txt="Axuda"/>
+    <str id="installer.help.close" txt="Pechar"/>
     <str id="installer.step" txt="Paso"/>
     <str id="installer.of" txt="de"/>
     <str id="installer.Message" txt="Mensaxe"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
@@ -42,6 +42,7 @@
     <str id="installer.cancel" txt="Megszakít"/>
     <str id="installer.error" txt="Hiba"/>
     <str id="installer.help" txt="Súgó"/>
+    <str id="installer.help.close" txt="Bezár"/>
     <str id="installer.step" txt="Lépés"/>
     <str id="installer.of" txt="-nak/nek"/>
     <str id="installer.Message" txt="Kijelzés"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
@@ -46,6 +46,7 @@
     <str id="installer.cancel" txt="Batal"/>
     <str id="installer.error" txt="Kesalahan"/>
     <str id="installer.help" txt="Pertolongan"/>
+    <str id="installer.help.close" txt="Tutup"/>
     <str id="installer.of" txt="dari"/>
     <str id="installer.step" txt="Langkah"/>
     <str id="installer.Message" txt="Pesan"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
@@ -46,6 +46,7 @@
     <str id="installer.cancel" txt="Annulla"/>
     <str id="installer.error" txt="Errore"/>
     <str id="installer.help" txt="Guida"/>
+    <str id="installer.help.close" txt="Chiudi"/>
     <str id="installer.step" txt="Step"/>
     <str id="installer.of" txt="di"/>
     <str id="installer.Message" txt="Messaggio"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
@@ -52,6 +52,7 @@
     <str id="installer.cancel" txt="Annuleer"/>
     <str id="installer.error" txt="Fout"/>
     <str id="installer.help" txt="Help"/>
+    <str id="installer.help.close" txt="Sluiten"/>
     <str id="installer.step" txt="Stap"/>
     <str id="installer.of" txt="van"/>
     <str id="installer.Message" txt="Bericht"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
@@ -55,6 +55,7 @@
     <str id="installer.cancel" txt="Avbryt"/>
     <str id="installer.error" txt="Feil"/>
     <str id="installer.help" txt="Hjelp"/>
+    <str id="installer.help.close" txt="Lukk"/>
 
     <str id="installer.step" txt="Steg"/>
     <str id="installer.of" txt="av"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
@@ -5,6 +5,9 @@
 	Created by: IzPack Translation Helper
 	Created at: 2009-04-22 12:36
 -->
+
+<!-- The Polish langpack -->
+
 <izpack:langpack version="5.0"
                  xmlns:izpack="http://izpack.org/schema/langpack"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -72,6 +75,7 @@
     <str id="installer.cancel" txt="Anuluj"/>
     <str id="installer.error" txt="Błąd"/>
     <str id="installer.help" txt="Pomoc"/>
+    <str id="installer.help.close" txt="Zamknij"/>
     <str id="installer.madewith" txt="(Utworzono za pomocą IzPack - http://izpack.org/)"/>
     <str id="installer.Message" txt="Wiadomość"/>
     <str id="installer.next" txt="Dalej"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
@@ -46,6 +46,7 @@
     <str id="installer.cancel" txt="Cancelar"/>
     <str id="installer.error" txt="Erro"/>
     <str id="installer.help" txt="Ajuda"/>
+    <str id="installer.help.close" txt="Fechar"/>
     <str id="installer.step" txt="Passo"/>
     <str id="installer.of" txt="de"/>
     <str id="installer.Message" txt="Mensagem"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
@@ -53,6 +53,7 @@
     <str id="installer.cancel" txt="Zrušiť"/>
     <str id="installer.error" txt="Chyba"/>
     <str id="installer.help" txt="Pomoc"/>
+    <str id="installer.help.close" txt="Zavrieť"/>
     <str id="installer.step" txt="Krok"/>
     <str id="installer.of" txt=" - "/>
     <str id="installer.Message" txt="Správa"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -45,6 +45,7 @@
     <str id="installer.cancel" txt="Cancelar"/>
     <str id="installer.error" txt="Error"/>
     <str id="installer.help" txt="Ayuda"/>
+    <str id="installer.help.close" txt="Cerrar"/>
     <str id="installer.step" txt="Paso"/>
     <str id="installer.of" txt="de"/>
     <str id="installer.Message" txt="Mensaje"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
@@ -47,6 +47,7 @@
     <str id="installer.cancel" txt="Відміна"/>
     <str id="installer.error" txt="Помилка"/>
     <str id="installer.help" txt="Допомога"/>
+    <str id="installer.help.close" txt="Закрити"/>
     <str id="installer.step" txt="Крок"/>
     <str id="installer.of" txt="з"/>
     <str id="installer.Message" txt="Повідомлення"/>


### PR DESCRIPTION
Added "Close" to English langpack. Obtained (and double-checked) translations for 17 other langpacks containing installer.help. Primary source: http://littlsvr.ca/ostd/. Also corrected leading comment on a couple of files to correctly identify the translation language.
