### PR TITLE
[IZPACK-1106] Disable Next button on PacksPanel if no visible pack is selected

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksConsolePanel.java
@@ -69,6 +69,7 @@ public class PacksConsolePanel extends AbstractConsolePanel implements ConsolePa
      * @param properties  the properties
      * @return <tt>true</tt> if the installation is successful, otherwise <tt>false</tt>
      */
+    @Override
     public boolean run(InstallData installData, Properties properties)
     {
         return true;
@@ -81,6 +82,7 @@ public class PacksConsolePanel extends AbstractConsolePanel implements ConsolePa
      * @param console     the console
      * @return <tt>true</tt> if the panel ran successfully, otherwise <tt>false</tt>
      */
+    @Override
     public boolean run(InstallData installData, Console console)
     {
         out(Type.INFORMATION, "");

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModel.java
@@ -98,12 +98,12 @@ public class PacksModel extends AbstractTableModel
         {
             // installation shall be modified
             // load installation information
-
+            ObjectInputStream oin = null;
             try
             {
                 FileInputStream fin = new FileInputStream(new File(
                         idata.getInstallPath() + File.separator + InstallData.INSTALLATION_INFORMATION));
-                ObjectInputStream oin = new ObjectInputStream(fin);
+                oin = new ObjectInputStream(fin);
                 List<Pack> packsinstalled = (List<Pack>) oin.readObject();
                 for (Pack installedpack : packsinstalled)
                 {
@@ -118,7 +118,6 @@ public class PacksModel extends AbstractTableModel
                 {
                     idata.setVariable((String) key, (String) variables.get(key));
                 }
-                fin.close();
             }
             catch (FileNotFoundException e)
             {
@@ -134,6 +133,14 @@ public class PacksModel extends AbstractTableModel
             {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
+            }
+            finally
+            {
+                if (oin != null)
+                {
+                    try { oin.close(); }
+                    catch (IOException e) {}
+                }
             }
         }
         this.rules = rules;
@@ -712,6 +719,7 @@ public class PacksModel extends AbstractTableModel
 
 
     /**
+     * Get previously installed packs on modifying a pre-installed application
      * @return the installedpacks
      */
     public Map<String, Pack> getInstalledpacks()
@@ -726,5 +734,4 @@ public class PacksModel extends AbstractTableModel
     {
         return this.modifyinstallation;
     }
-
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanel.java
@@ -69,12 +69,7 @@ public class PacksPanel extends PacksPanelBase
         super(panel, parent, installData, resources, factory, rules);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.izforge.izpack.panels.packs.PacksPanelBase#createNormalLayout()
-     */
-
+    @Override
     protected void createNormalLayout()
     {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelBase.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelBase.java
@@ -95,6 +95,10 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
 {
     private static final long serialVersionUID = -727171695900867059L;
 
+    private static final String ACTIONKEY_TOGGLE = "togglePack";
+    private static final String ACTIONKEY_NEXTCOLUMNCELL = "selectNextColumnCell";
+    private static final String ACTIONKEY_PREVIOUSCOLUMNCELL = "selectPreviousColumnCell";
+
     private static final transient Logger logger = Logger.getLogger(PacksPanelBase.class.getName());
 
     // Common used Swing fields
@@ -226,6 +230,7 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
      */
     abstract protected void createNormalLayout();
 
+    @Override
     public Messages getMessages()
     {
         return messages;
@@ -543,9 +548,11 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
         table.setShowGrid(false);
 
         // register an action to toggle the selected pack when SPACE is pressed in the table
-        table.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0), "togglePack");
-        table.getActionMap().put("togglePack", new AbstractAction()
+        table.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0), ACTIONKEY_TOGGLE);
+        table.getActionMap().put(ACTIONKEY_TOGGLE, new AbstractAction()
         {
+            private static final long serialVersionUID = -2367549964368751438L;
+
             @Override
             public void actionPerformed(ActionEvent e)
             {
@@ -556,8 +563,10 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
 
         // register an action for "selectNextColumnCell" to change selection to the next row.
         // When at the last row, move focus outside the table. This avoids the need to use Ctrl-Tab to move focus
-        table.getActionMap().put("selectNextColumnCell", new AbstractAction()
+        table.getActionMap().put(ACTIONKEY_NEXTCOLUMNCELL, new AbstractAction()
         {
+            private static final long serialVersionUID = -8459710483408176528L;
+
             @Override
             public void actionPerformed(ActionEvent e)
             {
@@ -576,8 +585,10 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
         // register an action for "selectPreviousColumnCell" to change selection to the previous row.
         // When at the first, move focus to the prior component. This avoids the need to use Ctrl-Shift-Tab to move
         // focus
-        table.getActionMap().put("selectPreviousColumnCell", new AbstractAction()
+        table.getActionMap().put(ACTIONKEY_PREVIOUSCOLUMNCELL, new AbstractAction()
         {
+            private static final long serialVersionUID = 5846709935309245963L;
+
             @Override
             public void actionPerformed(ActionEvent e)
             {
@@ -637,6 +648,8 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
     @Override
     public void panelActivate()
     {
+        parent.lockNextButton();
+
         try
         {
             packsModel = new PacksModel(this, installData, rules)
@@ -695,6 +708,8 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
         showSpaceRequired();
         showFreeSpace();
         packsTable.setRowSelectionInterval(0, 0);
+
+        updateButtons();
     }
 
     @Override
@@ -968,6 +983,18 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
         packsModel.setValueAt(checked, row, 0);
         packsTable.repaint();
         packsTable.changeSelection(row, 0, false, false);
+        updateButtons();
     }
 
+    private void updateButtons()
+    {
+        if (installData.getSelectedPacks().isEmpty())
+        {
+            parent.lockNextButton();
+        }
+        else
+        {
+            parent.unlockNextButton();
+        }
+    }
 }


### PR DESCRIPTION
Currently it is possible to unselect all packs in the PacksPanel and switching to the next panel. This is not intuitive and makes no sense from the user's point of view, even if there are hidden panels.

There should be at least one visible panel selected on the packPanel, either by the user or a required one, to show the user that something will be installed when he presses Next.

Disable the Next button as long as there is no pack selected.

Added also some smaller code cleanups concerning the existing PacksPanel.
