### PR TITLE
[IZPACK-1067] - ConfigurationInstallerListener - action for dedicated xpath expression does not work

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/xmlmerge/XmlMerge.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/xmlmerge/XmlMerge.java
@@ -73,17 +73,23 @@ public interface XmlMerge
     public String merge(String[] sources) throws AbstractXmlMergeException;
 
     /**
-     * Sets the MergeAction which will be applied to the root element.
+     * Sets the merge actions which will be applied to the root element.
      *
-     * @param rootMergeAction The MergeAction which will be applied to the root element
+     * @param rootMergeAction The merge actions which will be applied to the root element
      */
     public void setRootMergeActionFactory(OperationFactory factory);
 
     /**
-     * Sets the Mapper which will be applied to the root element.
+     * Sets the mappers which will be applied to the root element.
      *
-     * @param rootMapper The Mapper which will be applied to the root element
+     * @param rootMapper The mappers which will be applied to the root element
      */
     public void setRootMergeMapperFactory(OperationFactory factory);
 
+    /**
+     * Sets the matchers which will be applied to the root element.
+     *
+     * @param rootMapper The matchers which will be applied to the root element
+     */
+    public void setRootMergeMatcherFactory(OperationFactory factory);
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/xmlmerge/config/AbstractXPathConfigurer.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/xmlmerge/config/AbstractXPathConfigurer.java
@@ -202,6 +202,8 @@ public abstract class AbstractXPathConfigurer implements Configurer
         m_rootMergeAction.setActionFactory(actionFactory);
 
         xmlMerge.setRootMergeActionFactory(actionFactory);
