### PR TITLE
[IZPACK-1115] Use <executable> and <parsable> with filesets which do not access the filesystem

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -75,6 +75,7 @@ import com.izforge.izpack.api.data.Info.TempDir;
 import com.izforge.izpack.api.data.InstallerRequirement;
 import com.izforge.izpack.api.data.LookAndFeels;
 import com.izforge.izpack.api.data.OverrideType;
+import com.izforge.izpack.api.data.PackFile;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.data.PanelActionConfiguration;
 import com.izforge.izpack.api.data.binding.Help;
@@ -92,13 +93,13 @@ import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.compiler.data.CompilerData;
 import com.izforge.izpack.compiler.data.PropertyManager;
 import com.izforge.izpack.compiler.helper.AssertionHelper;
-import com.izforge.izpack.compiler.helper.CompilerHelper;
 import com.izforge.izpack.compiler.helper.TargetFileSet;
 import com.izforge.izpack.compiler.helper.XmlCompilerHelper;
 import com.izforge.izpack.compiler.listener.CompilerListener;
 import com.izforge.izpack.compiler.merge.CompilerPathResolver;
 import com.izforge.izpack.compiler.packager.IPackager;
 import com.izforge.izpack.compiler.resource.ResourceFinder;
+import com.izforge.izpack.compiler.util.AntPathMatcher;
 import com.izforge.izpack.compiler.util.CompilerClassLoader;
 import com.izforge.izpack.core.data.DynamicInstallerRequirementValidatorImpl;
 import com.izforge.izpack.core.data.DynamicVariableImpl;
@@ -802,12 +803,6 @@ public class CompilerConfig extends Thread
                 pack.setPackImgId(packImgId);
             }
 
-            List<IXMLElement> parsableChildren = packElement.getChildrenNamed("parsable");
-            processParsableChildren(pack, parsableChildren);
-
-            List<IXMLElement> executableChildren = packElement.getChildrenNamed("executable");
-            processExecutableChildren(pack, executableChildren);
-
             processFileChildren(baseDir, packElement, pack);
 
             processSingleFileChildren(baseDir, packElement, pack);
@@ -815,6 +810,12 @@ public class CompilerConfig extends Thread
             processFileSetChildren(baseDir, packElement, pack);
 
             processUpdateCheckChildren(packElement, pack);
+
+            List<IXMLElement> parsableChildren = packElement.getChildrenNamed("parsable");
+            processParsableChildren(pack, parsableChildren);
+
+            List<IXMLElement> executableChildren = packElement.getChildrenNamed("executable");
+            processExecutableChildren(pack, executableChildren);
 
             // We get the dependencies
             for (IXMLElement dependsNode : packElement.getChildrenNamed("depends"))
@@ -1037,7 +1038,8 @@ public class CompilerConfig extends Thread
                 {
                     fs.setFile(abssrcfile);
                 }
-                fs.setTargetDir(xmlCompilerHelper.requireAttribute(fileNode, "targetdir"));
+
+                fs.setTargetDir(fileNode.getAttribute("targetdir", "${INSTALL_PATH}"));
                 List<OsModel> osList = OsConstraintHelper.getOsList(fileNode); // TODO: unverified
                 fs.setOsList(osList);
                 fs.setOverride(getOverrideValue(fileNode));
