### PR TITLE
[IZPACK-1118] AntAction listener - add flag "logfile_append" to append to existing Ant action log files

### DIFF
--- a/izpack-dist/src/main/resources/schema/5.0/izpack-antactions-5.0.xsd
+++ b/izpack-dist/src/main/resources/schema/5.0/izpack-antactions-5.0.xsd
@@ -123,9 +123,11 @@
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="logfile" type="xs:string"/>
+        <xs:attribute name="logfile_append" type="xs:boolean" default="false"/>
         <xs:attribute name="messageid" type="xs:string"/>
         <xs:attribute name="buildfile" type="xs:string"/>
         <xs:attribute name="buildresource" type="xs:string"/>
+        <xs:attribute name="condition" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="propertyType">

--- a/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
@@ -70,6 +70,7 @@ public class ActionBase implements Serializable
     public static final String ANTCALL_VERBOSE_ATTR = "verbose";
     public static final String ANTCALL_LOGLEVEL_ATTR = "loglevel";
     public static final String ANTCALL_LOGFILE_ATTR = "logfile";
+    public static final String LOGFILE_APPEND = "logfile_append";
     public static final String ANTCALL_DIR_ATTR = "dir";
     public static final String ANTCALL_BUILDFILE_ATTR = "buildfile";
     public static final String ANTCALL_BUILDRESOURCE_ATTR = "buildresource";

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntAction.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntAction.java
@@ -76,6 +76,7 @@ public class AntAction extends ActionBase
     private List<String> uninstallTargets = null;
 
     private File logFile = null;
+    private boolean logFileAppend = false;
 
     private File buildDir = null;
 
@@ -267,10 +268,12 @@ public class AntAction extends ActionBase
      * Sets the logfile path to the given string.
      *
      * @param logFile to be set
+     * @append if true, then append new log entries to existing files
      */
-    public void setLogFile(File logFile)
+    public void setLogFile(File logFile, boolean append)
     {
         this.logFile = logFile;
+        this.logFileAppend = append;
     }
 
     /**
@@ -484,7 +487,7 @@ public class AntAction extends ActionBase
             try
             {
                 logFile.getParentFile().mkdirs();
-                printStream = new PrintStream(new FileOutputStream(logFile));
+                printStream = new PrintStream(new FileOutputStream(logFile, logFileAppend));
                 logger.setOutputPrintStream(printStream);
                 logger.setErrorPrintStream(printStream);
             }

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntActionInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntActionInstallerListener.java
@@ -405,13 +405,19 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
         String str = el.getAttribute(ActionBase.ANTCALL_LOGFILE_ATTR);
         if (str != null)
         {
+            String logAppendValue = el.getAttribute(ActionBase.LOGFILE_APPEND);
+            boolean logAppend = false;
+            if (logAppendValue != null)
+            {
+                logAppend = Boolean.parseBoolean(logAppendValue);
+            }
             try
             {
-                act.setLogFile(FileUtil.getAbsoluteFile(replacer.substitute(str), installData.getInstallPath()));
+                act.setLogFile(FileUtil.getAbsoluteFile(replacer.substitute(str), installData.getInstallPath()), logAppend);
             }
             catch (Exception e)
             {
-                act.setLogFile(FileUtil.getAbsoluteFile(str, installData.getInstallPath()));
+                act.setLogFile(FileUtil.getAbsoluteFile(str, installData.getInstallPath()), logAppend);
             }
         }
         String msgId = el.getAttribute(ActionBase.ANTCALL_MESSAGEID_ATTR);


### PR DESCRIPTION
In the built-in Antaction listeners, there is currently the possibility to log to separate logfiles, but each action requires an own log file, because it doesn't append to existing ones.

Add the possibility to choose whether to append to an Ant action log file or not.
Attribute name: `logfile_append` (Default: false)

Example:

``` xml
<antcall order="beforepack" buildresource="service.xml" logfile="${ant.log.file}" logfile_append="true">
    <property name="INSTALL_PATH" value="${INSTALL_PATH}" />
    <property name="service.name" value="${service.name}" />
    <target name="preinstall" />
</antcall>
```
