### PR TITLE
[IZPACK-1084] IzPack should leave compiler version in MANIFEST of installer and uninstaller jar (2nd part - added Git revision to manifest)

### DIFF
--- a/izpack-compiler/src/main/resources/META-INF/MANIFEST.MF
+++ b/izpack-compiler/src/main/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Created-By: ${project.version} (IzPack)
+Created-By: ${project.version}-${buildNumber} (IzPack)
 Main-Class: com.izforge.izpack.compiler.Compiler

--- a/izpack-compiler/src/main/resources/com/izforge/izpack/compiler/packager/impl/MANIFEST.MF
+++ b/izpack-compiler/src/main/resources/com/izforge/izpack/compiler/packager/impl/MANIFEST.MF
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 Built-By: IzPack
-Created-By: ${project.version} (IzPack)
+Created-By: ${project.version}-${buildNumber} (IzPack)
 Main-Class: com.izforge.izpack.installer.bootstrap.Installer

--- a/izpack-uninstaller/pom.xml
+++ b/izpack-uninstaller/pom.xml
@@ -43,4 +43,13 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/izpack-uninstaller/src/main/resources/uninstaller-META-INF/MANIFEST.MF
+++ b/izpack-uninstaller/src/main/resources/uninstaller-META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Created-By: ${project.version} (IzPack)
+Created-By: ${project.version}-${buildNumber} (IzPack)
 Main-Class: com.izforge.izpack.uninstaller.Uninstaller

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,25 @@
                 </executions>
             </plugin>
             <plugin>
+               <groupId>org.codehaus.mojo</groupId>
+               <artifactId>buildnumber-maven-plugin</artifactId>
+               <version>1.3</version>
+               <executions>
+                 <execution>
+                    <phase>initialize</phase>
+                    <goals>
+                      <goal>create</goal>
+                    </goals>
+                 </execution>
+               </executions>
+               <configuration>
+                  <docheck>false</docheck>
+                  <doupdate>false</doupdate>
+                  <shortrevisionlength>5</shortrevisionlength>
+                  <timestampFormat>{0, date, yyyy-MM-dd HH:mm:ss}</timestampFormat>
+               </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
@@ -416,6 +435,15 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                   <archive>
+                        <!-- will put the entries into META-INF/MANIFEST.MF file -->
+                        <manifestEntries>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                            <Implementation-Build>${buildNumber}</Implementation-Build>
+                        </manifestEntries>
+                   </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Now added the GIT revision to the buildNumber for better identifying snapshots
