### PR TITLE
Fix for IZPACK-1030 UserInputPanel checkbox revalidation doesn't trigger panel redisplay

### DIFF
--- a/izpack-dist/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-dist/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -50,6 +50,15 @@
                             <xs:element name="field" type="fieldType" maxOccurs="unbounded"/>
                         </xs:sequence>
                         <xs:attribute name="id" type="xs:string" use="required"/>
+                        <xs:attribute name="topBuffer" type="xs:integer" use="optional" default="25">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The percentage of left over vertical space to place on top of the components.
+                                    A value of 0 is useful to avoid components moving up and down during
+                                    dynamic validation where components are shown and hidden.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/test/AbstractPanelTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/test/AbstractPanelTest.java
@@ -175,6 +175,16 @@ public class AbstractPanelTest
     }
 
     /**
+     * Returns the rules.
+     *
+     * @return the rules
+     */
+    protected RulesEngine getRules()
+    {
+        return rules;
+    }
+
+    /**
      * Returns the uninstallation data writer.
      *
      * @return the uninstallation data writer

--- a/izpack-panel/src/test/resources/com/izforge/izpack/panels/userinput/check/userInputSpec.xml
+++ b/izpack-panel/src/test/resources/com/izforge/izpack/panels/userinput/check/userInputSpec.xml
@@ -50,8 +50,17 @@
         <field type="check" variable="check5">
             <spec txt="Check 5: " true="check5set" false="check5unset" revalidate="true"/>
         </field>
+
+        <field type="text" variable="check5text" conditionid="cond.check5set">
+            <spec txt="Check 6 Text: " size="20"/>
+        </field>
+
         <field type="check" variable="check6">
             <spec txt="Check 6: " true="check6set" false="check6unset" revalidate="true"/>
+        </field>
+
+        <field type="text" variable="check6text" conditionid="cond.check6unset">
+            <spec txt="Check 6 text:" size="20"/>
         </field>
     </panel>
 </izpack:userInput>


### PR DESCRIPTION
Also includes missing topBuffer attribute to izpack-userinput-5.0.xsd
