### PR TITLE
Fixed build failure - izpack-dist couldn't find izpack-maven-plugin in reactor

### DIFF
--- a/izpack-dist/pom.xml
+++ b/izpack-dist/pom.xml
@@ -118,7 +118,6 @@
             <plugin>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>izpack-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <configuration>
                     <comprLevel>9</comprLevel>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,11 @@
                 <groupId>${project.groupId}</groupId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <artifactId>izpack-maven-plugin</artifactId>
+                <groupId>${project.groupId}</groupId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- Inner dependencies to test jar -->
             <dependency>


### PR DESCRIPTION
Fixed build failure - the artifact izpack-maven-plugin haven't been necessarily from reactor for module izpack-dist, but had to be installed by Maven before.

This came up mainly after releasing, when the version had been switched to the next snapshot.
