### PR TITLE
[IZPACK-1062] - Dynamic variables using checkonce="true" cannot be overwritten by internal variables with the same name

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/DynamicVariable.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/DynamicVariable.java
@@ -68,6 +68,7 @@ public interface DynamicVariable extends Serializable
 
     String evaluate(VariableSubstitutor... substitutors) throws Exception;
 
+    boolean isCheckonce();
     void setCheckonce(boolean checkonce);
 
     void setIgnoreFailure(boolean ignore);

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.core.data;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -296,6 +297,8 @@ public class DefaultVariables implements Variables
     @Override
     public synchronized void refresh()
     {
+        Collection<DynamicVariable> removeDynamicVariables = new ArrayList<DynamicVariable>();
+
         for (DynamicVariable variable : dynamicVariables)
         {
             String conditionId = variable.getConditionid();
@@ -331,6 +334,10 @@ public class DefaultVariables implements Variables
                     {
                         logger.fine("Dynamic variable=" + variable.getName() + " set, value=" + newValue);
                     }
+                    if (variable.isCheckonce())
+                    {
+                        removeDynamicVariables.add(variable);
+                    }
                 }
                 else if (log)
                 {
@@ -338,6 +345,9 @@ public class DefaultVariables implements Variables
                 }
             }
         }
+
+        // Cleanup all dynamic variables set 'checkonce' which have been already evaluated.
+        dynamicVariables.removeAll(removeDynamicVariables);
     }
 
     /**

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -222,6 +222,7 @@ public class DynamicVariableImpl implements DynamicVariable
         }
     }
 
+    @Override
     public boolean isCheckonce()
     {
         return checkonce;

--- a/izpack-event/src/main/java/com/izforge/izpack/event/ConfigurationInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ConfigurationInstallerListener.java
@@ -24,6 +24,7 @@ package com.izforge.izpack.event;
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1221,6 +1222,8 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
 
         if (dynamicvariables != null)
         {
+            Collection<DynamicVariable> removeDynamicVariables = new ArrayList<DynamicVariable>();
+
             logger.fine("Evaluating configuration variables");
             RulesEngine rules = getInstallData().getRules();
             for (DynamicVariable dynvar : dynamicvariables)
@@ -1256,6 +1259,10 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                         {
                             logger.fine("Configuration variable " + name + ": " + newValue);
                             props.setProperty(name, newValue);
+                            if (dynvar.isCheckonce())
+                            {
+                                removeDynamicVariables.add(dynvar);
+                            }
                         }
                         else
                         {
@@ -1268,6 +1275,8 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     }
                 }
             }
+
+            dynamicvariables.removeAll(removeDynamicVariables);
         }
 
         return props;


### PR DESCRIPTION
Dynamic variables using checkonce="true" cannot be overwritten by internal variables with the same name, but the appropriate IzPack variable is reset to the value from the first (and last) evaluation of that variable.

During refreshing dynamic variables, for instance on a panel change, those with checkonce="true" should be mapped to a normal internal IzPack variable and be usable for instance in UserInputPanels as default value to be shown in edit fields.

Example:

install.xml:

``` xml
<dynamicvariables>
  <variable name="address" file="${INSTALL_PATH}/" type="options"
    key="server.address"
    condition="haveInstallPath" checkonce="true"/>
</dynamicvariables>
```

Resource userInputSpec.xml:

``` xml
<userInput>
  <panel id="configuration.panel">
    <field type="title" txt="Network Configuration" id="configuration.panel.title"/>
    <field type="rule" variable="address">
      <description align="left" id="address.description"/>
      <spec id="address.label" txt="Network address:" layout="O:15:U : N:5:5" resultFormat="displayFormat"/>
    </field>
  </panel>
</userInput>
```

In the above example, as soon as the condition haveInstallPath evaluates true and the dynamic variables are refreshed (for instance after leaving the TargetPanel), the value of the variable address can never receive the value the user entered on the user input panel, because it is overwritten with the frozen value of the appropriate dynamic variable.
Instead, overwriting a variable defined as dynamic variable with checkonce="true" should be possible from other sources, like user input fields.
This does not have effect on dynamic variables which should be always renewed, thus, with checkonce="false" (default for dynamic variables).
