### PR TITLE
[IZPACK-1096] Allow panel validators to be conditional

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
@@ -63,9 +63,16 @@ public class Panel implements Serializable
     private String condition;
 
     /**
-     * The validator for this panel
+     * The list of validators for this panel
      */
-    private String validator = null;
+    private List<String> validators = new ArrayList<String>();
+
+    /**
+     * The map of validator conditions for this panel depending on the validator
+     * Condition whether the validator has to be asked for validation.
+     */
+    private Map<Integer, String> validatorConditionIds = new HashMap<Integer, String>();
+
 
     private List<Action> actions;
 
@@ -166,14 +173,40 @@ public class Panel implements Serializable
         return this.condition != null;
     }
 
-    public String getValidator()
+    /**
+     * Get validator and validator condition entries for this panel
+     * @return Returns a list of validator class names and optional conditions defining
+     *  whether the panel validator should be asked at all.
+     */
+    public List<String> getValidators()
     {
-        return validator;
+        return validators;
     }
 
-    public void setValidator(String validator)
+    /**
+     * Gets a validator condition
+     * @param index
+     * @return the validator condition of a validator at the given index for this panel
+     */
+    public String getValidatorCondition(int index)
     {
-        this.validator = validator;
+        return this.validatorConditionIds.get(Integer.valueOf(index));
+    }
+
+    /**
+     * Adds a panel validator and a condition defining whether the panel validator should be asked at all.
+     * @param validatorClassName
+     * @param validatorConditionId the validator condition for this panel (set null for no condition)
+     */
+    public void addValidator(String validatorClassName, String validatorConditionId)
+    {
+        this.validators.add(validatorClassName);
+        if (validatorConditionId != null)
+        {
+            // There must be used the index in the ordered list of validators as key, because the validator
+            // has no own ID and its classname might not be unique.
+            this.validatorConditionIds.put(Integer.valueOf(validators.size()-1), validatorConditionId);
+        }
     }
 
     public List<Help> getHelps()
@@ -311,7 +344,7 @@ public class Panel implements Serializable
                 ", panelid='" + getPanelId() + '\'' +
                 ", condition='" + condition + '\'' +
                 ", actions=" + actions +
-                ", validator='" + validator + '\'' +
+                ", validator count='" + validators.size() + '\'' +
                 ", helps=" + helps +
                 '}';
     }

--- a/izpack-api/src/main/java/com/izforge/izpack/api/installer/DataValidator.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/installer/DataValidator.java
@@ -76,7 +76,12 @@ public interface DataValidator
     /**
      * attribute for class to use
      */
-    public static final String DATA_VALIDATOR_CLASSNAME_TAG = "classname";
+    public static final String DATA_VALIDATOR_CLASSNAME_ATTR = "classname";
+
+    /**
+     * attribute for validator condition to apply
+     */
+    public static final String DATA_VALIDATOR_CONDITION_ATTR = "condition";
 
     /**
      * Method to validate an {@link InstallData}.

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1375,8 +1375,8 @@ public class CompilerConfig extends Thread
 
         // Now checked the loaded XML file for basic syntax
         // We check it
-        if (! (  "izpack:installation".equalsIgnoreCase(refXMLData.getName())  // normally with the namespace prefix 
-        	  || "installation".equalsIgnoreCase(refXMLData.getName())))       // optional without
+        if (! (  "izpack:installation".equalsIgnoreCase(refXMLData.getName())  // normally with the namespace prefix
+            || "installation".equalsIgnoreCase(refXMLData.getName())))       // optional without
         {
             assertionHelper.parseError(refXMLData, "this is not an IzPack XML installation file");
         }
@@ -1545,14 +1545,15 @@ public class CompilerConfig extends Thread
             }
 
             // adding validator
-            IXMLElement validatorElement = panelElement.getFirstChildNamed(DataValidator.DATA_VALIDATOR_TAG);
-            if (validatorElement != null)
+            List<IXMLElement> validatorElements = panelElement.getChildrenNamed(DataValidator.DATA_VALIDATOR_TAG);
+            for (IXMLElement validatorElement : validatorElements)
             {
-                String validator = validatorElement.getAttribute(DataValidator.DATA_VALIDATOR_CLASSNAME_TAG);
+                String validator = validatorElement.getAttribute(DataValidator.DATA_VALIDATOR_CLASSNAME_ATTR);
                 if (!"".equals(validator))
                 {
+                    String validatorCondition = validatorElement.getAttribute(DataValidator.DATA_VALIDATOR_CONDITION_ATTR);
                     Class<DataValidator> validatorType = classLoader.loadClass(validator, DataValidator.class);
-                    panel.setValidator(validatorType.getName());
+                    panel.addValidator(validatorType.getName(), validatorCondition);
                 }
             }
             // adding helps

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
@@ -21,8 +21,6 @@
 
 package com.izforge.izpack.installer.panel;
 
-import static com.izforge.izpack.data.PanelAction.ActionStage;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -36,7 +34,9 @@ import com.izforge.izpack.api.factory.ObjectFactory;
 import com.izforge.izpack.api.handler.AbstractUIHandler;
 import com.izforge.izpack.api.installer.DataValidator;
 import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.data.PanelAction;
+import com.izforge.izpack.data.PanelAction.ActionStage;
 
 
 /**
@@ -78,9 +78,9 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
     private boolean visible = true;
 
     /**
-     * The data validator. May be {@code null}.
+     * Ordered list of panel data validators
      */
