### PR TITLE
[IZPACK-1114] Next panel not gathered correctly if it depends on panel conditions

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/DefaultNavigator.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/DefaultNavigator.java
@@ -45,7 +45,6 @@ import com.izforge.izpack.installer.panel.Panels;
  */
 public class DefaultNavigator implements Navigator
 {
-
     /**
      * The parent frame.
      */
@@ -326,7 +325,7 @@ public class DefaultNavigator implements Navigator
     public boolean next(boolean validate)
     {
         boolean result = false;
-        if (panels.isNextEnabled() && panels.hasNext())
+        if (panels.isNextEnabled())
         {
             try
             {
@@ -351,7 +350,7 @@ public class DefaultNavigator implements Navigator
     public boolean previous()
     {
         boolean result = false;
-        if (panels.isPreviousEnabled() && panels.hasPrevious())
+        if (panels.isPreviousEnabled())
         {
             try
             {
@@ -462,8 +461,7 @@ public class DefaultNavigator implements Navigator
      */
     private void configureVisibility()
     {
-        int index = panels.getIndex();
-        if (panels.getNext(index, true) == -1)
+        if (panels.getNext(true) == -1)
         {
             // last panel. Disable navigation.
             setPreviousVisible(false);
@@ -476,7 +474,7 @@ public class DefaultNavigator implements Navigator
             if (configurePrevious)
             {
                 // only configure the previous button if it wasn't modified during panel switching
-                boolean enablePrev = panels.getPrevious(index, true) != -1;
+                boolean enablePrev = panels.getPrevious(true) != -1;
                 setPreviousVisible(enablePrev);
                 setPreviousEnabled(enablePrev);
             }
@@ -484,7 +482,7 @@ public class DefaultNavigator implements Navigator
             if (configureNext)
             {
                 // only configure the next button if it wasn't modified during panel switching
-                boolean enableNext = panels.getNext(index, true) != -1;
+                boolean enableNext = panels.getNext(true) != -1;
                 setNextVisible(enableNext);
                 setNextEnabled(enableNext);
             }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -564,6 +564,7 @@ public class InstallerFrame extends JFrame implements InstallerView
                 panelsContainer.remove(oldView);
                 oldView.panelDeactivate();
             }
+
             panelsContainer.add(newView);
             installdata.setCurPanelNumber(newPanel.getIndex());
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
@@ -264,10 +264,12 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
         if (panel.hasCondition())
         {
             result = installData.getRules().isConditionTrue(panel.getCondition());
+            logger.fine("Panel '" + getPanelId() + "' depending on condition '" + panel.getCondition() + "' " + (result?"can be shown":"will be skipped"));
         }
         else
         {
             result = installData.getRules().canShowPanel(panelId, installData.getVariables());
+            logger.fine("Panel '" + getPanelId() + "' " + (result?"can be shown":"will be skipped"));
         }
         return result;
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanels.java
@@ -84,6 +84,10 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
      */
     private static final Logger logger = Logger.getLogger(AbstractPanels.class.getName());
 
+    T lastPanel;
+    boolean lastPanelCanShow;
+    boolean lastPanelVisibleOnly;
+
     /**
      * Constructs an {@code AbstractPanels}.
      *
@@ -170,7 +174,7 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
     public boolean isValid()
     {
         T panel = getPanelView();
-        return panel != null && executeValidationActions(panel, true);
+        return panel == null || executeValidationActions(panel, true);
     }
 
     /**
@@ -240,10 +244,15 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
     public boolean next(boolean validate)
     {
         boolean result = false;
-        int newIndex = getNext(index, false);
-        if (newIndex != -1)
+
+        // Evaluate and set variables for current panel before verifying panel conditions
+        if (isValid())
         {
-            result = switchPanel(newIndex, validate);
+            int newIndex = getNext(index, false);
+            if (newIndex != -1)
+            {
+                result = switchPanel(newIndex, validate);
+            }
         }
 
         return result;
@@ -335,7 +344,20 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
                 break;
             }
         }
+
         return result;
+    }
+
+    /**
+     * Determines if there is another panel after the current index.
+     *
+     * @param visibleOnly if {@code true}, only examine visible panels
+     * @return {@code true} if there is another panel
+     */
+    @Override
+    public int getNext(boolean visibleOnly)
+    {
+        return getNext(index, visibleOnly);
     }
 
     /**
@@ -358,6 +380,19 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
             }
         }
         return result;
+    }
+
+    /**
+     * Determines if there is another panel prior to the specified index.
+     *
+     * @param index       the panel index
+     * @param visibleOnly if {@code true}, only examine visible panels
+     * @return the previous panel index, or {@code -1} if there are no more panels
+     */
+    @Override
+    public int getPrevious(boolean visibleOnly)
+    {
+        return getPrevious(index, visibleOnly);
     }
 
     /**
@@ -438,14 +473,12 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
      */
     public boolean switchPanel(int newIndex, boolean validate)
     {
-        boolean result;
-
-        T panel = getPanelView();
-        if (!(panel == null || executeValidationActions(panel, validate)))
-            return false;
+       boolean result;
 
         if ((newIndex > index) && !isNextEnabled()) // NOTE: actions may change isNextEnabled() status
+        {
             return false;
+        }
 
 
         // refresh variables prior to switching panels
@@ -479,7 +512,7 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
             result = false;
         }
 
-        return result;
+       return result;
     }
 
     /**
@@ -537,7 +570,16 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
      */
     private boolean canShow(T panel, boolean visibleOnly)
     {
-        return (!visibleOnly || panel.isVisible()) && panel.canShow();
+        if (lastPanel != panel || lastPanelVisibleOnly != visibleOnly)
+        {
+            // Cache the values if the panel hasn't changed
+            // to not many times re-evaluate conditions and dynamic variables
+            lastPanel = panel;
+            lastPanelVisibleOnly = visibleOnly;
+            lastPanelCanShow = ((!visibleOnly || panel.isVisible()) && panel.canShow());
+        }
+
+        return lastPanelCanShow;
     }
 
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/Panels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/Panels.java
@@ -147,6 +147,14 @@ public interface Panels
     int getNext(int index, boolean visibleOnly);
 
     /**
+     * Determines if there is another panel after the current index.
+     *
+     * @param visibleOnly if {@code true}, only examine visible panels
+     * @return {@code true} if there is another panel
+     */
+    int getNext(boolean visibleOnly);
+
+    /**
      * Determines if there is another panel prior to the specified index.
      *
      * @param index       the panel index
@@ -154,6 +162,14 @@ public interface Panels
      * @return the previous panel index, or {@code -1} if there are no more panels
      */
     int getPrevious(int index, boolean visibleOnly);
+
+    /**
+     * Determines if there is another panel prior to the current index.
+     *
+     * @param visibleOnly if {@code true}, only examine visible panels
+     * @return the previous panel index, or {@code -1} if there are no more panels
+     */
+    int getPrevious(boolean visibleOnly);
 
     /**
      * Returns the number of visible panels.


### PR DESCRIPTION
There is an issue when changing panels using panel conditions:
If a panel depends on conditions based on variables set by a previous panel (like $INSTALL_PATH in TargetPanel), these conditions are not evaluated correctly, because at the evaluation time there are still not updated the variables set in the previous panel. This results in an unexpected panel order although the conditions are shown correctly in trace mode after the panel change (when showing them in trace mode the variable update has been already passed, in difference to the moment when gathering the next panel based on conditions).

There have been also made some small optimizations to avoid repeated evaluating on the same panel under the same circumstances.
