### PR TITLE
[IZPACK-1116] "afterpack" listeners launched before applying <executable>, <parsable> and <updatefiles>

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/ScriptParser.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/ScriptParser.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.data.ParsableFile;
@@ -40,6 +41,8 @@ import com.izforge.izpack.util.PlatformModelMatcher;
  */
 public class ScriptParser
 {
+    private static final Logger logger = Logger.getLogger(ScriptParser.class.getName());
+
     /**
      * The variable replacer.
      */
@@ -80,6 +83,9 @@ public class ScriptParser
         // Create a temporary file for the parsed data
         // (Use the same directory so that renaming works later)
         File file = new File(parsable.getPath());
+
+        logger.fine("Parsing and replacing variables in file " + file + "...");
+
         File parsedFile;
         try
         {

--- a/izpack-util/src/main/java/com/izforge/izpack/data/ExecutableFile.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/data/ExecutableFile.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2001,2002 Olexij Tkatchenko
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -159,6 +159,7 @@ public class ExecutableFile implements Serializable
         this.keepFile = keepFile;
     }
 
+    @Override
     public String toString()
     {
         StringBuffer retval = new StringBuffer();

--- a/izpack-util/src/main/java/com/izforge/izpack/data/ParsableFile.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/data/ParsableFile.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2001 Johannes Lehtinen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -151,4 +151,24 @@ public class ParsableFile implements Serializable
         return this.condition != null;
     }
 
+    @Override
+    public String toString()
+    {
+        StringBuffer retval = new StringBuffer();
+        retval.append("path = ").append(path);
+        retval.append("\n");
+        retval.append("type = ").append(type);
+        retval.append("\n");
+        retval.append("osList = ").append(osConstraints);
+        retval.append("\n");
+        if (osConstraints != null)
+        {
+            for (OsModel anOsList : osConstraints)
+            {
+                retval.append("\tos: ").append(anOsList);
+                retval.append("\n");
+            }
+        }
+        return retval.toString();
+    }
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/FileExecutor.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/FileExecutor.java
@@ -318,7 +318,8 @@ public class FileExecutor
             ExecutableFile efile = efileIterator.next();
             boolean deleteAfterwards = !efile.keepFile;
             File file = new File(efile.path);
-            logger.fine("Handling executable file " + efile);
+
+            logger.fine("Handling executable file " + efile + "...");
 
             // skip file if not for current OS (it might not have been installed
             // at all)


### PR DESCRIPTION
Currently, "afterpack" listeners launched before applying `<executable>`, `<parsable>` and `<updatefiles>` markers. This is non-intuitive and wrong.

Pre-parsed file with variables replaced and executable UNIX scripts cannot be used for instance in Ant actions this way.

Currently, unpacking a pack executes in this order:
- "beforepack" listeners
- "beforefile" listeners
- unpack file
- "afterfile" listener
- "afterpack" listeners.
- mark file "parsable"
- mark file "executable"
- clean up obsolete files according to `<updatefiles>`

Unpack packs should execute in the following new order:
- "beforepack" listeners
- "beforefile" listeners
- unpack file
- "afterfile" listener
- mark file "parsable"
- mark file "executable"
- clean up obsolete files according to `<updatefiles>`
- "afterpack" listeners.
