### PR TITLE
Izpack 980

### DIFF
--- a/izpack-dist/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-dist/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -381,7 +381,7 @@
     <!--                                                                                                        -->
     <xs:complexType name="packsType">
         <xs:sequence>
-            <xs:element name="pack" type="packType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="pack" type="packType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="refpack" type="refpackType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="refpackset" type="refpackSetType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>


### PR DESCRIPTION
Adding the missing XSD definitions for IZPACK-980.

But In my humble opinion the real cause of the message
Caused by: com.izforge.izpack.api.exception.CompilerException: /home/rkrell/IzPack_Installer/trunk/src/main/izpack/install.xml:6: this is not an IzPack XML installation file
is not the missing XSD definition. <refpack> and <refpackset> do already work in 5.0.0-rc2!
It is important, that the included files do not use a namespace(?) izpack:
This does not work:
<izpack:installation version="5.0"
                     xmlns:izpack="http://izpack.org/schema/installation"
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
But this does work:
<installation version="5.0"
                     xmlns:izpack="http://izpack.org/schema/installation"
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema
