### PR TITLE
[IZPACK-1072] Unset dynamic variables if they cannot be validated any longer for some reason

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -154,6 +154,8 @@ public class DynamicVariableImpl implements DynamicVariable
             logger.log(Level.FINE,
                        "Error evaluating dynamic variable '" + getName() + "': " + e,
                        e);
+
+            return null; // unset this variable
         }
 
         return newValue;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
@@ -347,7 +347,7 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
         }
         catch (Throwable exception)
         {
-            logger.log(Level.WARNING, exception.getMessage(), exception);
+            logger.log(Level.WARNING, "Could not validate dynamic conditions", exception);
             result = false;
         }
         return result;
@@ -361,6 +361,7 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
      */
     protected boolean validateData()
     {
+        installData.refreshVariables();
         return isValid(validator, installData);
     }
 
@@ -375,7 +376,7 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
      * @return {@code true} if the validator evaluated successfully, or with a warning that the user chose to skip;
      *         otherwise {@code false}
      */
-    protected boolean isValid(DataValidator validator, InstallData installData)
+    private boolean isValid(DataValidator validator, InstallData installData)
     {
         boolean result = false;
         DataValidator.Status status = validator.validateData(installData);

--- a/izpack-util/src/main/java/com/izforge/izpack/util/FileExecutor.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/FileExecutor.java
@@ -269,7 +269,7 @@ public class FileExecutor
         }
         catch (InterruptedException e)
         {
-            logger.log(Level.FINE, e.toString(), e);
+            logger.log(Level.FINE, "Command execution interrupted", e);
             stopThread(outMonitorThread, outMonitor);
             stopThread(errMonitorThread, errMonitor);
             output[0] = "";
@@ -277,7 +277,7 @@ public class FileExecutor
         }
         catch (IOException e)
         {
-            logger.log(Level.WARNING, e.toString(), e);
+            logger.log(Level.FINE, "Command execution failed", e);
             output[0] = "";
             output[1] = e.getMessage() + "\n";
         }


### PR DESCRIPTION
If a dynamic variable has been successfully evaluated and received a value, but for some reason cannot be reevaluated, for example this one:

```
Mar 25, 2014 3:46:07 PM com.izforge.izpack.core.data.DynamicVariableImpl evaluate
FINE: Error evaluating dynamic variable 'previous.version.4': java.lang.Exception: Error opening jar file /home/rkrell/myapp/lib/server.jar
```

the variable should be rather unset than left on this value. This should just happen if failOnError="false" in case of evaluation failures of the "natural" kind in the above example.

A second usecase for this is the multiple definition of a dynamic variable with one and the same name, but bound to different conditions each time, for example:

``` xml
<dynamicvariables>
  <variable name="thechoice" value="choice1" condition="cond1">
  <variable name="thechoice" value="choice2" condition="cond2">
</dynamicvariables>
```

For this case, the dynamic variable thechoice should be unset if neither of both conditions, cond1 and cond2, is true, even if there is already a previous value, because a condition became true at an earlier time.

Furthermore, all IOExceptions occuring during dynamic variable evaluation should be logged on DEBUG level (FINE), not as WARN nor INFO, like this one during gathering a dynamic variable value from the output of a command execution:

```
Mar 25, 2014 3:56:46 PM WARNING: java.io.IOException: Cannot run program "/home/rkrell/jre/sun/1.6.0_21/bin/java": java.io.IOException: error=2, No such file or directory
```
