### PR TITLE
[IZPACK-1099] Refactor automated installations as it is (for Swing installers, but more universal)

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/AutomatedInstallData.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/AutomatedInstallData.java
@@ -26,7 +26,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.event.InstallerListener;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.api.rules.RulesEngine;
@@ -170,7 +169,6 @@ public class AutomatedInstallData implements InstallData
         setAvailablePacks(new ArrayList<Pack>());
         setSelectedPacks(new ArrayList<Pack>());
         setPanelsOrder(new ArrayList<Panel>());
-        setXmlData(new XMLElementImpl("AutomatedInstallation"));
         setAttributes(new HashMap<String, Object>());
     }
 
@@ -339,7 +337,7 @@ public class AutomatedInstallData implements InstallData
     public void setAndProcessLocal(String locale, LocaleDatabase localeDatabase)
     {
         // We add an xml data information
-        getXmlData().setAttribute("langpack", locale);
+        getInstallationRecord().setAttribute("langpack", locale);
         // We load the langpack
         setVariable(ScriptParserConstant.ISO3_LANG, getLocaleISO3());
         setVariable(ScriptParserConstant.ISO2_LANG, getLocaleISO3());
@@ -363,7 +361,7 @@ public class AutomatedInstallData implements InstallData
     {
         return getVariable(ScriptParserConstant.ISO3_LANG);
     }
-    
+
     @Override
     public String getLocaleISO2()
     {
@@ -394,9 +392,9 @@ public class AutomatedInstallData implements InstallData
     public void setLocale(Locale locale, String code)
     {
         this.locale = locale;
-        getXmlData().setAttribute("langpack", code.toLowerCase());
+        getInstallationRecord().setAttribute("langpack", code.toLowerCase());
         setVariable(ScriptParserConstant.ISO3_LANG, code.toLowerCase());
-        if(locale != null) 
+        if(locale != null)
         {
             setVariable(ScriptParserConstant.ISO2_LANG, locale.getLanguage());
         }
@@ -562,12 +560,12 @@ public class AutomatedInstallData implements InstallData
     }
 
     @Override
-    public IXMLElement getXmlData()
+    public IXMLElement getInstallationRecord()
     {
         return xmlData;
     }
 
-    public void setXmlData(IXMLElement xmlData)
+    public void setInstallationRecord(IXMLElement xmlData)
     {
         this.xmlData = xmlData;
     }

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/InstallData.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/InstallData.java
@@ -265,7 +265,7 @@ public interface InstallData
      *
      * @return the XML data
      */
-    IXMLElement getXmlData();
+    IXMLElement getInstallationRecord();
 
     /**
      * Returns the installer requirements.

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
@@ -128,10 +128,6 @@ public class Panel implements Serializable
 
     public String getPanelId()
     {
-        if (panelId == null)
-        {
-            return "UNKNOWN (" + className + ")";
-        }
         return panelId;
     }
 

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -92,6 +92,7 @@ import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.compiler.data.CompilerData;
 import com.izforge.izpack.compiler.data.PropertyManager;
 import com.izforge.izpack.compiler.helper.AssertionHelper;
+import com.izforge.izpack.compiler.helper.CompilerHelper;
 import com.izforge.izpack.compiler.helper.TargetFileSet;
 import com.izforge.izpack.compiler.helper.XmlCompilerHelper;
 import com.izforge.izpack.compiler.listener.CompilerListener;
@@ -1508,7 +1509,12 @@ public class CompilerConfig extends Thread
 
             // add an id
             String id = panelElement.getAttribute("id");
+            if (id == null)
+            {
+                id = className + "_" + Integer.valueOf(panelCounter - 1);
+            }
             panel.setPanelId(id);
+
             String condition = panelElement.getAttribute("condition");
             panel.setCondition(condition);
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedPanelView.java
@@ -21,6 +21,7 @@
 
 package com.izforge.izpack.installer.automation;
 
+import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.exception.IzPackException;
@@ -117,5 +118,11 @@ public class AutomatedPanelView extends AbstractPanelView<PanelAutomation>
             handler.emitError(getMessage("data.validation.error.title"), message);
         }
         return defaultAnswer;
+    }
+
+    @Override
+    public void createInstallationRecord(IXMLElement panelRoot)
+    {
+        // TODO Auto-generated method stub
     }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/PanelAutomation.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/PanelAutomation.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
  *
  * Copyright 2003 Jonathan Halliday
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,13 +40,12 @@ public interface PanelAutomation
 {
 
     /**
-     * Asks the panel to set its own XML data that can be brought back for an automated installation
-     * process. Use it as a blackbox if your panel needs to do something even in automated mode.
+     * Creates an installation record for unattended installations and adds it to a XML root element.
      *
      * @param installData The installation data
-     * @param panelRoot   The XML root element of the panels blackbox tree.
+     * @param rootElement The root element to add panel-specific child elements to
      */
-    public void makeXMLData(InstallData installData, IXMLElement panelRoot);
+    void createInstallationRecord(InstallData installData, IXMLElement rootElement);
 
     /**
      * Makes the panel work in automated mode. Default is to do nothing, but any panel doing
@@ -57,5 +56,5 @@ public interface PanelAutomation
      * @throws com.izforge.izpack.api.exception.InstallerException
      *          if the automated work  failed critically.
      */
-    public void runAutomated(InstallData installData, IXMLElement panelRoot) throws InstallerException;
+    void runAutomated(InstallData installData, IXMLElement panelRoot) throws InstallerException;
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanelView.java
@@ -21,6 +21,7 @@
 
 package com.izforge.izpack.installer.console;
 
+import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.exception.IzPackException;
@@ -113,4 +114,9 @@ public class ConsolePanelView extends AbstractPanelView<ConsolePanel>
         };
     }
 
