### PR TITLE
[IZPACK-1066] - Improve usability of resolving system properties as IzPack variables

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/substitutor/VariableSubstitutorBase.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/substitutor/VariableSubstitutorBase.java
@@ -383,6 +383,16 @@ public abstract class VariableSubstitutorBase implements VariableSubstitutor
                         varvalue = "";
                     }
                 }
+                else if (braces && name.startsWith("SYSTEM[")
+                        && (name.lastIndexOf(']') == name.length() - 1))
+                {
+                    varvalue = System.getProperty(name.substring(7, name.length() - 1));
+                }
+                // TODO: Compatibility mode - to be removed in future
+                else if (braces && name.startsWith("SYSTEM_") && name.length() > 7)
+                {
+                    varvalue = System.getProperty(name.substring(7).replace('_', '.'));
+                }
                 else
                 {
                     Value val = getValue(name);

--- a/izpack-core/src/test/java/com/izforge/izpack/core/substitutor/VariableSubstitutorImplTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/substitutor/VariableSubstitutorImplTest.java
@@ -30,6 +30,10 @@ import org.junit.Test;
 import com.izforge.izpack.api.substitutor.SubstitutionType;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.fail;
+
+
 /**
  * Unit tests of substitutor features
  *
@@ -85,5 +89,22 @@ public class VariableSubstitutorImplTest
                 Is.is("onetwo"));
     }
 
+    @Test
+    public void testSystemPropertiesSubstition() throws Exception
+    {
+        String substituted = variableSubstitutor.substitute("${SYSTEM[user.dir]}");
+        assertNotNull(substituted);
+        if (substituted.trim().isEmpty() || substituted.startsWith("${SYSTEM["))
+        {
+            fail("The system variable resolution of ${SYSTEM[user.dir]} resulted in an invalid string '" + substituted + "\"");
+        }
+        // TODO: This is just for backward compatibility, remove in future
+        substituted = variableSubstitutor.substitute("${SYSTEM_user_dir}");
+        assertNotNull(substituted);
+        if (substituted.trim().isEmpty() || substituted.startsWith("${SYSTEM_"))
+        {
+            fail("The system variable resolution of ${SYSTEM_user_dir} resulted in an invalid string '" + substituted + "\"");
+        }
+    }
 
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
@@ -195,17 +195,6 @@ public abstract class AbstractInstallDataProvider implements Provider
         installData.setVariable(ScriptParserConstant.IP_ADDRESS, IPAddress);
         installData.setVariable(ScriptParserConstant.HOST_NAME, hostname);
         installData.setVariable(ScriptParserConstant.FILE_SEPARATOR, File.separator);
-
-        Set<String> systemProperties = System.getProperties().stringPropertyNames();
-        for (String varName : systemProperties)
-        {
-            String varValue = System.getProperty(varName);
-            if (varValue != null)
-            {
-                varName = varName.replace('.', '_');
-                installData.setVariable("SYSTEM_" + varName, varValue);
-            }
-        }
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelHelper.java
@@ -76,7 +76,7 @@ public class TargetPanelHelper
         if (defaultPath == null)
         {
             // Make the default path point to the current location
-            defaultPath = installData.getVariable("SYSTEM_user_dir");
+            defaultPath = System.getProperty("user.dir");
         }
 
         String path = getTargetPanelDir(installData);

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/target/TargetPanelHelperTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/target/TargetPanelHelperTest.java
@@ -58,10 +58,9 @@ public class TargetPanelHelperTest
     {
         Variables variables = new DefaultVariables();
         InstallData installData = new AutomatedInstallData(variables, Platforms.WINDOWS_7);
-        assertNull(TargetPanelHelper.getPath(installData));
 
         // verify that the user dir is returned if no other variable is set
-        variables.set("SYSTEM_user_dir", "userdir");
+        System.setProperty("user.dir", "userdir");
         assertEquals("userdir", TargetPanelHelper.getPath(installData));
 
         // verify that the DEFAULT_INSTALL_PATH overrides SYSTEM_user_dir
@@ -82,7 +81,7 @@ public class TargetPanelHelperTest
         Variables variables = new DefaultVariables();
         InstallData installData = new AutomatedInstallData(variables, Platforms.WINDOWS_7);
 
-        variables.set("SYSTEM_user_dir", "userdir");
+        System.setProperty("user.dir", "userdir");
         variables.set("DEFAULT_INSTALL_PATH", "default");
         assertEquals("default", TargetPanelHelper.getPath(installData));
 
@@ -106,7 +105,7 @@ public class TargetPanelHelperTest
         Variables variables = new DefaultVariables();
         InstallData installData = new AutomatedInstallData(variables, Platforms.MAC_OSX);
 
-        variables.set("SYSTEM_user_dir", "userdir");
+        System.setProperty("user.dir", "userdir");
         variables.set("DEFAULT_INSTALL_PATH", "default");
         assertEquals("default", TargetPanelHelper.getPath(installData));
 
@@ -132,7 +131,7 @@ public class TargetPanelHelperTest
         Variables variables = new DefaultVariables();
         InstallData installData = new AutomatedInstallData(variables, Platforms.FEDORA_LINUX);
 
-        variables.set("SYSTEM_user_dir", "userdir");
+        System.setProperty("user.dir", "userdir");
         variables.set("DEFAULT_INSTALL_PATH", "default");
         assertEquals("default", TargetPanelHelper.getPath(installData));
 


### PR DESCRIPTION
Currently it is possible to resolve variables with the syntax ${SYSTEM_variablename} from system variables, in that case would be variablename resolved from the Java system properties as IzPack variable SYSTEM_variablename.
The implementation is very limited. For example the following code doesn't currently work at all:

``` xml
<variables>
  <variable name="featureEnabled" value="${SYSTEM_featureEnabled}" />
</variables>

<conditions>
  <condition type="variable" id="isFeatureEnabled">
    <name>featureEnabled</name>
    <value>true</value>
  </condition>
</conditions>
```

but must be written as:

``` xml
<conditions>
  <condition type="variable" id="isFeatureEnabled">
    <name>SYSTEM_featureEnabled</name>
    <value>true</value>
  </condition>
</conditions>
```

Furthermore, variables starting on the prefix SYSTEM_ are not really dynamically resolved, but all system variables are expanded at IzPack variables by default. This takes just time and resources during installing. System properties should be resolved on demand like all other variable types.

Added syntax ${SYSTEM[variable.Name]} for parsing system properties.
Marking old syntax ${SYSTEM_variable_Name} as obsolete, to be removed in one of the next major versions. Leavin it now for backward compatibility.