+        xmlMerge.setRootMergeMapperFactory(mapperFactory);
+        xmlMerge.setRootMergeMatcherFactory(matcherFactory);
     }
 
     /**

--- a/izpack-util/src/main/java/com/izforge/izpack/util/xmlmerge/config/ConfigurableXmlMerge.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/xmlmerge/config/ConfigurableXmlMerge.java
@@ -109,4 +109,10 @@ public class ConfigurableXmlMerge implements XmlMerge
         m_wrappedXmlMerge.setRootMergeActionFactory(factory);
     }
 
+    @Override
+    public void setRootMergeMatcherFactory(OperationFactory factory)
+    {
+        m_wrappedXmlMerge.setRootMergeMatcherFactory(factory);
+    }
+
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/xmlmerge/merge/DefaultXmlMerge.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/xmlmerge/merge/DefaultXmlMerge.java
@@ -83,6 +83,7 @@ public class DefaultXmlMerge implements XmlMerge
         this.m_rootMergeAction.setActionFactory(factory);
     }
 
+    @Override
     public void setRootMergeMatcherFactory(OperationFactory factory)
     {
         m_rootMergeAction.setMatcherFactory(factory);
@@ -226,7 +227,7 @@ public class DefaultXmlMerge implements XmlMerge
         Document result = doMerge(docs);
 
         Format prettyFormatter = Format.getPrettyFormat();
-        // Use system line seperator to avoid problems
+        // Use system line separator to avoid problems
         // with carriage return under linux
         prettyFormatter.setLineSeparator(System.getProperty("line.separator"));
         XMLOutputter sortie = new XMLOutputter(prettyFormatter);
@@ -297,26 +298,5 @@ public class DefaultXmlMerge implements XmlMerge
         }
 
         root.sortChildren(comparator);
-    }
-
-
-    public static void main(String [] args)
-    {
-        DefaultXmlMerge merger = new DefaultXmlMerge();
-        try
-        {
-            File targetFile = new File("/home/rkrell/gkretail/sm.server/config/sm_client_log4j.xml.confignew");
-            if (targetFile.exists() && !targetFile.delete())
-            {
-                System.err.println("Delete error");
-            }
-            merger.merge(new File[] { new File("/home/rkrell/gkretail/sm.server/config/sm_client_log4j.xml.configbak"),
-                    new File("/home/rkrell/gkretail/sm.server/config/sm_client_log4j.xml")}, targetFile);
-        }
-        catch (AbstractXmlMergeException e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
     }
 }

--- a/izpack-util/src/test/java/com/izforge/izpack/util/xmlmerge/XmlMergeTest.java
+++ b/izpack-util/src/test/java/com/izforge/izpack/util/xmlmerge/XmlMergeTest.java
@@ -1,10 +1,24 @@
 package com.izforge.izpack.util.xmlmerge;
 import static org.junit.Assert.*;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.FileChannel;
 import java.util.Properties;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
 import com.izforge.izpack.util.xmlmerge.config.ConfigurableXmlMerge;
 import com.izforge.izpack.util.xmlmerge.config.PropertyXPathConfigurer;
@@ -12,6 +26,8 @@ import com.izforge.izpack.util.xmlmerge.config.PropertyXPathConfigurer;
 
 public class XmlMergeTest
 {
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception
@@ -72,6 +88,71 @@ public class XmlMergeTest
                 "</el1>\n";
         expectedResult = expectedResult.replace("\n", System.getProperty("line.separator"));
         assertEquals(result, expectedResult);
+    }
+
+    /**
+     * Test merging of a patch file to an original file, parallely use the original file as output file.
+     * Tests several XPath-based actions and matchers.
+     * @throws IOException
+     * @throws AbstractXmlMergeException
+     * @throws SAXException
+     * @throws ParserConfigurationException
+     */
+    @Test
+    public void testMergeFilesWithXPathTagMatcherReplace2Files() throws IOException, AbstractXmlMergeException, SAXException, ParserConfigurationException
+    {
+        URL patchSourceFileUrl = getClass().getResource("maps_resources_patch.xml");
+        URL patchTargetFileUrl = getClass().getResource("maps_resources_original.xml");
+        URL expectedFileUrl = getClass().getResource("maps_resources_expected.xml");
+        assertNotNull("Patch source file missing", patchSourceFileUrl);
+        assertNotNull("Patch target file missing", patchTargetFileUrl);
+        assertNotNull("Expected result file missing", expectedFileUrl);
+
+        File targetFile = tmpDir.newFile("maps_resources_merged.xml");
+
+        // Copy target file to a temporary location,
+        // it should be patch target and output at one time in this test and therefore is written to it
+        FileChannel inputChannel = null;
+        FileChannel outputChannel = null;
+        try {
+            inputChannel = new FileInputStream(new File(patchTargetFileUrl.getFile())).getChannel();
+            outputChannel = new FileOutputStream(targetFile).getChannel();
+            outputChannel.transferFrom(inputChannel, 0, inputChannel.size());
+        } finally {
+            inputChannel.close();
+            outputChannel.close();
+        }
+
+        XmlMerge xmlMerge;
+        Properties confProps = new Properties();
+        confProps.setProperty("action.default", "PRESERVE"); // Preserve with that from original
+        confProps.setProperty("xpath.path1", "/maps/address-source");
+        confProps.setProperty("matcher.path1", "TAG");
+        confProps.setProperty("xpath.path2", "/maps/proxy");
+        confProps.setProperty("matcher.path2", "TAG");
+        confProps.setProperty("action.path2", "REPLACE"); // Replace with that from patch
+        xmlMerge = new ConfigurableXmlMerge(new PropertyXPathConfigurer(confProps));
+        xmlMerge.merge( new File[]{
+                targetFile,
+                new File(patchSourceFileUrl.getFile())
+                },
+                targetFile);
+
+
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        dbf.setCoalescing(true);
+        dbf.setIgnoringElementContentWhitespace(true);
+        dbf.setIgnoringComments(false);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+
+        Document resultDocument = db.parse(targetFile);
+        resultDocument.normalizeDocument();
+
+        Document expectedDocument = db.parse(new File(expectedFileUrl.getFile()));
+        expectedDocument.normalizeDocument();
+
+        assertTrue("Result document does not match expected result", resultDocument.isEqualNode(expectedDocument));
     }
 
 }

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/xmlmerge/maps_resources_expected.xml
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/xmlmerge/maps_resources_expected.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<maps enabled="false" handler="client">
+  <address-source street="information.properties/STREET" city="information.properties/CITY" zip="information.properties/ZIP" state="information.properties/COUNTRY" federal_state="information.properties/FEDERAL_STATE" />
+  <caches>
+    <compressed-image-cache size="10000" />
+    <image-cache size="20000" />
+  </caches>
+  <geo-position-providers use="MapQuest">
+    <geo-position-provider id="MapQuest" geo-class="com.mysoft.util.maps.geo.GeoPositionProviderMapQuest">
+      <param name="key" value="123456789ABCDEFG%$§$)(=)" />
+    </geo-position-provider>
+  </geo-position-providers>
+  <proxy enabled="true" address="proxy.mycompany.com" port="33128" />
+  <tile-providers use="Open Street Maps">
+    <tile-provider id="Open Street Maps" tile-class="com.mysoft.client.ui.maps.tile.OSMTileFactoryInfo" />
+  </tile-providers>
+</maps>

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/xmlmerge/maps_resources_original.xml
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/xmlmerge/maps_resources_original.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<maps enabled="false" handler="client">
+  <address-source street="information.properties/STREET" city="information.properties/CITY" zip="information.properties/ZIP" state="information.properties/COUNTRY" federal_state="information.properties/FEDERAL_STATE" />
+  <caches>
+    <compressed-image-cache size="10000" />
+    <image-cache size="20000" />
+  </caches>
+  <geo-position-providers use="MapQuest">
+    <geo-position-provider id="MapQuest" geo-class="com.mysoft.util.maps.geo.GeoPositionProviderMapQuest">
+      <param name="key" value="123456789ABCDEFG%$§$)(=)" />
+    </geo-position-provider>
+  </geo-position-providers>
+  <proxy enabled="false" address="proxy" port="3128" />
+  <tile-providers use="Open Street Maps">
+    <tile-provider id="Open Street Maps" tile-class="com.mysoft.client.ui.maps.tile.OSMTileFactoryInfo" />
+  </tile-providers>
+</maps>

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/xmlmerge/maps_resources_patch.xml
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/xmlmerge/maps_resources_patch.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<maps
+  enabled="false"
+  handler="client"
+>
+  <proxy
+    enabled="true"
+    address="proxy.mycompany.com"
+    port="33128"
+  />
+
+  <geo-position-providers
+    use="MapQuest"
+  >
+    <geo-position-provider
+      id="MapQuest"
+      geo-class="com.mysoft.util.maps.geo.GeoPositionProviderMapQuest"
+    >
+      <param name="key" value="123456789ABCDEFG%$§$)(=)"/>
+    </geo-position-provider>
+  </geo-position-providers>
+
+  <tile-providers
+    use="Open Street Maps"
+  >
+    <tile-provider
+      id="Open Street Maps"
+      tile-class="com.mysoft.client.ui.maps.tile.OSMTileFactoryInfo"
+    />
+  </tile-providers>
+
+  <address-source
+    street="information.properties/STREET"
+    city="information.properties/CITY"
+    zip="information.properties/ZIP"
+    state="information.properties/COUNTRY"
+  />
+
+  <!-- Enter Cache Sizes in kB -->
+  <caches>
+   <image-cache size="20000"/>
+   <compressed-image-cache size="10000"/>
+  </caches>
+
+</maps>


### PR DESCRIPTION
Dedicated actions and matchers defined are ignored and according defaults are used by mistake.
This implementation should fix it.