@@ -1101,66 +1103,100 @@ public class CompilerConfig extends Thread
     {
         for (IXMLElement executableNode : childrenNamed)
         {
-            ExecutableFile executable = new ExecutableFile();
-            String val; // temp value
+            String target = executableNode.getAttribute("targetfile");
             String condition = executableNode.getAttribute("condition");
-            executable.setCondition(condition);
-            executable.path = xmlCompilerHelper.requireAttribute(executableNode, "targetfile");
+            List<OsModel> osList = OsConstraintHelper.getOsList(executableNode); // TODO: unverified
+            int executionStage = ExecutableFile.NEVER, type = ExecutableFile.BIN, onFailure = ExecutableFile.ASK;
+            String mainClass = null;
+            boolean keepFile;
 
-            // when to execute this executable
-            val = executableNode.getAttribute("stage", "never");
+            String val = executableNode.getAttribute("stage", "never");
             if ("postinstall".equalsIgnoreCase(val))
             {
-                executable.executionStage = ExecutableFile.POSTINSTALL;
+                executionStage = ExecutableFile.POSTINSTALL;
             }
             else if ("uninstall".equalsIgnoreCase(val))
             {
-                executable.executionStage = ExecutableFile.UNINSTALL;
+                executionStage = ExecutableFile.UNINSTALL;
             }
 
             // type of this executable
             val = executableNode.getAttribute("type", "bin");
             if ("jar".equalsIgnoreCase(val))
             {
-                executable.type = ExecutableFile.JAR;
-                executable.mainClass = executableNode.getAttribute("class"); // executable
-                // class
+                type = ExecutableFile.JAR;
+                mainClass = executableNode.getAttribute("class"); // executable class
             }
 
             // what to do if execution fails
             val = executableNode.getAttribute("failure", "ask");
             if ("abort".equalsIgnoreCase(val))
             {
-                executable.onFailure = ExecutableFile.ABORT;
+                onFailure = ExecutableFile.ABORT;
             }
             else if ("warn".equalsIgnoreCase(val))
             {
-                executable.onFailure = ExecutableFile.WARN;
+                onFailure = ExecutableFile.WARN;
             }
             else if ("ignore".equalsIgnoreCase(val))
             {
-                executable.onFailure = ExecutableFile.IGNORE;
+                onFailure = ExecutableFile.IGNORE;
             }
 
             // whether to keep the executable after executing it
             val = executableNode.getAttribute("keep");
-            executable.keepFile = Boolean.parseBoolean(val);
+            keepFile = Boolean.parseBoolean(val);
 
             // get arguments for this executable
             IXMLElement args = executableNode.getFirstChildNamed("args");
+            List<String> argsList = new ArrayList<String>();
             if (null != args)
             {
                 for (IXMLElement ixmlElement : args.getChildrenNamed("arg"))
                 {
-                    executable.argList.add(xmlCompilerHelper.requireAttribute(ixmlElement, "value"));
+                    argsList.add(xmlCompilerHelper.requireAttribute(ixmlElement, "value"));
                 }
             }
 
-            executable.osList = OsConstraintHelper.getOsList(executableNode); // TODO:
-            // unverified
-
-            pack.addExecutable(executable);
+            if (target != null)
+            {
+                addNewExecutableFile(pack, target, condition, osList, executionStage, type, mainClass,
+                        onFailure, keepFile, argsList);
+                logger.info("Marked target file executable: " + target);
+            }
+            for (IXMLElement fileSetElement : executableNode.getChildrenNamed("fileset"))
+            {
+                String targetdir = fileSetElement.getAttribute("targetdir", "${INSTALL_PATH}");
+                Set<String> includedFiles = getFilesetIncludedFiles(pack, fileSetElement, targetdir);
+                for (String filePath : includedFiles)
+                {
+                    addNewExecutableFile(pack, filePath, condition, osList, executionStage, type, mainClass,
+                            onFailure, keepFile, argsList);
+                    logger.info("Marked target file executable: " + filePath);
+                }
+            }
         }
+    }
+
+    private void addNewExecutableFile(PackInfo pack, String target, String condition, List<OsModel> osList,
+            int executionStage, int type, String mainClass, int onFailure, boolean keepFile, List<String> argsList
+            ) throws CompilerException
+    {
+        ExecutableFile executable = new ExecutableFile();
+        executable.path = target;
+        executable.setCondition(condition);
+        executable.osList = osList;
+        executable.executionStage = executionStage;
+        executable.type = type;
+        executable.mainClass = mainClass;
+        executable.onFailure = onFailure;
+        executable.keepFile = keepFile;
+        for (String arg : argsList)
+        {
+            executable.argList.add(arg);
+        }
+
+        pack.addExecutable(executable);
     }
 
     private void processParsableChildren(PackInfo pack, List<IXMLElement> parsableChildren) throws CompilerException
@@ -1177,58 +1213,27 @@ public class CompilerConfig extends Thread
                 ParsableFile parsable = new ParsableFile(target, type, encoding, osList);
                 parsable.setCondition(condition);
                 pack.addParsable(parsable);
+                logger.info("Marked target file parsable: " + target);
             }