+    @Override
+    public void createInstallationRecord(IXMLElement panelRoot)
+    {
+        // TODO Auto-generated method stub
+    }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanels.java
@@ -23,6 +23,7 @@ package com.izforge.izpack.installer.console;
 
 import java.util.List;
 
+import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.installer.panel.AbstractPanels;
 import com.izforge.izpack.installer.panel.Panels;
@@ -48,9 +49,9 @@ public class ConsolePanels extends AbstractPanels<ConsolePanelView, ConsolePanel
      * @param panels    the panels
      * @param variables the variables. These are refreshed prior to each panel switch
      */
-    public ConsolePanels(List<ConsolePanelView> panels, Variables variables)
+    public ConsolePanels(List<ConsolePanelView> panels, InstallData installData)
     {
-        super(panels, variables);
+        super(panels, installData);
     }
 
     /**

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 
 import org.picocontainer.injectors.Provider;
 
+import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.DynamicInstallerRequirementValidator;
 import com.izforge.izpack.api.data.DynamicVariable;
@@ -413,6 +414,7 @@ public abstract class AbstractInstallDataProvider implements Provider
         Locale locale = locales.getLocale();
         if (locale != null)
         {
+            installData.setInstallationRecord(new XMLElementImpl("AutomatedInstallation"));
             installData.setLocale(locale, locales.getISOCode());
             installData.setMessages(locales.getMessages());
         }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/ConsolePanelsProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/ConsolePanelsProvider.java
@@ -63,7 +63,7 @@ public class ConsolePanelsProvider extends PanelsProvider
             ConsolePanelView panelView = new ConsolePanelView(panel, factory, installData, console);
             panels.add(panelView);
         }
-        return new ConsolePanels(panels, installData.getVariables());
+        return new ConsolePanels(panels, installData);
     }
 
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/PanelsProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/PanelsProvider.java
@@ -28,8 +28,6 @@ import java.util.Set;
 
 import org.picocontainer.injectors.Provider;
 
-import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.exception.IzPackException;
@@ -48,7 +46,6 @@ public abstract class PanelsProvider implements Provider
     /**
      * Prepares panels for the current platform.
      * <br/>
-     * This adds XML to the {@link InstallData#getXmlData() XML data} for each panel.
      *
      * @param installData the installation data
      * @param matcher     The platform-model matcher
@@ -70,28 +67,10 @@ public abstract class PanelsProvider implements Provider
                     throw new IzPackException("Duplicate panel: " + key);
                 }
 
-                addPanelXml(panel, installData);
 
                 result.add(panel);
             }
         }
         return result;
-    }
-
-    /**
-     * Adds XML to the {@link InstallData#getXmlData() XML data} for the supplied panel.
-     *
-     * @param panel       the panel
-     * @param installData the installation data
-     */
-    protected void addPanelXml(Panel panel, InstallData installData)
-    {
-        IXMLElement panelRoot = new XMLElementImpl(panel.getClassName(), installData.getXmlData());
-        String panelId = panel.getPanelId();
-        if (panelId != null)
-        {
-            panelRoot.setAttribute("id", panelId);
-        }
-        installData.getXmlData().addChild(panelRoot);
     }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -41,7 +41,6 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseMotionAdapter;
 import java.io.File;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -64,9 +63,6 @@ import javax.swing.WindowConstants;
 import javax.swing.border.TitledBorder;
 import javax.swing.text.JTextComponent;
 
-import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.adaptator.IXMLWriter;
-import com.izforge.izpack.api.adaptator.impl.XMLWriter;
 import com.izforge.izpack.api.data.Info;
 import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.data.Panel;
@@ -722,29 +718,16 @@ public class InstallerFrame extends JFrame implements InstallerView
     }
 
     /**
-     * Writes an XML tree.
+     * Writes the installation record to a file.
      *
-     * @param root The XML tree to write out.
-     * @param out  The stream to write on.
+     * @param out  The file to write to.
      * @throws Exception Description of the Exception
      */
-    public void writeXMLTree(IXMLElement root, OutputStream out) throws Exception
+    public void writeInstallationRecord(File file) throws Exception
     {
-        IXMLWriter writer = new XMLWriter(out);
-        // fix bug# 4551
-        // write.write(root);
-        for (int i = 0; i < installdata.getPanels().size(); i++)
-        {
-            IzPanel panel = installdata.getPanels().get(i);
-            if (!rules.canShowPanel(panel.getMetadata().getPanelId(), variables) ||
-            		(panel.getMetadata().hasCondition() && !rules.isConditionTrue(panel.getMetadata().getCondition(), installdata))) {
-            	continue;
-            }
-            panel.makeXMLData(installdata.getXmlData().getChildAtIndex(i));
-        }
-        writer.write(root);
-
+        panels.writeInstallationRecord(file);
     }
+
 
     /**
      * Changes the quit button text. If <tt>text</tt> is null, the default quit text is used.

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
@@ -68,7 +68,7 @@ import com.izforge.izpack.installer.data.GUIInstallData;
  * @author Julien Ponge
  * @author Klaus Bartz
  */
