### PR TITLE
[IZPACK-1072] Unset dynamic variables if they cannot be validated any longer for some reason - post-fix

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/DynamicVariable.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/DynamicVariable.java
@@ -71,6 +71,9 @@ public interface DynamicVariable extends Serializable
     boolean isCheckonce();
     void setCheckonce(boolean checkonce);
 
+    boolean isChecked();
+    void setChecked();
+
     void setIgnoreFailure(boolean ignore);
 
     void addFilter(ValueFilter filter);

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -53,6 +53,7 @@ public class DynamicVariableImpl implements DynamicVariable
     private boolean ignorefailure = true;
 
     private transient String currentValue;
+    private transient boolean checked = false;
 
     public DynamicVariableImpl() {}
 
@@ -265,5 +266,16 @@ public class DynamicVariableImpl implements DynamicVariable
         // TODO: check if this always correct
         return name.hashCode() ^ conditionid.hashCode();
     }
+
+    @Override
+    public boolean isChecked()
+    {
+        return checked;
+    }
+
+    @Override
+    public void setChecked()
+    {
+        checked = true;    }
 
 }

--- a/izpack-event/src/main/java/com/izforge/izpack/event/ConfigurationInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ConfigurationInstallerListener.java
@@ -24,7 +24,6 @@ package com.izforge.izpack.event;
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1222,8 +1221,6 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
 
         if (dynamicvariables != null)
         {
-            Collection<DynamicVariable> removeDynamicVariables = new ArrayList<DynamicVariable>();
-
             logger.fine("Evaluating configuration variables");
             RulesEngine rules = getInstallData().getRules();
             for (DynamicVariable dynvar : dynamicvariables)
@@ -1254,20 +1251,20 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                 {
                     try
                     {
-                        String newValue = dynvar.evaluate(replacer);
-                        if (newValue != null)
+                        if (!(dynvar.isCheckonce() && dynvar.isChecked()))
                         {
-                            logger.fine("Configuration variable " + name + ": " + newValue);
-                            props.setProperty(name, newValue);
-                            if (dynvar.isCheckonce())
+                            String newValue = dynvar.evaluate(replacer);
+                            if (newValue != null)
                             {
-                                removeDynamicVariables.add(dynvar);
+                                logger.fine("Configuration variable " + name + ": " + newValue);
+                                props.setProperty(name, newValue);
+                            }
+                            else
+                            {
+                                logger.fine("Configuration variable " + name + " unchanged: " + dynvar.getValue());
                             }
                         }
-                        else
-                        {
-                            logger.fine("Configuration variable " + name + " unchanged: " + dynvar.getValue());
-                        }
+                        dynvar.setChecked();
                     }
                     catch (Exception e)
                     {
@@ -1275,8 +1272,6 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     }
                 }
             }
-
-            dynamicvariables.removeAll(removeDynamicVariables);
         }
 
         return props;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
@@ -361,7 +361,6 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
      */
     protected boolean validateData()
     {
-        installData.refreshVariables();
         return isValid(validator, installData);
     }
 


### PR DESCRIPTION
After some extensive tests with more complex installers we found still implementation errors.
Looks fine for us now.
Added also a unit test for the changes.