-            //FIXME Use different type of fileset to scan already added files instead of the local filesystem
             for (IXMLElement fileSetElement : parsableNode.getChildrenNamed("fileset"))
             {
-                String targetdir = xmlCompilerHelper.requireAttribute(fileSetElement, "targetdir");
-                String dir_attr = xmlCompilerHelper.requireAttribute(fileSetElement, "dir");
-                File dir = new File(dir_attr);
-                if (!dir.isAbsolute())
+                String targetdir = fileSetElement.getAttribute("targetdir", "${INSTALL_PATH}");
+                Set<String> includedFiles = getFilesetIncludedFiles(pack, fileSetElement, targetdir);
+                for (String filePath : includedFiles)
                 {
-                    dir = new File(compilerData.getBasedir(), dir_attr);
-                }
-                if (!dir.isDirectory()) // also tests '.exists()'
-                {
-                    assertionHelper.parseError(fileSetElement, "Invalid directory 'dir': " + dir_attr);
-                }
-                String[] includedFiles = getFilesetIncludedFiles(fileSetElement);
-                if (includedFiles != null)
-                {
-                    for (String filePath : includedFiles)
-                    {
-                        File file = new File(dir, filePath);
-                        if (file.exists() && file.isFile())
-                        {
-                            String targetFile = new File(targetdir, filePath).getPath().replace(File.separatorChar,
-                                                                                                '/');
-                            ParsableFile parsable = new ParsableFile(targetFile, type, encoding, osList);
-                            parsable.setCondition(condition);
-                            pack.addParsable(parsable);
-                        }
-                    }
+                    ParsableFile parsable = new ParsableFile(filePath, type, encoding, osList);
+                    parsable.setCondition(condition);
+                    pack.addParsable(parsable);
+                    logger.info("Marked target file parsable: " + filePath);
                 }
             }
         }
     }
 