-    private DataValidator validator;
+    private List<DataValidator> validators = new ArrayList<DataValidator>();
 
     /**
      * The installation data.
@@ -187,10 +187,11 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
         {
             executePreConstructionActions();
             view = createView(panel, viewClass);
-            String dataValidator = panel.getValidator();
-            if (dataValidator != null)
+
+            List<String> dataValidatorClassNames = panel.getValidators();
+            for (String dataValidatorClassName : dataValidatorClassNames)
             {
-                validator = factory.create(dataValidator, DataValidator.class, panel, view);
+                validators.add(factory.create(dataValidatorClassName, DataValidator.class, panel, view));
             }
 
             addActions(panel.getPreActivationActions(), preActivationActions, ActionStage.preactivate);
@@ -239,7 +240,7 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
         List<DynamicInstallerRequirementValidator> conditions = installData.getDynamicInstallerRequirements();
         if (conditions == null || validateDynamicConditions())
         {
-            result = validator == null || validateData();
+            result = validators.size() == 0 || validateData();
         }
 
         executePostValidationActions();
@@ -347,7 +348,7 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
         }
         catch (Throwable exception)
         {
-            logger.log(Level.WARNING, "Could not validate dynamic conditions", exception);
+            logger.log(Level.WARNING, "Panel " + getPanelId() + ": Could not validate dynamic conditions", exception);
             result = false;
         }
         return result;
@@ -361,6 +362,45 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
      */
     protected boolean validateData()
     {
+        boolean result = true;
+        DataValidator[] validatorArray = validators.toArray(new DataValidator[] {});
+        for (int i = 0; i < validatorArray.length; i++)
+        {
+            DataValidator validator = validatorArray[i];
+            if (!isValid(validator, i, installData))
+            {
+                result = false;
+                break;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Evaluates a validator.
+     * <p/>
+     * If the validator returns a warning status, then a prompt will be displayed asking the user to skip the
+     * validation or not.
+     *
+     * @param validator   the validator to evaluate
+     * @param index   the index in the list of validators for finding its appropriate validator condition
+     * @param installData the installation data
+     * @return {@code true} if the validator evaluated successfully, or with a warning that the user chose to skip;
+     *         otherwise {@code false}
+     */
+    private boolean isValid(DataValidator validator, Integer index, InstallData installData)
+    {
+        String dataValidatorConditionId = panel.getValidatorCondition(index);
+        if (dataValidatorConditionId != null)
+        {
+            Condition dataValidatorCondition = installData.getRules().getCondition(dataValidatorConditionId);
+            if (!dataValidatorCondition.isTrue())
+            {
+                // Skip panel validation
+                logger.fine("Panel " + getPanelId() + ": Skip validation (" + validator.getClass().getName() +")");
+                return true;
+            }
+        }
         return isValid(validator, installData);
     }
 
@@ -371,6 +411,7 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
      * validation or not.
      *
      * @param validator   the validator to evaluate
+     * @param index   the index in the list of validators for finding its appropriate validator condition
      * @param installData the installation data
      * @return {@code true} if the validator evaluated successfully, or with a warning that the user chose to skip;
      *         otherwise {@code false}
@@ -378,8 +419,9 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
     private boolean isValid(DataValidator validator, InstallData installData)
     {
         boolean result = false;
+
         DataValidator.Status status = validator.validateData(installData);
-        logger.fine("Data validation status=" + status + ", for validator=" + validator.getClass().getName());
+        logger.fine("Panel " + getPanelId() + ": Data validation status=" + status + " (" + validator.getClass().getName() + ")");
 
         if (status == DataValidator.Status.OK)
         {
@@ -392,7 +434,7 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
                 String message = getMessage(validator.getWarningMessageId(), true);
                 if (message == null)
                 {
-                    logger.warning("No warning message for validator=" + validator.getClass().getName());
+                    logger.warning("Panel " + getPanelId() + ": No warning message for validator " + validator.getClass().getName());
                 }
                 result = isWarningValid(message, validator.getDefaultAnswer());
             }
@@ -401,7 +443,7 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
                 String message = getMessage(validator.getErrorMessageId(), true);
                 if (message == null)
                 {
-                    logger.warning("No error message for validator=" + validator.getClass().getName());
+                    logger.warning("Panel " + getPanelId() + ": No error message for validator " + validator.getClass().getName());
                     message = "Validation error";
                 }
                 getHandler().emitError(getMessage("data.validation.error.title"), message);
@@ -425,12 +467,12 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
             if (getHandler().emitWarning(getMessage("data.validation.warning.title"), message))
             {
                 result = true;
-                logger.fine("User decided to skip validation warning");
+                logger.fine("Panel " + getPanelId() + ": User decided to skip validation warning");
             }
         }
         else
         {
-            logger.fine("No warning message available, using default answer=" + defaultAnswer);
+            logger.fine("Panel " + getPanelId() + ": No warning message available, using default answer=" + defaultAnswer);
             result = defaultAnswer;
         }
         return result;

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/datavalidator/DataValidatorTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/datavalidator/DataValidatorTest.java
@@ -163,13 +163,13 @@ public class DataValidatorTest
 
         // verify that all class names are fully qualified
         assertEquals(HelloPanel.class.getName(), hello.getClassName());
-        assertEquals(TestDataValidator.class.getName(), hello.getValidator());
+        assertEquals(TestDataValidator.class.getName(), hello.getValidators().iterator().next());
 
         assertEquals(InstallPanel.class.getName(), install.getClassName());
-        assertEquals(TestDataValidator.class.getName(), install.getValidator());
+        assertEquals(TestDataValidator.class.getName(), install.getValidators().iterator().next());
 
         assertEquals(SimpleFinishPanel.class.getName(), finish.getClassName());
-        assertEquals(TestDataValidator.class.getName(), finish.getValidator());
+        assertEquals(TestDataValidator.class.getName(), finish.getValidators().iterator().next());
 
         frameFixture = HelperTestMethod.prepareFrameFixture(frame, controller);
 

--- a/izpack-test/src/test/resources/samples/datavalidators.xml
+++ b/izpack-test/src/test/resources/samples/datavalidators.xml
@@ -13,9 +13,14 @@
         <langpack iso3="eng"/>
     </locale>
 
+    <condition type="variable" id="isCorrectVersion">
+      <name>APP_VER</name>
+      <value>1.4 beta 666</value>
+    </condition>
+
     <panels>
         <panel classname="HelloPanel" id="HelloPanel">
-            <validator classname="com.izforge.izpack.integration.datavalidator.TestDataValidator"/>
+            <validator classname="com.izforge.izpack.integration.datavalidator.TestDataValidator" condition="isCorrectVersion"/>
         </panel>
         <panel classname="InstallPanel" id="InstallPanel">
             <validator classname="com.izforge.izpack.integration.datavalidator.TestDataValidator"/>


### PR DESCRIPTION
Add conditional validation to izpack panels.
Also allow to have more than one panel validators. Currently there can be more than one defined, but during compilation just one of them "wins" and the other validators are silently ignored by the compiler parser, which is bad.

Example:

``` xml
<condition type="variable" id="Install">
    <name>installAction</name>
    <value>install</value>
</condition>
<condition type="variable" id="Update">
    <name>installAction</name>
    <value>update</value>
</condition>
<condition type="variable" id="Uninstall">
    <name>installAction</name>
    <value>remove</value>
</condition>

<panel classname="UserInputPanel" id="panel.example">
    <validator classname="com.mycompany.MyValidator1" condition="Install" />
    <validator classname="com.mycompany.MyValidator2" condition="Update" />
    <validator classname="com.mycompany.MyValidator3" condition="Uninstall" />
</panel>
```
