### PR TITLE
[IZPACK-084] - AntActionInstallerListener - add working directory attribute to <antaction>

### DIFF
--- a/izpack-event/pom.xml
+++ b/izpack-event/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>izpack-installer</artifactId>
         </dependency>
         <dependency>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </dependency>
+        <dependency>
             <groupId>bsf</groupId>
             <artifactId>bsf</artifactId>
         </dependency>

--- a/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
@@ -43,7 +43,7 @@ public class ActionBase implements Serializable
 
     public static final String NAME = "name";
 
-    public static final String CONDITIONID = "condition";
+    public static final String ANTCALL_CONDITIONID_ATTR = "condition";
 
     // Order related "symbols"
     public static final String ORDER = "order";
@@ -66,23 +66,17 @@ public class ActionBase implements Serializable
 
     public static final String VALUE = "value";
 
-    public static final String YES = "yes";
+    public static final String ANTCALL_QUIET_ATTR = "quiet";
 
-    public static final String NO = "no";
+    public static final String ANTCALL_VERBOSE_ATTR = "verbose";
 
-    public static final String FALSE = "false";
+    public static final String ANTCALL_LOGFILE_ATTR = "logfile";
 
-    public static final String TRUE = "true";
+    public static final String ANTCALL_DIR_ATTR = "dir";
 
-    public static final String QUIET = "quiet";
+    public static final String ANTCALL_BUILDFILE_ATTR = "buildfile";
 
-    public static final String VERBOSE = "verbose";
-
-    public static final String LOGFILE = "logfile";
-
-    public static final String BUILDFILE = "buildfile";
-
-    public static final String BUILDRESOURCE = "buildresource";
+    public static final String ANTCALL_BUILDRESOURCE_ATTR = "buildresource";
 
     public static final String PROPERTYFILE = "propertyfile";
 
@@ -120,7 +114,7 @@ public class ActionBase implements Serializable
 
     public static final String FILESET = "fileset";
 
-    public static final String MESSAGEID = "messageid";
+    public static final String ANTCALL_MESSAGEID_ATTR = "messageid";
 
     public static final String INCLUDE = "include";
 

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntAction.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntAction.java
@@ -76,6 +76,8 @@ public class AntAction extends ActionBase
 
     private File logFile = null;
 
+    private File buildDir = null;
+
     private File buildFile = null;
 
     private String conditionId = null;
@@ -131,7 +133,9 @@ public class AntAction extends ActionBase
     {
         if (verbose)
         {
-            System.out.println("Calling ANT with buildfile: " + buildFile);
+            System.out.print("Calling ANT with buildfile: " + buildFile);
+            System.out.print(buildDir!=null ? " in directory "+buildDir : " in default base directory");
+            System.out.println();
         }
         SecurityManager oldsm = null;
         if (!JavaEnvUtils.isJavaVersion("1.0") && !JavaEnvUtils.isJavaVersion("1.1"))
@@ -160,7 +164,11 @@ public class AntAction extends ActionBase
                 for (String choosenTarget : choosenTargets)
                 {
                     antcall = (Ant) antProj.createTask("ant");
-                    antcall.setAntfile(getBuildFile().getAbsolutePath());
+                    if (buildDir != null)
+                    {
+                        antcall.setDir(buildDir);
+                    }
+                    antcall.setAntfile(buildFile.getAbsolutePath());
                     antcall.setTarget(choosenTarget);
                     antcalls.add(antcall);
                 }
@@ -222,6 +230,26 @@ public class AntAction extends ActionBase
     public void setBuildFile(File buildFile)
     {
         this.buildFile = buildFile;
+    }
+
+    /**
+     * Returns the build working directory.
+     *
+     * @return the working directory
+     */
+    public File getBuildDir()
+    {
+        return buildDir;
+    }
+
+    /**
+     * Sets the build working directory to be used to the given string.
+     *
+     * @param buildFile build working directory path to be used
+     */
+    public void setBuildDir(File buildDir)
+    {
+        this.buildDir = buildDir;
     }
 
     /**

--- a/izpack-util/src/main/java/com/izforge/izpack/util/IoHelper.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/IoHelper.java
@@ -852,7 +852,6 @@ public class IoHelper
         {
             copyStream(zin, out);
         }
-        out.closeEntry();
     }
 
     public static void copyStreamToJar(InputStream zin, java.util.zip.ZipOutputStream out, String currentName,

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.8.3</version>
+                <version>1.9.2</version>
             </dependency>
             <dependency>
                 <groupId>bsf</groupId>


### PR DESCRIPTION
With this patch it will be possible to use <antaction dir="some_base_dir" .../> to override the basedir of the launched build.

Additional changes:
- Increased dependency version of Ant to 1.9.2
- Ant action handling code cleanup
