### PR TITLE
Fix script to install icon in Linux when dir contains whitespace

### DIFF
--- a/izpack-util/src/main/resources/com/izforge/izpack/util/unix/xdgdesktopiconscript.sh
+++ b/izpack-util/src/main/resources/com/izforge/izpack/util/unix/xdgdesktopiconscript.sh
@@ -544,7 +544,7 @@ case $action in
 
         for x in $desktop_dir ; do
             mkdir -p $x
-            eval 'cp $desktop_file $x/$basefile'$xdg_redirect_output
+            eval 'cp "$desktop_file" $x/$basefile'$xdg_redirect_output
 # Ubuntu 10.04 needs .desktop files to be executable
             chmod u+x $x/$basefile
         done


### PR DESCRIPTION
The icon copy for the desktop fails when installing an application in a directory containing whitespaces. Wrapping the desktop_file variable in double quotes in the cp command fixes it.
