### PR TITLE
Adding missing TreePacksPanel.headline string

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Instalação terminada"/>
     <str id="SummaryPanel.headline" txt="Resumo dos dados do usuário"/>
     <str id="TargetPanel.headline" txt="Caminho de destino"/>
+    <str id="TreePacksPanel.headline" txt="Selecione pacotes de instalação"/>
     <str id="UserInputPanel.headline" txt="Dados do usuário"/>
 
     <!-- General installer strings -->

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Installation abgeschlossen"/>
     <str id="SummaryPanel.headline" txt="Zusammenfassung Konfigurationsdaten"/>
     <str id="TargetPanel.headline" txt="Installationspfad"/>
+    <str id="TreePacksPanel.headline" txt="Auswahl Installationspakete"/>
     <str id="UserInputPanel.headline" txt="Benutzerdaten"/>
     <str id="UserPathPanel.headline" txt="Pfad auswählen"/>
     <str id="InstallationTypePanel.headline" txt="Installationsart"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Installation Finished"/>
     <str id="SummaryPanel.headline" txt="Summary Configuration Data"/>
     <str id="TargetPanel.headline" txt="Target Path"/>
+    <str id="TreePacksPanel.headline" txt="Select Installation Packages"/>
     <str id="UserInputPanel.headline" txt="User Data"/>
     <str id="UserPathPanel.headline" txt="Select Path"/>
     <str id="InstallationTypePanel.headline" txt="Installation Type"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Instalazioa bukatua"/>
     <str id="SummaryPanel.headline" txt="Konfigurazio Datuen Laburpena"/>
     <str id="TargetPanel.headline" txt="Jopunturako bidea"/>
+    <str id="TreePacksPanel.headline" txt="Paketeak aukeratu"/>
     <str id="UserInputPanel.headline" txt="Erabiltzailearen datuak"/>
     <str id="UserPathPanel.headline" txt="Aukeratu Bidea"/>
     <str id="InstallationTypePanel.headline" txt="Instalazio Mota"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="نصب به پایان رسید."/>
     <str id="SummaryPanel.headline" txt="خلاصه اطلاعات پیکربندی"/>
     <str id="TargetPanel.headline" txt="مسیر مقصد"/>
+    <str id="TreePacksPanel.headline" txt="انتخاب بسته های نصب"/>
     <str id="UserInputPanel.headline" txt="اطلاعات کاربر"/>
 
     <!-- General installer strings -->

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Asennus on päättynyt"/>
     <str id="SummaryPanel.headline" txt="Yhteenveto asetustiedoista"/>
     <str id="TargetPanel.headline" txt="Kohdepolku"/>
+    <str id="TreePacksPanel.headline" txt="Valitse asennuspaketit"/>
     <str id="UserInputPanel.headline" txt="Käyttäjän data"/>
     <str id="UserPathPanel.headline" txt="Valitse polku"/>
     <str id="InstallationTypePanel.headline" txt="Asennuksen tyyppi"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Installation Terminée"/>
     <str id="SummaryPanel.headline" txt="Résumé des données de configuration"/>
     <str id="TargetPanel.headline" txt="Chemin d'installation"/>
+    <str id="TreePacksPanel.headline" txt="Sélection des paquets à installer"/>
     <str id="UserInputPanel.headline" txt="Données utilisateur"/>
     <str id="UserPathPanel.headline" txt="Sélectionnez le chemin"/>
     <str id="InstallationTypePanel.headline" txt="Type d'installation"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Instalación Finalizada"/>
     <str id="SummaryPanel.headline" txt="Sumario dos Datos da Configuración"/>
     <str id="TargetPanel.headline" txt="Ruta de Destino"/>
+    <str id="TreePacksPanel.headline" txt="Seleccionar Paquetes de Instalación"/>
     <str id="UserInputPanel.headline" txt="Datos do Usuario"/>
     <str id="UserPathPanel.headline" txt="Ruta Seleccionada"/>
     <str id="InstallationTypePanel.headline" txt="Tipo de Instalación"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
@@ -25,6 +25,7 @@
     <str id="SimpleFinishPanel.headline" txt="Telepítés befejezõdött"/>
     <str id="SummaryPanel.headline" txt="Konfigurációs fájlok összefoglalása"/>
     <str id="TargetPanel.headline" txt="Telepítési ösvény"/>
+    <str id="TreePacksPanel.headline" txt="Telepítési csomagok kiválasztása"/>
     <str id="UserInputPanel.headline" txt="Fölhasználói adatok"/>
     <str id="InstallationTypePanel.headline" txt="Telepítés módja"/>
 

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Pemasangan Telah Selesai"/>
     <str id="SummaryPanel.headline" txt="Ringkasan Data Konfigurasi"/>
     <str id="TargetPanel.headline" txt="Alamat Tujuan"/>
+    <str id="TreePacksPanel.headline" txt="Pilih Paket-Paket Pemasangan"/>
     <str id="UserInputPanel.headline" txt="Data Pengguna"/>
     <str id="UserPathPanel.headline" txt="Pilih Lokasi"/>
     <str id="InstallationTypePanel.headline" txt="Jenis Pemasangan"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Installazione completata"/>
     <str id="SummaryPanel.headline" txt="Riepilogo dati configurazione"/>
     <str id="TargetPanel.headline" txt="Percorso destinazione"/>
+    <str id="TreePacksPanel.headline" txt="Selezionare i moduli da installare"/>
     <str id="UserInputPanel.headline" txt="Dati utente"/>
     <str id="UserPathPanel.headline" txt="Selezionare percorso"/>
     <str id="InstallationTypePanel.headline" txt="Tipo installazione"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
