### PR TITLE
[IZPACK-1061] - UserInputPanel: Installer crashes on missing 'set' attribute for RuleInputFields

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/rule/RuleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/rule/RuleField.java
@@ -105,10 +105,22 @@ public class RuleField extends Field
     @Override
     public String getInitialValue()
     {
+        String value = getValue();
+
+        if (value != null)
+        {
+            ValidationStatus status = validateFormatted(value);
+            if (status.isValid())
+            {
+                return value;
+            }
+        }
+
         if (hasDefaultValues())
         {
             return format(getDefaultValues());
         }
+
         return null;
     }
 
@@ -121,6 +133,11 @@ public class RuleField extends Field
      */
     public boolean hasDefaultValues()
     {
+        if (defaultValues == null)
+        {
+            return false;
+        }
+
         for (String value : defaultValues)
         {
             if (value != null && !value.equals(""))
@@ -133,12 +150,29 @@ public class RuleField extends Field
 
     /**
      * Returns the default values for each sub-field.
+     * Field validators are not activated here, this method just verifies whether the value matches the layout.
      *
      * @return the default values
      */
     public String[] getDefaultValues()
     {
-        return defaultValues;
+        String value = super.getInitialValue();
+
+        if (hasDefaultValues())
+        {
+            return defaultValues;
+        }
+
+        if (value != null)
+        {
+            ValidationStatus status = layout.validate(value);
+            if (status.isValid())
+            {
+                return status.getValues();
+            }
+        }
+
+        return new String[0];
     }
 
     /**
@@ -327,6 +361,11 @@ public class RuleField extends Field
      */
     private String[] parseSet(String set, ObjectFactory factory)
     {
+        if (set == null)
+        {
+            return null;
+        }
+
         StringTokenizer tokenizer = new StringTokenizer(set);
         String[] result = new String[layout.getFieldSpecs().size()];
 

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/field/rule/RuleFieldValidatorTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/field/rule/RuleFieldValidatorTest.java
@@ -42,6 +42,8 @@ import com.izforge.izpack.panels.userinput.validator.HostAddressValidator;
 import com.izforge.izpack.panels.userinput.validator.RegularExpressionValidator;
 import com.izforge.izpack.util.Platforms;
 
+import static org.junit.Assert.assertArrayEquals;
+
 
 /**
  * Tests the field validation of {@link RuleField} class instances.
@@ -107,6 +109,30 @@ public class RuleFieldValidatorTest
         RuleField model = new RuleField(config, installData, factory);
         ValidationStatus status = model.validate(new String[] {"127.0.0.1", "1234"});
         assertTrue(status.isValid());
+    }
+
+    @Test
+    public void testDefaultValues()
+    {
+        String layout = "O:15:U : N:5:5"; // host : port format
+        String variable = "server.address";
+        String separator = null;
+        //String defaultValue = "0: 1:";
+
+        TestRuleFieldConfig config = new TestRuleFieldConfig(variable, layout, separator, RuleFormat.DISPLAY_FORMAT);
+        //config.setDefaultValue(defaultValue);
+
+        Map<String, String> regexp = new HashMap<String, String>();
+        regexp.put(RegularExpressionValidator.PATTERN_PARAM, "\\b.*\\:(6553[0-5]|655[0-2]\\d|65[0-4]\\d{2}|6[0-4]\\d{3}|[1-5]\\d{4}|[1-9]\\d{0,3})\b");
+
+        // Tests, whether the following validator is ignored for just receiving unvalidated default values
+        FieldValidator fieldValidator = new FieldValidator( RegularExpressionValidator.class.getName(), regexp, "Host address validation failed", factory);
+        config.addValidator(fieldValidator);
+
+        installData.setVariable(variable, "@HOST_ADDRESS@:1234");
+        RuleField model = new RuleField(config, installData, factory);
+
+        assertArrayEquals(model.getDefaultValues(), new String[] { "@HOST_ADDRESS@", "1234"});
     }
 
 }

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleFieldTest.java
@@ -141,5 +141,25 @@ public class GUIRuleFieldTest
         assertEquals("192.168.0.1", installData.getVariable(variable));
     }
 
+    /**
+     * Tests the specification of a {@link Processor} as part of the 'set' attribute.
+     */
+    @Test
+    public void testDefaultValueProcessorOnePart()
+    {
+        String layout = "O:25:U";
+        String variable = "variable1";
+        String separator = null;
+        TestRuleFieldConfig config = new TestRuleFieldConfig(variable, layout, separator, RuleFormat.DISPLAY_FORMAT);
+        config.setDefaultValue("0:localhost");
+        RuleField model = new RuleField(config, installData, factory);
+
+        GUIRuleField field = new GUIRuleField(model);
+        assertEquals("localhost", field.getValue());
+
+        assertNull(installData.getVariable("variable1"));
+        assertTrue(field.updateField(LoggingPrompt.INSTANCE));
+        assertEquals("localhost", installData.getVariable(variable));
+    }
 }
 


### PR DESCRIPTION
This is a post-fix with a new unit test for the failing non-standard use case:

``` xml
<field type="rule" variable="host">
  <spec txt="Hostname or IP address:" id="host.label" layout="O:25:U" set="0:localhost" />
</field>
```

which initialized the (single) GUI input by "0:localhost" instead of the expected text "localhost".
