### PR TITLE
[IZPACK-1093] SummaryPanel shows content of skipped and not relevant panels

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/rules/RulesEngine.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/rules/RulesEngine.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.data.Variables;
 
 /**
@@ -44,7 +45,7 @@ public interface RulesEngine
 
     boolean canShowPanel(String panelId, Variables variables);
 
-    void addPanelCondition(String panelId, Condition newCondition);
+    void addPanelCondition(Panel panel, Condition newCondition);
 
     boolean canInstallPack(String packid, Variables variables);
 

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -36,6 +36,7 @@ import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.adaptator.impl.XMLWriter;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Pack;
+import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.rules.Condition;
@@ -376,25 +377,21 @@ public class RulesEngineImpl implements RulesEngine
     }
 
     @Override
-    public void addPanelCondition(String panelId, Condition newCondition)
+    public void addPanelCondition(Panel panel, Condition newCondition)
     {
-        Condition panelCond = null;
-        String panelCondString = this.panelConditions.get(panelId);
+        String panelId = panel.getPanelId();
+        String panelCondString = panel.getCondition();
         if (panelCondString != null)
-        {
-            panelCond = getCondition(this.panelConditions.get(panelId));
-        }
-
-        if (panelCond != null)
         {
             AndCondition andCondition = new AndCondition(this);
             andCondition.setId(andCondition.toString());
             andCondition.addOperands(newCondition);
-            andCondition.addOperands(panelCond);
+            andCondition.addOperands(getCondition(panelCondString));
             newCondition = andCondition;
         }
 
         addCondition(newCondition);
+        panel.setCondition(newCondition.getId());
         this.panelConditions.put(panelId, newCondition.getId());
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -141,7 +141,7 @@ public class UserInputPanel extends IzPanel
         Condition globalConstraint = reader.getComplexPanelCondition(spec, matcher, installData, rules);
         if (globalConstraint != null)
         {
-            rules.addPanelCondition(panel.getPanelId(), globalConstraint);
+            rules.addPanelCondition(panel, globalConstraint);
         }
     }
 


### PR DESCRIPTION
Post-fix: panel condition did override createForPack constraint.

When an explicit <panel condition="..."/> has been evaluated true, but a createForPack constraint did not allow the UserInputPanel to be activated. In this case it has been shown anyway.
