### PR TITLE
[IZPACK-1065] - Inconsistent artifact extension for deploy

### DIFF
--- a/izpack-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/izpack-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -44,14 +44,14 @@
     </component>
     <component>
       <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>izpack</role-hint>
+      <role-hint>izpack-jar</role-hint>
       <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
       <configuration>
         <type>izpack</type>
-        <includesDependencies>false</includesDependencies>
+        <includesDependencies>true</includesDependencies>
         <language>java</language>
         <extension>jar</extension>
-        <addedToClasspath>true</addedToClasspath>
+        <addedToClasspath>false</addedToClasspath>
         <packaging>izpack-jar</packaging>
       </configuration>
     </component>


### PR DESCRIPTION
This commit fixes the appropriate ArtifactHandler configuration for the IzPack Maven plugin.
