### PR TITLE
[IZPACK-1093] SummaryPanel shows content of skipped and not relevant panels

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
@@ -70,6 +70,11 @@ public class Panel implements Serializable
     private List<Action> actions;
 
     /**
+     * Whether the panel has been visited for summarizing the installation story
+     */
+    private transient boolean visited = false;
+
+    /**
      * list of all pre panel construction actions
      */
     private List<PanelActionConfiguration> preConstructionActions = null;
@@ -309,5 +314,22 @@ public class Panel implements Serializable
                 ", validator='" + validator + '\'' +
                 ", helps=" + helps +
                 '}';
+    }
+
+    /**
+     * @return Whether the panel has been visited for summarizing the installation story
+     */
+    public boolean isVisited()
+    {
+        return visited;
+    }
+
+    /**
+     * Mark panel visited for summarizing the installation story
+     * @param visited
+     */
+    public void setVisited(boolean visited)
+    {
+        this.visited = visited;
     }
 }

--- a/izpack-api/src/main/java/com/izforge/izpack/api/rules/RulesEngine.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/rules/RulesEngine.java
@@ -42,7 +42,9 @@ public interface RulesEngine
 
     boolean isConditionTrue(Condition cond);
 
-    boolean canShowPanel(String panelid, Variables variables);
+    boolean canShowPanel(String panelId, Variables variables);
+
+    void addPanelCondition(String panelId, Condition newCondition);
 
     boolean canInstallPack(String packid, Variables variables);
 

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -361,18 +361,41 @@ public class RulesEngineImpl implements RulesEngine
      *         condition was not met
      */
     @Override
-    public boolean canShowPanel(String panelid, Variables variables)
+    public boolean canShowPanel(String panelId, Variables variables)
     {
-        if (!this.panelConditions.containsKey(panelid))
+        if (!this.panelConditions.containsKey(panelId))
         {
-            logger.fine("Panel " + panelid + " unconditionally activated");
+            logger.fine("Panel " + panelId + " unconditionally activated");
             return true;
         }
-        Condition condition = getCondition(this.panelConditions.get(panelid));
+        Condition condition = getCondition(this.panelConditions.get(panelId));
         boolean b = condition.isTrue();
-        logger.fine("Panel " + panelid + ": activation depends on condition "
+        logger.fine("Panel " + panelId + ": activation depends on condition "
                             + condition.getId() + " -> " + b);
         return b;
+    }
+
+    @Override
+    public void addPanelCondition(String panelId, Condition newCondition)
+    {
+        Condition panelCond = null;
+        String panelCondString = this.panelConditions.get(panelId);
+        if (panelCondString != null)
+        {
+            panelCond = getCondition(this.panelConditions.get(panelId));
+        }
+
+        if (panelCond != null)
+        {
+            AndCondition andCondition = new AndCondition(this);
+            andCondition.setId(andCondition.toString());
+            andCondition.addOperands(newCondition);
+            andCondition.addOperands(panelCond);
+            newCondition = andCondition;
+        }
+
+        addCondition(newCondition);
+        this.panelConditions.put(panelId, newCondition.getId());
     }
 
     /**

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanels.java
@@ -24,7 +24,6 @@ package com.izforge.izpack.installer.panel;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.izforge.izpack.api.data.Panel;
@@ -403,20 +402,30 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
     protected boolean switchPanel(int newIndex)
     {
         boolean result;
-        if (logger.isLoggable(Level.FINE))
-        {
-            logger.fine("Selecting panel=" + newIndex + ", old index=" + index);
-        }
 
         // refresh variables prior to switching panels
         variables.refresh();
 
-        T oldPanel = getPanelView(index);
-        T newPanel = getPanelView(newIndex);
+        T oldPanelView = getPanelView(index);
+        T newPanelView = getPanelView(newIndex);
         int oldIndex = index;
         index = newIndex;
-        if (switchPanel(newPanel, oldPanel))
+        if (switchPanel(newPanelView, oldPanelView))
         {
+
+            if (oldIndex > newIndex)
+            {
+                  // Switches back in a sorted list of panels
+                  // -> set unvisited all panels in order after this one to always keep history information up to date
+                  // -> important for summary panel and generation of auto-install.xml
+                  for (int i = index + 1; i < panelViews.size(); i++)
+                  {
+                      T futurePanelView = panelViews.get(i);
+                      futurePanelView.getPanel().setVisited(false);
+                  }
+            }
+            newPanelView.getPanel().setVisited(true);
+            logger.fine("Switched panel index: " + oldIndex + " -> " + index);
             result = true;
         }
         else
@@ -424,6 +433,7 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
             index = oldIndex;
             result = false;
         }
+
         return result;
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/util/SummaryProcessor.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/util/SummaryProcessor.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2005 Klaus Bartz
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ package com.izforge.izpack.installer.util;
 
 import com.izforge.izpack.api.installer.ISummarisable;
 import com.izforge.izpack.installer.data.GUIInstallData;
+import com.izforge.izpack.installer.gui.IzPanel;
 
 /**
  * A helper class which creates a summary from all panels. This class calls all declared panels for
@@ -73,18 +74,20 @@ public class SummaryProcessor
         buffer.append(HTML_HEADER);
         for (ISummarisable panel : idata.getPanels())
         {
-            String caption = panel.getSummaryCaption();
-            String msg = panel.getSummaryBody();
-            // If no caption or/and message, ignore it.
-            if (caption == null || msg == null)
+            if (((IzPanel) panel).getMetadata().isVisited())
             {
-                continue;
+                String caption = panel.getSummaryCaption();
+                String msg = panel.getSummaryBody();
+                // If no caption or/and message, ignore it.
+                if (caption == null || msg == null)
+                {
+                    continue;
+                }
+                buffer.append(HEAD_START).append(caption).append(HEAD_END);
+                buffer.append(BODY_START).append(msg).append(BODY_END);
             }
-            buffer.append(HEAD_START).append(caption).append(HEAD_END);
-            buffer.append(BODY_START).append(msg).append(BODY_END);
         }
         buffer.append(HTML_FOOTER);
         return (buffer.toString());
     }
-
 }


### PR DESCRIPTION
This solves the problem of showing contents of skipped panels the user has never visited or that have been deactivated during a sequence of Back, new choices and new panel conditions in SummaryPanel.
Panels are marked visited now if they have been visited, all following panels are marked unvisited, depending on how the are defined in the <panels> section.

In relation to this fix there has been also made a cleanup how createForPack, createForUnselectedPack and os constraints are handled for UserInputPanels. Switching a panel from within activatePanel() has not been a good idea and messed up the AbstractPanels handling.