@@ -58,6 +58,7 @@
     <str id="SimpleFinishPanel.headline" txt="�C���X�g�[������"/>
     <str id="SummaryPanel.headline" txt="�ݒ��f�[�^�̃T�}��"/>
     <str id="TargetPanel.headline" txt="�C���X�g�[����"/>
+    <str id="TreePacksPanel.headline" txt="�C���X�g�[���p�b�P�[�W�̑I��"/>
     <str id="UserInputPanel.headline" txt="���[�U�f�[�^"/>
     <str id="UserPathPanel.headline" txt="�p�X�̑I��"/>
     <str id="InstallationTypePanel.headline" txt="�C���X�g�[���̎���"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
@@ -31,6 +31,7 @@
     <str id="SummaryPanel.headline"
          txt="Overzicht configuratiegegevens"/>
     <str id="TargetPanel.headline" txt="Installatiepad"/>
+    <str id="TreePacksPanel.headline" txt="Selecteer Installatiepakketten"/>
     <str id="UserInputPanel.headline" txt="Gebruikersgegevens"/>
     <str id="UserPathPanel.headline" txt="Selekteer pad"/>
     <str id="InstallationTypePanel.headline" txt="Installatietype"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
@@ -30,6 +30,7 @@
     <str id="SimpleFinishPanel.headline" txt="Installasjon fullført"/>
     <str id="SummaryPanel.headline" txt="Oppsummering av konfigurasjon"/>
     <str id="TargetPanel.headline" txt="Målsti"/>
+    <str id="TreePacksPanel.headline" txt="Velg installasjonspakker"/>
     <str id="UserInputPanel.headline" txt="Brukerdata"/>
     <str id="UserPathPanel.headline" txt="Velg mål"/>
     <str id="InstallationTypePanel.headline" txt="Installasjonstype"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
@@ -212,6 +212,7 @@
     <str id="TargetPanel.summaryCaption" txt="Katalog docelowy"/>
     <str id="TargetPanel.warn"
          txt="Katalog już istnieje! Czy jesteś pewien, że chcesz kontynuować instalację i nadpisać istniejące pliki?"/>
+    <str id="TreePacksPanel.headline" txt="Wybierz pakiety do zainstalowania"/>
     <str id="TreePacksPanel.summaryCaption" txt="Wybrane pakiety"/>
     <str id="uninstaller.destroytarget" txt=" Wymuś usunięcie "/>
     <str id="uninstaller.uninstall" txt="Odinstaluj"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Instalação Terminada"/>
     <str id="SummaryPanel.headline" txt="Resumo dos Dados de Configuração"/>
     <str id="TargetPanel.headline" txt="Localização de Destino"/>
+    <str id="TreePacksPanel.headline" txt="Seleccione os Pacotes de Instalação"/>
     <str id="UserInputPanel.headline" txt="Dados do Utilizador"/>
     <str id="UserPathPanel.headline" txt="Seleccione a Localização"/>
     <str id="InstallationTypePanel.headline" txt="Tipo de Instalação"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Inštalácia ukončená"/>
     <str id="SummaryPanel.headline" txt="Sumár konfiguračných dát"/>
     <str id="TargetPanel.headline" txt="Cieľová cesta"/>
+    <str id="TreePacksPanel.headline" txt="Vyberte inštalačné balíky"/>
     <str id="UserInputPanel.headline" txt="Použivateľské data"/>
     <str id="UserPathPanel.headline" txt="Select Path"/>
     <str id="InstallationTypePanel.headline" txt="Typ inštalácie"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -28,6 +28,7 @@
     <str id="SimpleFinishPanel.headline" txt="Instalación completada"/>
     <str id="SummaryPanel.headline" txt="Resumen de los datos de configuración"/>
     <str id="TargetPanel.headline" txt="Ruta destino"/>
+    <str id="TreePacksPanel.headline" txt="Seleccione los paquetes para la instalación"/>
     <str id="UserInputPanel.headline" txt="Datos del usuario"/>
     <str id="InstallationTypePanel.headline" txt="Tipo de instalación"/>
 

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
@@ -35,6 +35,7 @@
     <str id="SimpleFinishPanel.headline" txt="Kurulum Tamamlandı"/>
     <str id="SummaryPanel.headline" txt="Özet Kurulum Bilgileri"/>
     <str id="TargetPanel.headline" txt="Hedef Dizin"/>
+    <str id="TreePacksPanel.headline" txt="Kurmak İstediğiniz Paketleri Seçiniz"/>
     <str id="UserInputPanel.headline" txt="Kullanıcı Bilgileri"/>
 
     <!-- Genel kurulum karakter dizileri -->

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
@@ -29,6 +29,7 @@
     <str id="SimpleFinishPanel.headline" txt="Встановлення завершено"/>
     <str id="SummaryPanel.headline" txt="Загальне налаштування"/>
     <str id="TargetPanel.headline" txt="Шлях встановлення"/>
+    <str id="TreePacksPanel.headline" txt="Виберіть пакунки для встановлення"/>
     <str id="UserInputPanel.headline" txt="Дані користувача"/>
     <str id="UserPathPanel.headline" txt="Виберіть шлях"/>
     <str id="InstallationTypePanel.headline" txt="Тип встановлення"/>


### PR DESCRIPTION
This is to address http://jira.codehaus.org/browse/IZPACK-1071

I have copied the PacksPanel.headline string as TreePacksPanel.headline strings where available.
This will ensure that the header image for the TreePacksPanel will be shown if configured.
