### PR TITLE
Added 'run-privileged' element to info element in installation.dtd

### DIFF
--- a/src/dtd/installation.dtd
+++ b/src/dtd/installation.dtd
@@ -16,7 +16,7 @@ $Id$
 <!ATTLIST installation version CDATA #REQUIRED>
 
 <!-- The info section (general information on an installation) -->
-<!ELEMENT info (appname, appversion, appsubpath?, authors?, url?, javaversion?, uninstaller?, webdir?, summarylogfilepath?,writeinstallationinformation?)>
+<!ELEMENT info (appname, appversion, appsubpath?, authors?, url?, javaversion?, uninstaller?, webdir?, summarylogfilepath?,writeinstallationinformation?, run-privileged?)>
     <!ELEMENT appname (#PCDATA)>
     <!ELEMENT appversion (#PCDATA)>
     <!ELEMENT appsubpath (#PCDATA)>
@@ -35,6 +35,7 @@ $Id$
     <!ELEMENT webdir (#PCDATA)>
     <!ELEMENT summarylogfilepath (#PCDATA)>
 	<!ELEMENT writeinstallationinformation (#PCDATA)>
+	<!ELEMENT run-privileged EMPTY>
 
 <!ELEMENT packaging (packager, unpacker)>
 <!ELEMENT packager (options)>


### PR DESCRIPTION
When validating an installation xml with the installation.dtd from IzPack 4.3.5, the run-privileged element is shown as error since it does not exist in the DTD. This modification adds the XML element to the DTD.