-public class IzPanel extends JPanel implements AbstractUIHandler, LayoutConstants, ISummarisable
+public abstract class IzPanel extends JPanel implements AbstractUIHandler, LayoutConstants, ISummarisable
 {
     private static final long serialVersionUID = 3256442495255786038L;
 
@@ -317,15 +317,10 @@ public class IzPanel extends JPanel implements AbstractUIHandler, LayoutConstant
     {
     }
 
-    /**
-     * Asks the panel to set its own XML data that can be brought back for an automated installation
-     * process. Use it as a blackbox if your panel needs to do something even in automated mode.
-     *
-     * @param panelRoot The XML root element of the panels blackbox tree.
-     */
-    public void makeXMLData(IXMLElement panelRoot)
+    public void createInstallationRecord(IXMLElement rootElement)
     {
-    }
+        // Default method, override to record panel contents
+    };
 
     /**
      * Ask the user a question.

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanelView.java
@@ -24,6 +24,7 @@ package com.izforge.izpack.installer.gui;
 import java.awt.Component;
 import java.awt.Cursor;
 
+import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.factory.ObjectFactory;
@@ -132,5 +133,11 @@ public class IzPanelView extends AbstractPanelView<IzPanel>
         {
             component.setCursor(current);
         }
+    }
+
+    @Override
+    public void createInstallationRecord(IXMLElement panelRoot)
+    {
+        getView().createInstallationRecord(panelRoot);
     }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanels.java
@@ -64,7 +64,7 @@ public class IzPanels extends AbstractPanels<IzPanelView, IzPanel>
      */
     public IzPanels(List<IzPanelView> panels, Container container, GUIInstallData installData)
     {
-        super(panels, installData.getVariables());
+        super(panels, installData);
         this.container = container;
         this.installData = installData;
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.data.DynamicInstallerRequirementValidator;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
@@ -577,6 +579,23 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
             }
         }
         return message;
+    }
+
+    /**
+     * Creates an empty root element prepared for adding auto-installation records for this panel.
+     *
+     * @return IXMLElement The prepared panel record XML
+     */
+    protected final IXMLElement createPanelRootRecord()
+    {
+        IXMLElement panelRoot = new XMLElementImpl(panel.getClassName(), installData.getInstallationRecord());
+        panelRoot.setAttribute(AUTOINSTALL_PANELROOT_ATTR_INDEX, Integer.toString(getIndex()));
+        String panelId = panel.getPanelId();
+        if (panelId != null)
+        {
+            panelRoot.setAttribute(AUTOINSTALL_PANELROOT_ATTR_ID, panelId);
+        }
+        return panelRoot;
     }
 
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/PanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/PanelView.java
@@ -1,5 +1,6 @@
 package com.izforge.izpack.installer.panel;
 
