### PR TITLE
[IZPACK-993] Dynamic variables - add configuration attribute to control whether to escape backslashes when reading from option and INI files

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -176,7 +176,7 @@ public class CompilerConfig extends Thread
      * @see #mergePacksLangFiles()
      */
     private Map<String, List<URL>> packsLangUrlMap = new HashMap<String, List<URL>>();
- 
+
     /**
      * UserInputPanel IDs for cross check whether given user input panel
      * referred in the installation descriptor are really defined
@@ -1466,7 +1466,7 @@ public class CompilerConfig extends Thread
         {
             File tmp = new File(dirName);
             org.apache.commons.io.FileUtils.forceMkdir(tmp);
-            org.apache.commons.io.FileUtils.forceDeleteOnExit(tmp); 
+            org.apache.commons.io.FileUtils.forceDeleteOnExit(tmp);
             String target = targetdir + "/" + dirName;
             logger.info("Adding file: " + tmp + ", as target file=" + target);
             pack.addFile(baseDir, tmp, target, osList,
@@ -1505,7 +1505,7 @@ public class CompilerConfig extends Thread
             panel.setOsConstraints(OsConstraintHelper.getOsList(panelElement));
             String className = xmlCompilerHelper.requireAttribute(panelElement, "classname");
 
-            // add an id                               
+            // add an id
             String id = panelElement.getAttribute("id");
             panel.setPanelId(id);
             String condition = panelElement.getAttribute("condition");
@@ -2209,10 +2209,16 @@ public class CompilerConfig extends Thread
                 String stype = var.getAttribute("type");
                 String filesection = var.getAttribute("section");
                 String filekey = xmlCompilerHelper.requireAttribute(var, "key");
+                String escapeVal = var.getAttribute("escape");
+                boolean escape = true;
+                if (escapeVal != null)
+                {
+                    escape = Boolean.parseBoolean(escapeVal);
+                }
                 if (dynamicVariable.getValue() == null)
                 {
                     dynamicVariable.setValue(new PlainConfigFileValue(value, getConfigFileType(
-                            name, stype), filesection, filekey));
+                            name, stype), filesection, filekey, escape));
                 }
                 else
                 {
@@ -2228,11 +2234,17 @@ public class CompilerConfig extends Thread
                 String stype = var.getAttribute("type");
                 String filesection = var.getAttribute("section");
                 String filekey = xmlCompilerHelper.requireAttribute(var, "key");
+                String escapeVal = var.getAttribute("escape");
+                boolean escape = true;
+                if (escapeVal != null)
+                {
+                    escape = Boolean.parseBoolean(escapeVal);
+                }
                 if (dynamicVariable.getValue() == null)
                 {
                     dynamicVariable.setValue(new ZipEntryConfigFileValue(value, entryname,
                                                                          getConfigFileType(name, stype), filesection,
-                                                                         filekey));
+                                                                         filekey, escape));
                 }
                 else
                 {
@@ -2248,11 +2260,17 @@ public class CompilerConfig extends Thread
                 String stype = var.getAttribute("type");
                 String filesection = var.getAttribute("section");
                 String filekey = xmlCompilerHelper.requireAttribute(var, "key");
+                String escapeVal = var.getAttribute("escape");
+                boolean escape = true;
+                if (escapeVal != null)
+                {
+                    escape = Boolean.parseBoolean(escapeVal);
+                }
                 if (dynamicVariable.getValue() == null)
                 {
                     dynamicVariable.setValue(new JarEntryConfigValue(value, entryname,
                                                                      getConfigFileType(name, stype), filesection,
-                                                                     filekey));
+                                                                     filekey, escape));
                 }
                 else
                 {

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/JarEntryConfigValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/JarEntryConfigValue.java
@@ -30,9 +30,9 @@ import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 public class JarEntryConfigValue extends ZipEntryConfigFileValue
 {
 
-    public JarEntryConfigValue(String filename, String entryname, int type, String section, String key)
+    public JarEntryConfigValue(String filename, String entryname, int type, String section, String key, boolean escape)
     {
-        super(filename, entryname, type, section, key);
+        super(filename, entryname, type, section, key, escape);
     }
 
     @Override

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/PlainConfigFileValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/PlainConfigFileValue.java
@@ -35,9 +35,9 @@ public class PlainConfigFileValue extends ConfigFileValue implements Serializabl
 
     public String location; // mandatory
 
-    public PlainConfigFileValue(String location, int type, String section, String key)
+    public PlainConfigFileValue(String location, int type, String section, String key, boolean escape)
     {
-        super(type, section, key);
+        super(type, section, key, escape);
         this.location = location;
     }
 

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/ZipEntryConfigFileValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/ZipEntryConfigFileValue.java
@@ -33,9 +33,9 @@ public class ZipEntryConfigFileValue extends ConfigFileValue
     private String filename;
     private String entryname;
 
-    public ZipEntryConfigFileValue(String filename, String entryname, int type, String section, String key)
+    public ZipEntryConfigFileValue(String filename, String entryname, int type, String section, String key, boolean escape)
     {
-        super(type, section, key);
+        super(type, section, key, escape);
         this.filename = filename;
         this.entryname = entryname;
     }

--- a/izpack-core/src/test/java/com/izforge/izpack/core/variable/ConfigFileValueTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/variable/ConfigFileValueTest.java
@@ -1,0 +1,131 @@
+package com.izforge.izpack.core.variable;
+
+import static org.junit.Assert.fail;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ConfigFileValueTest
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File properties;
+    private File zipFile;
+    private File jarFile;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        properties = folder.newFile("test.properties");
+        BufferedWriter out = new BufferedWriter(new FileWriter(properties));
+        out.write("test.path = C:\\mypath\\myfile\n");
+        out.write("test.path2 = C:\\\\mypath\\\\myfile\n");
+        out.close();
+
+        byte[] buf = new byte[1024];
+
+        try {
+            zipFile = folder.newFile("test.zip");
+            ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(zipFile));
+            FileInputStream in = new FileInputStream(properties);
+            zout.putNextEntry(new ZipEntry("test.properties"));
+            int len;
+            while ((len = in.read(buf)) > 0) {
+                zout.write(buf, 0, len);
+            }
+            zout.closeEntry();
+            in.close();
+            zout.close();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        try {
+            jarFile = folder.newFile("test.jar");
+            JarOutputStream jout = new JarOutputStream(new FileOutputStream(jarFile));
+            FileInputStream in = new FileInputStream(properties);
+            jout.putNextEntry(new JarEntry("test.properties"));
+            int len;
+            while ((len = in.read(buf)) > 0) {
+                jout.write(buf, 0, len);
+            }
+            jout.closeEntry();
+            in.close();
+            jout.close();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testPlainConfigFileValue()
+    {
+        PlainConfigFileValue value = new PlainConfigFileValue(properties.getPath(), ConfigFileValue.CONFIGFILE_TYPE_OPTIONS, null, "test.path", false);
+        PlainConfigFileValue value2 = new PlainConfigFileValue(properties.getPath(), ConfigFileValue.CONFIGFILE_TYPE_OPTIONS, null, "test.path2", true);
+        try
+        {
+            Assert.assertEquals("C:\\mypath\\myfile", value.resolve());
+            Assert.assertEquals("C:\\mypath\\myfile", value2.resolve());
+        }
+        catch (Exception e)
+        {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testZipConfigFileValue()
+    {
+        ZipEntryConfigFileValue value = new ZipEntryConfigFileValue(zipFile.getPath(), "test.properties", ConfigFileValue.CONFIGFILE_TYPE_OPTIONS, null, "test.path", false);
+        ZipEntryConfigFileValue value2 = new ZipEntryConfigFileValue(zipFile.getPath(), "test.properties", ConfigFileValue.CONFIGFILE_TYPE_OPTIONS, null, "test.path2", true);
+        try
+        {
+            Assert.assertEquals("C:\\mypath\\myfile", value.resolve());
+            Assert.assertEquals("C:\\mypath\\myfile", value2.resolve());
+        }
+        catch (Exception e)
+        {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testJarConfigFileValue()
+    {
+        JarEntryConfigValue value = new JarEntryConfigValue(zipFile.getPath(), "test.properties", ConfigFileValue.CONFIGFILE_TYPE_OPTIONS, null, "test.path", false);
+        JarEntryConfigValue value2 = new JarEntryConfigValue(zipFile.getPath(), "test.properties", ConfigFileValue.CONFIGFILE_TYPE_OPTIONS, null, "test.path2", true);
+        try
+        {
+            Assert.assertEquals("C:\\mypath\\myfile", value.resolve());
+            Assert.assertEquals("C:\\mypath\\myfile", value2.resolve());
+        }
+        catch (Exception e)
+        {
+            fail(e.getMessage());
+        }
+    }
+
+    @After
+    public void cleanUp() {
+       Assert.assertTrue(properties.exists());
+       Assert.assertTrue(zipFile.exists());
+       Assert.assertTrue(jarFile.exists());
+    }
+}

--- a/izpack-event/src/main/java/com/izforge/izpack/event/ConfigurationInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ConfigurationInstallerListener.java
@@ -1023,10 +1023,16 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     String stype = var.getAttribute("type");
                     String filesection = var.getAttribute("section");
                     String filekey = requireAttribute(var, "key");
+                    String escapeVal = var.getAttribute("escape");
+                    boolean escape = true;
+                    if (escapeVal != null)
+                    {
+                        escape = Boolean.parseBoolean(escapeVal);
+                    }
                     if (dynamicVariable.getValue() == null)
                     {
                         dynamicVariable.setValue(new PlainConfigFileValue(value, getConfigFileType(
-                                name, stype), filesection, filekey));
+                                name, stype), filesection, filekey, escape));
                     }
                     else
                     {
@@ -1042,11 +1048,17 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     String stype = var.getAttribute("type");
                     String filesection = var.getAttribute("section");
                     String filekey = requireAttribute(var, "key");
+                    String escapeVal = var.getAttribute("escape");
+                    boolean escape = true;
+                    if (escapeVal != null)
+                    {
+                        escape = Boolean.parseBoolean(escapeVal);
+                    }
                     if (dynamicVariable.getValue() == null)
                     {
                         dynamicVariable.setValue(new ZipEntryConfigFileValue(value, entryname,
                                                                              getConfigFileType(name, stype), filesection,
-                                                                             filekey));
+                                                                             filekey, escape));
                     }
                     else
                     {
@@ -1062,11 +1074,17 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     String stype = var.getAttribute("type");
                     String filesection = var.getAttribute("section");
                     String filekey = requireAttribute(var, "key");
+                    String escapeVal = var.getAttribute("escape");
+                    boolean escape = true;
+                    if (escapeVal != null)
+                    {
+                        escape = Boolean.parseBoolean(escapeVal);
+                    }
                     if (dynamicVariable.getValue() == null)
                     {
                         dynamicVariable.setValue(new JarEntryConfigValue(value, entryname,
                                                                          getConfigFileType(name, stype), filesection,
-                                                                         filekey));
+                                                                         filekey, escape));
                     }
                     else
                     {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Ini.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Ini.java
@@ -37,7 +37,12 @@ public class Ini extends BasicProfile implements Persistable, Configurable
 
     public Ini()
     {
-        _config = Config.getGlobal();
+        this(Config.getGlobal().clone());
+    }
+
+    public Ini(Config config)
+    {
+        setConfig(config);
     }
 
     public Ini(Reader input) throws IOException, InvalidFileFormatException

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Options.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Options.java
@@ -38,8 +38,13 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
 
     public Options()
     {
-        _config = Config.getGlobal().clone();
-        _config.setEmptyOption(true);
+        this(Config.getGlobal().clone());
+    }
+
+    public Options(Config config)
+    {
+        config.setEmptyOption(true);
+        setConfig(config);
     }
 
     public Options(Reader input) throws IOException, InvalidFileFormatException


### PR DESCRIPTION
Also added a unit test for dynamic variables reading a value from a config file (plain, zip, jar).