-    private String[] getFilesetIncludedFiles(IXMLElement fileSetElement) throws CompilerException
+    private Set<String> getFilesetIncludedFiles(PackInfo info, IXMLElement fileSetElement, String targetDir)
+    throws CompilerException
     {
-        List<String> includedFiles = new ArrayList<String>();
-        String dir_attr = xmlCompilerHelper.requireAttribute(fileSetElement, "dir");
-
-        File dir = new File(dir_attr);
-        if (!dir.isAbsolute())
-        {
-            dir = new File(compilerData.getBasedir(), dir_attr);
-        }
-        if (!dir.isDirectory()) // also tests '.exists()'
-        {
-            assertionHelper.parseError(fileSetElement, "Invalid directory 'dir': " + dir_attr);
-        }
-
         boolean casesensitive = xmlCompilerHelper.validateYesNoAttribute(fileSetElement, "casesensitive", YES);
-        boolean defexcludes = xmlCompilerHelper.validateYesNoAttribute(fileSetElement, "defaultexcludes", YES);
 
         // get includes and excludes
         List<IXMLElement> xcludesList;
@@ -1270,8 +1275,7 @@ public class CompilerConfig extends Thread
                 String[] nCont = null;
                 if (containers[j] != null && containers[j].length > 0)
                 {   // old container exist; create a new which can hold
-                    // all values
-                    // and copy the old stuff to the front
+                    // all values and copy the old stuff to the front
                     newSize += containers[j].length;
                     nCont = new String[newSize];
                     System.arraycopy(containers[j], 0, nCont, 0, containers[j].length);
@@ -1293,33 +1297,43 @@ public class CompilerConfig extends Thread
         excludes = containers[1]; // push the new excludes to the
         // local var
 
-        // scan and add fileset
-        DirectoryScanner directoryScanner = new DirectoryScanner();
-        directoryScanner.setIncludes(includes);
-        directoryScanner.setExcludes(excludes);
-        if (defexcludes)
-        {
-            directoryScanner.addDefaultExcludes();
-        }
-        directoryScanner.setBasedir(dir);
-        directoryScanner.setCaseSensitive(casesensitive);
-        try
-        {
-            directoryScanner.scan();
 
-            String[] files = directoryScanner.getIncludedFiles();
-            String[] dirs = directoryScanner.getIncludedDirectories();
-            // Directory scanner has done recursion, add files and
-            // directories
-            Collections.addAll(includedFiles, files);
-            Collections.addAll(includedFiles, dirs);
-        }
-        catch (Exception e)
+        HashSet<String> matches = new HashSet<String>();
+        AntPathMatcher matcher = new AntPathMatcher();
+
+        if (includes == null || includes.length == 0)
         {
-            throw new CompilerException(e.getMessage());
+            throw new CompilerException("At least one included file required in a fileset");
         }
 
-        return includedFiles.toArray(new String[includedFiles.size()]);
+        logger.fine("Fileset (targetDir=\""+targetDir+"\"");
+        for (String include : includes)
+        {
+            logger.fine("Processing include: \"" + include+"\"");
+            for (PackFile s:info.getPackFiles()) {
+                String targetPath = s.getTargetPath();
+                if (matcher.match(targetDir + "/" + include, targetPath, casesensitive))
+                {
+                    matches.add(targetPath);
+                }
+            }
+        }
+
+        if (excludes != null)
+        {
+            for (int i = 0; i < excludes.length; i++)
+            {
+                for (PackFile s:info.getPackFiles()) {
+                    String targetPath = s.getTargetPath();
+                    if (matcher.match(excludes[i], targetPath, casesensitive))
+                    {
+                        matches.remove(targetPath);
+                    }
+                }
+            }
+        }
+
+        return matches;
     }
 
     private IXMLElement readRefPackData(String refFileName, boolean isselfcontained)
@@ -3005,7 +3019,7 @@ public class CompilerConfig extends Thread
     {
         TargetFileSet fs = new TargetFileSet();
 
-        fs.setTargetDir(xmlCompilerHelper.requireAttribute(fileSetNode, "targetdir"));
+        fs.setTargetDir(fileSetNode.getAttribute("targetdir", "${INSTALL_PATH}"));
         List<OsModel> osList = OsConstraintHelper.getOsList(fileSetNode); // TODO: unverified
         fs.setOsList(osList);
         fs.setOverride(getOverrideValue(fileSetNode));

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/util/AntPathMatcher.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/util/AntPathMatcher.java
@@ -1,0 +1,58 @@
+package com.izforge.izpack.compiler.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * PathMatcher implementation for Ant-style path patterns. Examples are provided below.
+ *
+ * <p>Part of this mapping code has been kindly borrowed from <a href="http://ant.apache.org">Apache Ant</a>.
+ *
+ * <p>The mapping matches URLs using the following rules:<br> <ul> <li>? matches one character</li> <li>* matches zero
+ * or more characters</li> <li>** matches zero or more 'directories' in a path</li> </ul>
+ *
+ * <p>Some examples:<br>
+ * <ul>
+ * <li><code>bin/t?st.exe</code> - matches <code>bin/test.exe</code> but also <code>bin/tast.exe</code>
+ *     or <code>bin/txst.exe</code></li>
+ * <li><code>bin/*.exe</code> - matches all <code>.exe</code> files in the <code>bin</code> directory</li>
+ * <li><code>bin/&#42;&#42;/test.exe</code> - matches all <code>test.exe</code> files underneath the <code>bin</code> path</li>
+ * </ul>
+ */
+public class AntPathMatcher {
+
+    private static final Pattern VAR_PATTERN = Pattern.compile("\\$\\{([^/]+?)\\}");
+
+    /**
+     * Match the given <code>path</code> against the given <code>pattern</code>,
+     * according to this PathMatcher's matching strategy.
+     * @param pattern the pattern to match against
+     * @param path the path String to test
+     * @param caseInsensitive whether the test should be case-insensitive
+     * @return <code>true</code> if the supplied <code>path</code> matched,
+     * <code>false</code> if it didn't
+     */
+    public boolean match(String pattern, String path, boolean caseSensitive) {
+
+        pattern = pattern.replaceAll("\\\\", "/");
+        pattern = pattern.replaceAll("\\.", "\\\\.");
+        pattern = pattern.replaceAll("\\*", "[^/]*");
+        pattern = pattern.replaceAll("(\\[\\^/\\]\\*){2}", ".*");
+
+        Matcher m = VAR_PATTERN.matcher(pattern);
+        StringBuffer s = new StringBuffer();
+        while (m.find()) {
+            m.appendReplacement(s, "\\\\Q\\$\\{"+m.group(1)+"\\}\\\\E");
+        }
+        m.appendTail(s);
+
+        int flags = 0;
+        if (!caseSensitive)
+        {
+            flags |= Pattern.CASE_INSENSITIVE;
+        }
+        Pattern p = Pattern.compile(s.toString(), flags);
+
+        return p.matcher(path).matches();
+    }
+}

--- a/izpack-dist/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-dist/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -391,7 +391,7 @@
         <xs:sequence>
             <xs:element name="description" type="xs:string" maxOccurs="1"/>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element name="fileset" type="fileSetType"/>
+                <xs:element name="fileset" type="fileSetTypeDisk"/>
                 <xs:element name="file" type="fileType"/>
                 <xs:element name="singlefile" type="singleFileType"/>
                 <xs:element name="parsable" type="parsableType"/>
@@ -422,7 +422,7 @@
     <!--                                                                                                        -->
     <!-- File sets                                                                                              -->
     <!--                                                                                                        -->
-    <xs:complexType name="fileSetType">
+    <xs:complexType name="fileSetTypeDisk">
         <xs:sequence>
             <xs:element name="include" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="exclude" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
@@ -432,9 +432,19 @@
         <xs:attribute name="dir" type="xs:string" use="required"/>
         <xs:attribute name="includes" type="xs:string" use="optional"/>
         <xs:attribute name="excludes" type="xs:string" use="optional"/>
-        <xs:attribute name="targetdir" type="xs:string" use="required"/>
+        <xs:attribute name="targetdir" type="xs:string" use="optional" default="${INSTALL_PATH}"/>
         <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
         <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="fileSetTypePack">
+        <xs:sequence>
+            <xs:element name="include" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="exclude" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="includes" type="xs:string" use="optional"/>
+        <xs:attribute name="excludes" type="xs:string" use="optional"/>
+        <xs:attribute name="targetdir" type="xs:string" use="optional" default="${INSTALL_PATH}"/>
     </xs:complexType>
 
     <xs:complexType name="fileType">
@@ -468,7 +478,7 @@
 
     <xs:complexType name="parsableType">
         <xs:sequence>
-            <xs:element name="fileset" type="fileSetType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="fileset" type="fileSetTypePack" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="targetfile" type="xs:string" use="optional"/>
@@ -479,7 +489,7 @@
 
     <xs:complexType name="executableType">
         <xs:sequence>
-            <xs:element name="fileset" type="fileSetType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="fileset" type="fileSetTypePack" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="args" minOccurs="0">
                 <xs:complexType>
                     <xs:sequence>


### PR DESCRIPTION
The `<parsable>` tag currently supports a nested fileset, which requires a `dir` and a `targetDir` attribute. Accessing the filesystem a second time here is not a goot choice and this lack has been already commented in the code. Instead, `<parsable>` should mark files parsable, which are added using the `<file>`, `<singlefile>` and `<fileset>` tags nested against the `<pack>` definition, the original filesystem access should happen only there (the files are packed into the installer).

The same for the `<executable>` tag, which currently even doesn't support nested filesets although it is documented.

Furthermore, for all filesets (nested in `<pack>`, `<executable>`, `<parsable>`) the `targetDir` attribute should be optional and default to "${INSTALL_PATH}".

The dir attribute should no longer been parsed in `<fileset>` nested to `<executable>`, `<parsable>` at all.

Example:

``` xml
<pack name="Core files" required="yes" id="pack.core" condition="Install">
  <description>Core files</description>
  <fileset dir="@{staging.dir}" override="true">
    <exclude name="*.zip" />
    <exclude name="conf/*.properties" />
    <exclude name="conf/*.xml" />
  </fileset>
  <fileset dir="@{staging.dir}/config_files" targetdir="${INSTALL_PATH}/conf" override="true" overrideRenameTo="*.configbak">
    <include name="*.properties" />
    <include name="*.xml" />
    <exclude name="special.xml" />
  </fileset>
  <parsable encoding="UTF-8">
    <fileset targetdir="${INSTALL_PATH}/conf">
      <include name="wrapper.conf" />
    </fileset>
  </parsable>
  <parsable>
    <fileset>
      <include name="**/*.bat" />
      <include name="**/*.cmd" />
    </fileset>
  </parsable>
  <parsable type="shell">
    <fileset>
      <include name="**/*.sh" />
    </fileset>
  </parsable>
  <executable>
    <fileset>
      <include name="**/*.sh" />
    </fileset>
  </executable>
</pack>
```