+import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.DynamicInstallerRequirementValidator;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
@@ -12,6 +13,9 @@ import com.izforge.izpack.api.installer.DataValidator;
  */
 public interface PanelView<T>
 {
+    public static final String AUTOINSTALL_PANELROOT_ATTR_INDEX = "index";
+    public static final String AUTOINSTALL_PANELROOT_ATTR_ID = "id";
+
     /**
      * Returns the panel identifier.
      *
@@ -91,4 +95,12 @@ public interface PanelView<T>
      * @return {@code true} if the panel can be shown
      */
     boolean canShow();
+
+    /**
+     * Creates an installation record for unattended installations and adds it to a XML root element.
+     *
+     * @param rootElement the root to add child elements to
+     */
+    void createInstallationRecord(IXMLElement rootElement);
+
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/PanelViews.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/PanelViews.java
@@ -21,6 +21,7 @@
 
 package com.izforge.izpack.installer.panel;
 
+import java.io.File;
 import java.util.List;
 
 
@@ -60,5 +61,13 @@ public interface PanelViews<T extends AbstractPanelView<V>, V> extends Panels
      * @return the panel's visible index, or {@code -1} if the panel is not visible
      */
     int getVisibleIndex(T panel);
+
+    /**
+     * Writes an XML tree to a file.
+     *
+     * @param out  The file to write to.
+     * @throws Exception
+     */
+    void writeInstallationRecord(File file) throws Exception;
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/compile/CompilePanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/compile/CompilePanelAutomationHelper.java
@@ -1,18 +1,18 @@
 /*
  /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2003 Jonathan Halliday
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,8 +40,8 @@ import com.izforge.izpack.util.PlatformModelMatcher;
  * @author Jonathan Halliday
  * @author Tino Schwarze
  */
-public class CompilePanelAutomationHelper extends PanelAutomationHelper implements PanelAutomation,
-        CompileHandler
+public class CompilePanelAutomationHelper extends PanelAutomationHelper
+implements PanelAutomation, CompileHandler
 {
 
     private CompileWorker worker = null;
@@ -287,4 +287,7 @@ public class CompilePanelAutomationHelper extends PanelAutomationHelper implemen
     {
         // no-op
     }
+
+    @Override
+    public void createInstallationRecord(InstallData installData, IXMLElement rootElement) {}
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetPanel.java
@@ -63,6 +63,7 @@ public class DefaultTargetPanel extends PathInputPanel
     /**
      * Called when the panel becomes active.
      */
+    @Override
     public void panelActivate()
     {
         String path = TargetPanelHelper.getPath(installData);
@@ -75,27 +76,19 @@ public class DefaultTargetPanel extends PathInputPanel
      *
      * @return Whether the panel has been validated or not.
      */
+    @Override
     public boolean isValidated()
     {
         return (true);
     }
 
-    /**
-     * Asks to make the XML panel installDataGUI.
-     *
-     * @param panelRoot The tree to put the installDataGUI in.
-     */
-    public void makeXMLData(IXMLElement panelRoot)
+    @Override
+    public void createInstallationRecord(IXMLElement rootElement)
     {
-        defaultTargetPanelAutomationHelper.makeXMLData(this.installData, panelRoot);
+        defaultTargetPanelAutomationHelper.createInstallationRecord(this.installData, rootElement);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.izforge.izpack.installer.IzPanel#getSummaryBody()
-     */
-
+    @Override
     public String getSummaryBody()
     {
         return (this.installData.getInstallPath());

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetPanelAutomationHelper.java
@@ -34,14 +34,8 @@ import com.izforge.izpack.installer.automation.PanelAutomation;
  */
 public class DefaultTargetPanelAutomationHelper implements PanelAutomation
 {
-
-    /**
-     * Asks to make the XML panel installDataGUI.
-     *
-     * @param idata     The installation installDataGUI.
-     * @param panelRoot The tree to put the installDataGUI in.
-     */
-    public void makeXMLData(InstallData idata, IXMLElement panelRoot)
+    @Override
+    public void createInstallationRecord(InstallData idata, IXMLElement panelRoot)
     {
         // Installation path markup
         IXMLElement ipath = new XMLElementImpl("installpath", panelRoot);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishConsolePanel.java
@@ -51,7 +51,7 @@ import com.izforge.izpack.util.file.FileUtils;
 
 /**
  * Console implementation of the {@link FinishPanel}.
- * 
+ *
  * @author Mounir el hajj
  */
 public class FinishConsolePanel extends AbstractConsolePanel
@@ -62,10 +62,10 @@ public class FinishConsolePanel extends AbstractConsolePanel
     private final Prompt prompt;
     private final ObjectFactory factory;
     private final PlatformModelMatcher matcher;
-    
+
     /**
      * Constructs an {@code FinishConsolePanel}.
-     * 
+     *
      * @param panel the parent panel/view. May be {@code null}
      */
     public FinishConsolePanel(final ObjectFactory factory, final PlatformModelMatcher matcher,
@@ -84,7 +84,7 @@ public class FinishConsolePanel extends AbstractConsolePanel
 
     /**
      * Runs the panel using the supplied properties.
-     * 
+     *
      * @param installData the installation data
      * @param properties the properties
      * @return <tt>true</tt>
@@ -97,7 +97,7 @@ public class FinishConsolePanel extends AbstractConsolePanel
 
     /**
      * Runs the panel using the specified console.
-     * 
+     *
      * @param installData the installation data
      * @param console the console
      * @return <tt>true</tt>
@@ -184,7 +184,7 @@ public class FinishConsolePanel extends AbstractConsolePanel
             writer = new XMLWriter(outputStream);
 
             IXMLElement root;
-            root = installData.getXmlData();
+            root = installData.getInstallationRecord();
 
             AutomatedPanels automatedPanels;
             automatedPanels = getAutomatedPanels(installData);
@@ -230,7 +230,7 @@ public class FinishConsolePanel extends AbstractConsolePanel
     {
         try
         {
-            panelView.getView().makeXMLData(installData, root);
+            panelView.getView().createInstallationRecord(installData, root);
 
         }
         catch (Exception e)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishPanel.java
@@ -24,9 +24,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
@@ -90,14 +88,13 @@ public class FinishPanel extends IzPanel implements ActionListener
      *
      * @return true if the panel has been validated.
      */
+    @Override
     public boolean isValidated()
     {
         return true;
     }
 
-    /**
-     * Called when the panel becomes active.
-     */
+    @Override
     public void panelActivate()
     {
         parent.lockNextButton();
@@ -145,42 +142,32 @@ public class FinishPanel extends IzPanel implements ActionListener
         log.informUser();
     }
 
-    /**
-     * Actions-handling method.
-     *
-     * @param e The event.
-     */
+    @Override
     public void actionPerformed(ActionEvent e)
     {
         // Prepares the file chooser
         JFileChooser fileChooser = new JFileChooser();
         fileChooser.setName(GuiId.FINISH_PANEL_FILE_CHOOSER.id);
         fileChooser.setCurrentDirectory(new File(this.installData.getInstallPath()));
+        fileChooser.setSelectedFile(new File(this.installData.getInstallPath(), "auto-install.xml"));
         fileChooser.setMultiSelectionEnabled(false);
         fileChooser.addChoosableFileFilter(new AutomatedInstallScriptFilter(installData.getMessages()));
         // fileChooser.setCurrentDirectory(new File("."));
 
-        // Shows it
         try
         {
             if (fileChooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION)
             {
                 // We handle the xml installDataGUI writing
                 File file = fileChooser.getSelectedFile();
-                FileOutputStream out = new FileOutputStream(file);
-                BufferedOutputStream outBuff = new BufferedOutputStream(out, 5120);
-                parent.writeXMLTree(this.installData.getXmlData(), outBuff);
-                outBuff.flush();
-                outBuff.close();
-
+                parent.writeInstallationRecord(file);
                 autoButton.setEnabled(false);
             }
         }
         catch (Exception err)
         {
-            err.printStackTrace();
             JOptionPane.showMessageDialog(this, err.toString(), getString("installer.error"),
-                                          JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.ERROR_MESSAGE);
         }
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelAutomationHelper.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2003 Jonathan Halliday
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -55,16 +55,8 @@ public class InstallPanelAutomationHelper extends PanelAutomationHelper implemen
         unpacker.setProgressListener(this);
     }
 
-    /**
-     * Null op - this panel type has no state to serialize.
-     *
-     * @param installData unused.
-     * @param panelRoot   unused.
-     */
-    public void makeXMLData(InstallData installData, IXMLElement panelRoot)
-    {
-        // do nothing.
-    }
+    @Override
+    public void createInstallationRecord(InstallData idata, IXMLElement panelRoot) {}
 
     /**
      * Perform the installation actions.

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupPanel.java
@@ -273,17 +273,19 @@ public class InstallationGroupPanel extends IzPanel
         }
     }
 
-    /* Add the installation group to pack mappings
-    * @see com.izforge.izpack.installer.IzPanel#makeXMLData(com.izforge.izpack.api.adaptator.IXMLElement)
-    */
-
+    /**
+     * Creates an installation record for unattended installations on {@link InstallationGroupPanel},
+     * created during GUI installations.
+     *
+     * @param panelRoot the root element to add the xml to
+     */
     @Override
-    public void makeXMLData(IXMLElement panelRoot)
+    public void createInstallationRecord(IXMLElement panelRoot)
     {
         InstallationGroupPanelAutomationHelper helper = new InstallationGroupPanelAutomationHelper();
         this.installData.setAttribute("GroupData", rows);
         this.installData.setAttribute("packsByName", packsByName);
-        helper.makeXMLData(this.installData, panelRoot);
+        helper.createInstallationRecord(this.installData, panelRoot);
     }
 
     /*

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupPanelAutomationHelper.java
@@ -34,37 +34,32 @@ import com.izforge.izpack.panels.installationgroup.InstallationGroupPanel.GroupD
 
 /**
  * An automation helper for the InstallationGroupPanel
- *
- * @author Scott.Stark@jboss.org
- * @version $Revision:$
  */
-public class InstallationGroupPanelAutomationHelper
-        implements PanelAutomation
+public class InstallationGroupPanelAutomationHelper implements PanelAutomation
 {
     private static final Logger logger = Logger.getLogger(InstallationGroupPanelAutomationHelper.class.getName());
 
     @Override
-    public void makeXMLData(InstallData idata, IXMLElement panelRoot)
+    public void createInstallationRecord(InstallData installData, IXMLElement rootElement)
     {
-        GroupData[] rows = (GroupData[]) idata.getAttribute("GroupData");
-        HashMap<String, Pack> packsByName = (HashMap) idata.getAttribute("packsByName");
-        String selectedInstallGroup = idata.getVariable("INSTALL_GROUP");
-        
+        GroupData[] rows = (GroupData[]) installData.getAttribute("GroupData");
+        HashMap<String, Pack> packsByName = (HashMap<String, Pack>) installData.getAttribute("packsByName");
+        String selectedInstallGroup = installData.getVariable("INSTALL_GROUP");
+
         // Write out the group to pack mappings
         for (GroupData groupData : rows)
         {
             if (groupData.name.equals(selectedInstallGroup))
             {
-              IXMLElement xgroup = new XMLElementImpl("group", panelRoot);
+              IXMLElement xgroup = new XMLElementImpl("group", rootElement);
               xgroup.setAttribute("name", groupData.name);
               for (String name : groupData.packNames)
               {
-                  Pack pack = packsByName.get(name);
                   IXMLElement xpack = new XMLElementImpl("pack", xgroup);
                   xpack.setContent(name);
                   xgroup.addChild(xpack);
               }
-              panelRoot.addChild(xgroup);
+              rootElement.addChild(xgroup);
             }
         }
     }
@@ -83,9 +78,9 @@ public class InstallationGroupPanelAutomationHelper
             for (IXMLElement xpack : packs)
             {
                 String packName = xpack.getContent();
-                for (Pack pack: idata.getAvailablePacks()) 
+                for (Pack pack: idata.getAvailablePacks())
                 {
-                    if (pack.getName().equals(packName)) 
+                    if (pack.getName().equals(packName))
                     {
                         idata.getSelectedPacks().add(pack);
                         logger.fine("Added pack: " + pack.getName());

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanel.java
@@ -151,6 +151,7 @@ public class JDKPathPanel extends PathInputPanel implements HyperlinkListener
      *
      * @return Wether the panel has been validated or not.
      */
+    @Override
     public boolean isValidated()
     {
         boolean retval = false;
@@ -214,6 +215,7 @@ public class JDKPathPanel extends PathInputPanel implements HyperlinkListener
     /**
      * Called when the panel becomes active.
      */
+    @Override
     public void panelActivate()
     {
         // Resolve the default for chosenPath
@@ -250,11 +252,11 @@ public class JDKPathPanel extends PathInputPanel implements HyperlinkListener
             }
             else
             {
-            	String javaHome = installData.getVariable("JAVA_HOME");
-            	if (javaHome != null)
-            	{
-            		chosenPath = new File(javaHome).getAbsolutePath();
-            	}
+                String javaHome = installData.getVariable("JAVA_HOME");
+                if (javaHome != null)
+                {
+                    chosenPath = new File(javaHome).getAbsolutePath();
+                }
             }
         }
         // Set the path for method pathIsValid ...
@@ -623,23 +625,18 @@ public class JDKPathPanel extends PathInputPanel implements HyperlinkListener
         this.variableName = variableName;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.izforge.izpack.installer.IzPanel#getSummaryBody()
-     */
-
+    @Override
     public String getSummaryBody()
     {
         return (this.installData.getVariable(getVariableName()));
     }
-    
+
     @Override
-    public void makeXMLData(IXMLElement panelRoot) {
+    public void createInstallationRecord(IXMLElement panelRoot) {
         IXMLElement ipath = new XMLElementImpl("jdkPath", panelRoot);
         ipath.setContent(pathSelectionPanel.getPath());
         panelRoot.addChild(ipath);
-        
+
         IXMLElement varname = new XMLElementImpl("jdkVarName", panelRoot);
         varname.setContent(variableName);
         panelRoot.addChild(varname);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelAutomationHelper.java
@@ -9,25 +9,25 @@ import com.izforge.izpack.installer.automation.PanelAutomationHelper;
 
 public class JDKPathPanelAutomationHelper extends PanelAutomationHelper implements PanelAutomation {
 
-	@Override
-	public void makeXMLData(InstallData installData, IXMLElement panelRoot) {
-		IXMLElement varname = new XMLElementImpl("jdkVarName", panelRoot);
-		varname.setContent(installData.getVariable("jdkVarName"));
-		panelRoot.addChild(varname);
-		
-		IXMLElement jdkPath = new XMLElementImpl("jdkPath", panelRoot);
-		jdkPath.setContent(installData.getVariable(installData.getVariable("jdkVarName")));
-		panelRoot.addChild(jdkPath);
-	}
+    @Override
+    public void createInstallationRecord(InstallData installData, IXMLElement rootElement) {
+        IXMLElement varname = new XMLElementImpl("jdkVarName", rootElement);
+        varname.setContent(installData.getVariable("jdkVarName"));
+        rootElement.addChild(varname);
 
-	@Override
-	public void runAutomated(InstallData installData, IXMLElement panelRoot) throws InstallerException {
-		IXMLElement jdkPathElement = panelRoot.getFirstChildNamed("jdkPath");
-		String jdkPath = jdkPathElement.getContent();
-		
-		IXMLElement jdkVarNameElement = panelRoot.getFirstChildNamed("jdkVarName");
-		String jdkVarName = jdkVarNameElement.getContent();
-		
-		installData.setVariable(jdkVarName, jdkPath);
-	}
+        IXMLElement jdkPath = new XMLElementImpl("jdkPath", rootElement);
+        jdkPath.setContent(installData.getVariable(installData.getVariable("jdkVarName")));
+        rootElement.addChild(jdkPath);
+    }
+
+    @Override
+    public void runAutomated(InstallData installData, IXMLElement panelRoot) throws InstallerException {
+        IXMLElement jdkPathElement = panelRoot.getFirstChildNamed("jdkPath");
+        String jdkPath = jdkPathElement.getContent();
+
+        IXMLElement jdkVarNameElement = panelRoot.getFirstChildNamed("jdkVarName");
+        String jdkVarName = jdkVarNameElement.getContent();
+
+        installData.setVariable(jdkVarName, jdkPath);
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelAutomationHelper.java
@@ -42,23 +42,17 @@ public class PacksPanelAutomationHelper implements PanelAutomation
 {
     private static final Logger logger = Logger.getLogger(PacksPanelAutomationHelper.class.getName());
 
-    /**
-     * Asks to make the XML panel installDataGUI.
-     *
-     * @param idata     The installation installDataGUI.
-     * @param panelRoot The XML tree to write the installDataGUI in.
-     */
     @Override
-    public void makeXMLData(InstallData idata, IXMLElement panelRoot)
+    public void createInstallationRecord(InstallData installData, IXMLElement panelRoot)
     {
         // We add each pack to the panelRoot element
-        for (int i = 0; i < idata.getAvailablePacks().size(); i++)
+        for (int i = 0; i < installData.getAvailablePacks().size(); i++)
         {
-            Pack pack = idata.getAvailablePacks().get(i);
+            Pack pack = installData.getAvailablePacks().get(i);
             IXMLElement packElement = new XMLElementImpl("pack", panelRoot);
             packElement.setAttribute("index", Integer.toString(i));
             packElement.setAttribute("name", pack.getName());
-            Boolean selected = idata.getSelectedPacks().contains(pack);
+            Boolean selected = installData.getSelectedPacks().contains(pack);
             packElement.setAttribute("selected", selected.toString());
 
             panelRoot.addChild(packElement);
@@ -200,6 +194,6 @@ public class PacksPanelAutomationHelper implements PanelAutomation
         {
             panelRoot.removeChild(panelRoot.getChildAtIndex(0));
         }
-        makeXMLData(idata, panelRoot);
+        createInstallationRecord(idata, panelRoot);
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelBase.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelBase.java
@@ -324,9 +324,9 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
      * @param panelRoot The XML tree to write the installDataGUI in.
      */
     @Override
-    public void makeXMLData(IXMLElement panelRoot)
+    public void createInstallationRecord(IXMLElement panelRoot)
     {
-        new PacksPanelAutomationHelper().makeXMLData(this.installData, panelRoot);
+        new PacksPanelAutomationHelper().createInstallationRecord(this.installData, panelRoot);
     }
 
     @Override

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelAutomation.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelAutomation.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2003 Jonathan Halliday
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -59,13 +59,8 @@ public class ProcessPanelAutomation extends PanelAutomationHelper implements Pan
         processPanelWorker.setHandler(this);
     }
 
-    /**
-     * Save installDataGUI for running automated.
-     *
-     * @param installData installation parameters
-     * @param panelRoot   unused.
-     */
-    public void makeXMLData(InstallData installData, IXMLElement panelRoot)
+    @Override
+    public void createInstallationRecord(InstallData idata, IXMLElement panelRoot)
     {
         // not used here - during automatic installation, no automatic
         // installation information is generated

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanel.java
@@ -793,9 +793,9 @@ public class ShortcutPanel extends IzPanel implements ActionListener, ListSelect
     }
 
     @Override
-    public void makeXMLData(IXMLElement panelRoot)
+    public void createInstallationRecord(IXMLElement panelRoot)
     {
-    	List<IXMLElement> autoinstallXMLData = shortcutPanelLogic.getAutoinstallXMLData(panelRoot);
+        List<IXMLElement> autoinstallXMLData = shortcutPanelLogic.getAutoinstallXMLData(panelRoot);
         for (IXMLElement element : autoinstallXMLData)
         {
             panelRoot.addChild(element);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelAutomationHelper.java
@@ -72,7 +72,7 @@ public class ShortcutPanelAutomationHelper extends PanelAutomationHelper impleme
      * @param panelRoot   panel specific data for autoinstall.xml
      */
     @Override
-    public void makeXMLData(InstallData installData, IXMLElement panelRoot)
+    public void createInstallationRecord(InstallData installData, IXMLElement panelRoot)
     {
         for (IXMLElement element : shortcutPanelLogic.getAutoinstallXMLData(panelRoot))
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanel.java
@@ -21,6 +21,8 @@
 
 package com.izforge.izpack.panels.target;
 
+import java.io.File;
+
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Resources;
@@ -28,8 +30,6 @@ import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
 import com.izforge.izpack.panels.path.PathInputPanel;
-
-import java.io.File;
 
 /**
  * The target directory selection panel.
@@ -65,7 +65,7 @@ public class TargetPanel extends PathInputPanel
     public void panelActivate()
     {
        String path = TargetPanelHelper.getPath(installData);
-        
+
         if (path != null)
         {
             pathSelectionPanel.setPath(path);
@@ -74,11 +74,6 @@ public class TargetPanel extends PathInputPanel
         super.panelActivate();
     }
 
-    /**
-     * Indicates whether the panel has been validated or not.
-     *
-     * @return Whether the panel has been validated or not.
-     */
     @Override
     public boolean isValidated()
     {
@@ -102,27 +97,16 @@ public class TargetPanel extends PathInputPanel
         return result;
     }
 
-    /**
-     * Asks to make the XML panel installDataGUI.
-     *
-     * @param panelRoot The tree to put the installDataGUI in.
-     */
     @Override
-    public void makeXMLData(IXMLElement panelRoot)
+    public void createInstallationRecord(IXMLElement panelRoot)
     {
-        new TargetPanelAutomation().makeXMLData(installData, panelRoot);
+        new TargetPanelAutomation().createInstallationRecord(installData, panelRoot);
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.izforge.izpack.installer.IzPanel#getSummaryBody()
-     */
 
     @Override
     public String getSummaryBody()
     {
-        return (this.installData.getInstallPath());
+        return (installData.getInstallPath());
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelAutomation.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelAutomation.java
@@ -39,19 +39,14 @@ public class TargetPanelAutomation implements PanelAutomation
     {
     }
 
-    /**
-     * Asks to make the XML panel installDataGUI.
-     *
-     * @param idata     The installation installDataGUI.
-     * @param panelRoot The tree to put the installDataGUI in.
-     */
-    public void makeXMLData(InstallData idata, IXMLElement panelRoot)
+    @Override
+    public void createInstallationRecord(InstallData installData, IXMLElement panelRoot)
     {
         // Installation path markup
         IXMLElement ipath = new XMLElementImpl("installpath", panelRoot);
         // check this writes even if value is the default,
         // because without the constructor, default does not get set.
-        ipath.setContent(idata.getInstallPath());
+        ipath.setContent(installData.getInstallPath());
 
         // Checkings to fix bug #1864
         IXMLElement prev = panelRoot.getFirstChildNamed("installpath");
@@ -62,25 +57,19 @@ public class TargetPanelAutomation implements PanelAutomation
         panelRoot.addChild(ipath);
     }
 
-    /**
-     * Asks to run in the automated mode.
-     *
-     * @param idata     The installation installDataGUI.
-     * @param panelRoot The XML tree to read the installDataGUI from.
-     * @throws InstallerException if an incompatible installation exists at the specified path
-     */
-    public void runAutomated(InstallData idata, IXMLElement panelRoot)
+    @Override
+    public void runAutomated(InstallData installData, IXMLElement panelRoot)
     {
         // We set the installation path
         IXMLElement ipath = panelRoot.getFirstChildNamed("installpath");
 
         // Allow for variable substitution of the installpath value
         String path = ipath.getContent();
-        path = idata.getVariables().replace(path);
+        path = installData.getVariables().replace(path);
         if (TargetPanelHelper.isIncompatibleInstallation(path))
         {
-            throw new InstallerException(idata.getMessages().get("TargetPanel.incompatibleInstallation"));
+            throw new InstallerException(installData.getMessages().get("TargetPanel.incompatibleInstallation"));
         }
-        idata.setInstallPath(path);
+        installData.setInstallPath(path);
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -299,15 +299,10 @@ public class TreePacksPanel extends IzPanel implements PacksPanelInterface
         return (true);
     }
 
-    /**
-     * Asks to make the XML panel installDataGUI.
-     *
-     * @param panelRoot The XML tree to write the installDataGUI in.
-     */
     @Override
-    public void makeXMLData(IXMLElement panelRoot)
+    public void createInstallationRecord(IXMLElement panelRoot)
     {
-        new ImgPacksPanelAutomationHelper().makeXMLData(this.installData, panelRoot);
+        new ImgPacksPanelAutomationHelper().createInstallationRecord(this.installData, panelRoot);
     }
 
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -20,7 +20,12 @@ package com.izforge.izpack.panels.userinput;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
@@ -189,13 +194,11 @@ public class UserInputPanel extends IzPanel
     }
 
     /**
-     * Asks the panel to set its own XML installDataGUI that can be brought back for an automated installation
-     * process. Use it as a blackbox if your panel needs to do something even in automated mode.
-     *
-     * @param panelRoot The XML root element of the panels blackbox tree.
+     * Creates an installation record for unattended installations on {@link UserInputPanel},
+     * created during GUI installations.
      */
     @Override
-    public void makeXMLData(IXMLElement panelRoot)
+    public void createInstallationRecord(IXMLElement rootElement)
     {
         Map<String, String> entryMap = new HashMap<String, String>();
 
@@ -212,7 +215,7 @@ public class UserInputPanel extends IzPanel
             }
         }
 
-        new UserInputPanelAutomationHelper(entryMap).makeXMLData(installData, panelRoot);
+        new UserInputPanelAutomationHelper(entryMap).createInstallationRecord(installData, rootElement);
     }
 
     private void init()

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
@@ -46,8 +46,6 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
     // ------------------------------------------------------
     // automatic script section keys
     // ------------------------------------------------------
-    private static final String AUTO_KEY_USER_INPUT = "userInput";
-
     private static final String AUTO_KEY_ENTRY = "entry";
 
     // ------------------------------------------------------
@@ -81,20 +79,13 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
     /**
      * Serialize state to XML and insert under panelRoot.
      *
-     * @param idata     The installation installDataGUI.
-     * @param panelRoot The XML root element of the panels blackbox tree.
+     * @param installData The installation installData GUI.
+     * @param rootElement The XML root element of the panels blackbox tree.
      */
     @Override
-    public void makeXMLData(InstallData idata, IXMLElement panelRoot)
+    public void createInstallationRecord(InstallData installData, IXMLElement rootElement)
     {
-        IXMLElement userInput;
         IXMLElement dataElement;
-
-        // ----------------------------------------------------
-        // add the item that combines all entries
-        // ----------------------------------------------------
-        userInput = new XMLElementImpl(AUTO_KEY_USER_INPUT, panelRoot);
-        panelRoot.addChild(userInput);
 
         // ----------------------------------------------------
         // add all entries
@@ -102,11 +93,11 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
         for (String key : this.entries.keySet())
         {
             String value = this.entries.get(key);
-            dataElement = new XMLElementImpl(AUTO_KEY_ENTRY, userInput);
+            dataElement = new XMLElementImpl(AUTO_KEY_ENTRY, rootElement);
             dataElement.setAttribute(AUTO_ATTRIBUTE_KEY, key);
             dataElement.setAttribute(AUTO_ATTRIBUTE_VALUE, value);
 
-            userInput.addChild(dataElement);
+            rootElement.addChild(dataElement);
         }
     }
 
@@ -121,26 +112,10 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
     @Override
     public void runAutomated(InstallData idata, IXMLElement panelRoot) throws InstallerException
     {
-        IXMLElement userInput;
         String variable;
         String value;
 
-        // ----------------------------------------------------
-        // get the section containing the user entries
-        // ----------------------------------------------------
-        userInput = panelRoot.getFirstChildNamed(AUTO_KEY_USER_INPUT);
-
-        if (userInput == null)
-        {
-            throw new InstallerException("Missing userInput element on line " + panelRoot.getLineNr());
-        }
-
-        List<IXMLElement> userEntries = userInput.getChildrenNamed(AUTO_KEY_ENTRY);
-
-        if (userEntries == null)
-        {
-            throw new InstallerException("Missing entry element(s) on line " + panelRoot.getLineNr());
-        }
+        List<IXMLElement> userEntries = panelRoot.getChildrenNamed(AUTO_KEY_ENTRY);
 
         // ----------------------------------------------------
         // retieve each entry and substitute the associated

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathPanel.java
@@ -110,11 +110,6 @@ public class UserPathPanel extends UserPathInputPanel
         _pathSelectionPanel.setPath(expandedPath);
     }
 
-    /**
-     * Indicates whether the panel has been validated or not.
-     *
-     * @return Whether the panel has been validated or not.
-     */
     @Override
     public boolean isValidated()
     {
@@ -127,25 +122,14 @@ public class UserPathPanel extends UserPathInputPanel
         return (true);
     }
 
-    /**
-     * Asks to make the XML panel installDataGUI.
-     *
-     * @param panelRoot The tree to put the installDataGUI in.
-     */
     @Override
-    public void makeXMLData(IXMLElement panelRoot)
+    public void createInstallationRecord(IXMLElement panelRoot)
     {
         if (!(skip))
         {
-            new UserPathPanelAutomationHelper().makeXMLData(installData, panelRoot);
+            new UserPathPanelAutomationHelper().createInstallationRecord(installData, panelRoot);
         }
     }
-
-    /*
-    * (non-Javadoc)
-    *
-    * @see com.izforge.izpack.installer.IzPanel#getSummaryBody()
-    */
 
     @Override
     public String getSummaryBody()

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathPanelAutomationHelper.java
@@ -39,13 +39,8 @@ public class UserPathPanelAutomationHelper implements PanelAutomation
     {
     }
 
-    /**
-     * Asks to make the XML panel installDataGUI.
-     *
-     * @param idata     The installation installDataGUI.
-     * @param panelRoot The tree to put the installDataGUI in.
-     */
-    public void makeXMLData(InstallData idata, IXMLElement panelRoot)
+    @Override
+    public void createInstallationRecord(InstallData idata, IXMLElement panelRoot)
     {
         // Installation path markup
         IXMLElement ipath = new XMLElementImpl(UserPathPanel.pathElementName, panelRoot);
@@ -62,12 +57,7 @@ public class UserPathPanelAutomationHelper implements PanelAutomation
         panelRoot.addChild(ipath);
     }
 
-    /**
-     * Asks to run in the automated mode.
-     *
-     * @param idata     The installation installDataGUI.
-     * @param panelRoot The XML tree to read the installDataGUI from.
-     */
+    @Override
     public void runAutomated(InstallData idata, IXMLElement panelRoot)
     {
         // We set the installation path

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/UserInputConsolePanelTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/UserInputConsolePanelTest.java
@@ -210,7 +210,7 @@ public class UserInputConsolePanelTest
         panel.setClassName(panelClass.getName());
         panel.setPanelId(id);
         ConsolePanelView panelView = new ConsolePanelView(panel, factory, installData, console);
-        ConsolePanels panels = new ConsolePanels(Arrays.asList(panelView), installData.getVariables());
+        ConsolePanels panels = new ConsolePanels(Arrays.asList(panelView), installData);
         container.addComponent(ConsolePanels.class, panels);
         panels.setAction(new ConsoleInstallAction(console, installData, mock(UninstallDataWriter.class)));
         return panels;


### PR DESCRIPTION
The current state before this change has been:
- Adding the generation of auto-install.xml to the FinishConsolePanel is not possible without refactoring the implementation and API in common, because the whole implementation is bound to Swing installer classes (IzPanel).
- The created file cannot always be processed especially for createForPack constraints to UserInputPanel. If there are skipped panels due to this constraints and the installer is re-ran in a same environment with the recorded first installation it fails, because the panels with constraints like createForPack are not skipped, but there is expected and validated user input for them.
- The file dialog on FinishPanel should offer a default file name.

Should be solved herewith.
