### PR TITLE
[IZPACK-1125] ConfigurationInstallerListener - footer comments are not preserved

### DIFF
--- a/izpack-util/pom.xml
+++ b/izpack-util/pom.xml
@@ -47,6 +47,12 @@
             <version>1.21</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/ConfigFileTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/ConfigFileTask.java
@@ -23,13 +23,10 @@
 package com.izforge.izpack.util.config;
 
 import java.io.File;
+import java.util.List;
 
 public abstract class ConfigFileTask extends SingleConfigurableTask
 {
-    /*
-     * Instance variables.
-     */
-
     protected File oldFile;
 
     protected File newFile;
@@ -42,7 +39,7 @@ public abstract class ConfigFileTask extends SingleConfigurableTask
     /**
      * Use this to prepend a comment to the configuration file's header
      */
-    private String comment;
+    private List<String> comment;
 
     /**
      * Location of the configuration file to be patched to; optional. If not set, any empty
@@ -83,12 +80,12 @@ public abstract class ConfigFileTask extends SingleConfigurableTask
     /**
      * optional header comment for the file
      */
-    public void setComment(String hdr)
+    public void setComment(List<String> hdr)
     {
         comment = hdr;
     }
 
-    protected String getComment()
+    protected List<String> getComment()
     {
         return this.comment;
     }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
@@ -22,6 +22,7 @@
 
 package com.izforge.izpack.util.config;
 
+import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.ParseException;
@@ -59,7 +60,7 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
     protected boolean createConfigurable = true;
 
     /*
-     * ini4j settings
+     * ini4j-like settings
      */
     private boolean escape = Config.getGlobal().isEscape();
     private boolean escapeNewLine = Config.getGlobal().isEscapeNewline();
@@ -67,6 +68,7 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
     private boolean emptyLines = true;
     private boolean autoNumbering = true;
     private String operator = Config.getGlobal().getOperator();
+    private Charset encoding = Config.getGlobal().getFileEncoding();
 
 
     /*
@@ -177,6 +179,16 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
     }
 
     /**
+     * The encoding to be used for loading and saving configuration files
+     *
+     * @param encoding - an encoding string
+     */
+    public void setEncoding(Charset encoding)
+    {
+        this.encoding = encoding;
+    }
+
+    /**
      * Whether the configuration file or registry root entry should be created if it doesn't already
      * exist (default: true).
      *
@@ -196,6 +208,7 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
         Config.getGlobal().setEscape(escape);
         Config.getGlobal().setEscapeNewline(escapeNewLine);
         Config.getGlobal().setOperator(operator);
+        Config.getGlobal().setFileEncoding(encoding);
         checkAttributes();
         readConfigurable();
         readSourceConfigurable();

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleIniFileTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleIniFileTask.java
@@ -116,7 +116,7 @@ public class SingleIniFileTask extends ConfigFileTask
             }
             Ini ini = (Ini) configurable;
             ini.setFile(toFile);
-            ini.setComment(getComment());
+            ini.setHeaderComment(getComment());
             ini.store();
         }
         catch (IOException ioe)

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleOptionFileTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleOptionFileTask.java
@@ -116,7 +116,7 @@ public class SingleOptionFileTask extends ConfigFileTask
             }
             Options opts = (Options) configurable;
             opts.setFile(toFile);
-            opts.setComment(getComment());
+            opts.setHeaderComment(getComment());
             opts.store();
         }
         catch (IOException ioe)

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/BasicOptionMap.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/BasicOptionMap.java
@@ -280,7 +280,7 @@ public class BasicOptionMap extends CommonMultiMap<String, String> implements Op
         }
     }
 
-    private void requireArray(Class clazz)
+    private void requireArray(Class<? extends Object> clazz)
     {
         if (!clazz.isArray())
         {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/BasicProfile.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/BasicProfile.java
@@ -23,6 +23,7 @@ package com.izforge.izpack.util.config.base;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Proxy;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,7 +42,8 @@ public class BasicProfile extends CommonMultiMap<String, Profile.Section> implem
     private static final int G_OPTION = 5;
     private static final int G_OPTION_IDX = 7;
     private static final long serialVersionUID = -1817521505004015256L;
-    private String _comment;
+    private List<String> _comment;
+    private List<String> _footerComment;
     private final boolean _propertyFirstUpper;
     private final boolean _treeMode;
 
@@ -56,14 +58,24 @@ public class BasicProfile extends CommonMultiMap<String, Profile.Section> implem
         _propertyFirstUpper = propertyFirstUpper;
     }
 
-    @Override public String getComment()
+    @Override public List<String> getHeaderComment()
     {
         return _comment;
     }
 
-    @Override public void setComment(String value)
+    @Override public void setHeaderComment(List<String> value)
     {
         _comment = value;
+    }
+
+    @Override public List<String> getFooterComment()
+    {
+        return _footerComment;
+    }
+
+    @Override public void setFooterComment(List<String> value)
+    {
+        _footerComment = value;
     }
 
     @Override public Section add(String name)
@@ -207,10 +219,14 @@ public class BasicProfile extends CommonMultiMap<String, Profile.Section> implem
     void store(IniHandler formatter)
     {
         formatter.startIni();
-        store(formatter, getComment());
+        store(formatter, getHeaderComment());
         for (Ini.Section s : values())
         {
             store(formatter, s);
+        }
+        if (_footerComment != null)
+        {
+            store(formatter, _footerComment);
         }
 
         formatter.endIni();
@@ -218,7 +234,6 @@ public class BasicProfile extends CommonMultiMap<String, Profile.Section> implem
 
     void store(IniHandler formatter, Section s)
     {
-        store(formatter, getNewLineCount(s.getName()));
         store(formatter, getComment(s.getName()));
         formatter.startSection(s.getName());
         for (String name : s.keySet())
@@ -229,22 +244,13 @@ public class BasicProfile extends CommonMultiMap<String, Profile.Section> implem
         formatter.endSection();
     }
 
-    void store(IniHandler formatter, int emptyLines)
-    {
-        for (int i = 0; i < emptyLines; i++)
-        {
-            formatter.handleEmptyLine();
-        }
-    }
-
-    void store(IniHandler formatter, String comment)
+    void store(IniHandler formatter, List<String> comment)
     {
         formatter.handleComment(comment);
     }
 
     void store(IniHandler formatter, Section section, String option)
     {
-        store(formatter, section.getNewLineCount(option));
         store(formatter, section.getComment(option));
         int n = section.length(option);
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/CommentedMap.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/CommentedMap.java
@@ -21,15 +21,16 @@
  */
 package com.izforge.izpack.util.config.base;
 
+import java.util.List;
 import java.util.Map;
 
 public interface CommentedMap<K, V> extends Map<K, V>
 {
-    String getComment(Object key);
+    List<String> getComment(Object key);
 
-    String putComment(K key, String comment);
+    List<String> putComment(K key, List<String> comment);
 
-    String removeComment(Object key);
+    List<String> removeComment(Object key);
 
     int getNewLineCount(Object key);
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/CommonMultiMap.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/CommonMultiMap.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
  */
 package com.izforge.izpack.util.config.base;
 
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -52,10 +53,10 @@ public class CommonMultiMap<K, V> extends BasicMultiMap<K, V> implements Comment
         return (Integer) putMeta(META_NEWLINE_COUNT, key, Integer.valueOf(newLines.intValue()+1));
     }
 
-
-    @Override public String getComment(Object key)
+    @SuppressWarnings("unchecked")
+    @Override public List<String> getComment(Object key)
     {
-        return (String) getMeta(META_COMMENT, key);
+        return (List<String>) getMeta(META_COMMENT, key);
     }
 
     @Override public void clear()
@@ -83,9 +84,10 @@ public class CommonMultiMap<K, V> extends BasicMultiMap<K, V> implements Comment
         }
     }
 
-    @Override public String putComment(K key, String comment)
+    @SuppressWarnings("unchecked")
+    @Override public List<String> putComment(K key, List<String> comment)
     {
-        return (String) putMeta(META_COMMENT, key, comment);
+        return (List<String>) putMeta(META_COMMENT, key, comment);
     }
 
     @Override public V remove(Object key)
@@ -109,9 +111,10 @@ public class CommonMultiMap<K, V> extends BasicMultiMap<K, V> implements Comment
         return ret;
     }
 
-    @Override public String removeComment(Object key)
+    @SuppressWarnings("unchecked")
+    @Override public List<String> removeComment(Object key)
     {
-        return (String) removeMeta(META_COMMENT, key);
+        return (List<String>) removeMeta(META_COMMENT, key);
     }
 
     Object getMeta(String category, Object key)

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Config.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Config.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ package com.izforge.izpack.util.config.base;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 
-@SuppressWarnings("PMD.ExcessivePublicCount")
 public class Config implements Cloneable, Serializable
 {
     public static final String KEY_PREFIX = "org.ini4j.config.";
@@ -48,7 +47,6 @@ public class Config implements Cloneable, Serializable
     public static final String PROP_FILE_ENCODING = "fileEncoding";
     public static final String PROP_LINE_SEPARATOR = "lineSeparator";
     public static final String PROP_COMMENT = "comment";
-    public static final String PROP_HEADER_COMMENT = "headerComment";
     public static final String PROP_EMPTY_LINES = "emptyLines";
     public static final String PROP_AUTO_NUMBERING = "autoNumbering";
     public static final boolean DEFAULT_EMPTY_OPTION = false;
@@ -416,7 +414,6 @@ public class Config implements Cloneable, Serializable
         _lineSeparator = getString(PROP_LINE_SEPARATOR, DEFAULT_LINE_SEPARATOR);
         _fileEncoding = getCharset(PROP_FILE_ENCODING, DEFAULT_FILE_ENCODING);
         _comment = getBoolean(PROP_COMMENT, DEFAULT_COMMENT);
-        _headerComment = getBoolean(PROP_HEADER_COMMENT, DEFAULT_HEADER_COMMENT);
         _emptyLines = getBoolean(PROP_EMPTY_LINES, DEFAULT_EMPTY_LINES);
         _autoNumbering = getBoolean(PROP_AUTO_NUMBERING, DEFAULT_AUTO_NUMBERING);
     }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Options.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Options.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ package com.izforge.izpack.util.config.base;
 
 import java.io.*;
 import java.net.URL;
+import java.util.List;
 
 import com.izforge.izpack.util.config.base.spi.OptionsBuilder;
 import com.izforge.izpack.util.config.base.spi.OptionsFormatter;
@@ -32,7 +33,8 @@ import com.izforge.izpack.util.config.base.spi.OptionsParser;
 public class Options extends BasicOptionMap implements Persistable, Configurable
 {
     private static final long serialVersionUID = -1119753444859181822L;
-    private String _comment;
+    private List<String> _headerComment;
+    private List<String> _footerComment;
     private Config _config;
     private File _file;
 
@@ -72,14 +74,24 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
         load();
     }
 
-    public String getComment()
+    public List<String> getHeaderComment()
     {
-        return _comment;
+        return _headerComment;
     }
 
-    public void setComment(String value)
+    public void setHeaderComment(List<String> value)
     {
-        _comment = value;
+        _headerComment = value;
+    }
+
+    public List<String> getFooterComment()
+    {
+        return _footerComment;
+    }
+
+    public void setFooterComment(List<String> value)
+    {
+        _footerComment = value;
     }
 
     @Override public Config getConfig()
@@ -168,10 +180,10 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
     protected void store(OptionsHandler formatter) throws IOException
     {
         formatter.startOptions();
-        storeComment(formatter, _comment);
+        storeComment(formatter, _headerComment);
+
         for (String name : keySet())
         {
-            storeNewLines(formatter, getNewLineCount(name));
             storeComment(formatter, getComment(name));
             int n = getConfig().isMultiOption() || getConfig().isAutoNumbering() ? length(name) : 1;
 
@@ -192,6 +204,11 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
                 }
             }
         }
+        if (_footerComment != null)
+        {
+            formatter.handleEmptyLine();
+            storeComment(formatter, _footerComment);
+        }
 
         formatter.endOptions();
     }
@@ -201,32 +218,8 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
         return getConfig().isPropertyFirstUpper();
     }
 
-    private void storeNewLines(OptionsHandler formatter, int emptyLines)
-    {
-        for (int i = 0; i < emptyLines; i++)
-        {
-            formatter.handleEmptyLine();
-        }
-    }
-
-    private void storeComment(OptionsHandler formatter, String comment)
+    private void storeComment(OptionsHandler formatter, List<String> comment)
     {
         formatter.handleComment(comment);
     }
-
-//    public final static void main(String argv[])
-//    {
-//        Config.getGlobal().setHeaderComment(false);
-//        Config.getGlobal().setEmptyLines(true);
-//        Config.getGlobal().setAutoNumbering(true);
-//        try
-//        {
-//            Options options = new Options(new File("/home/rkrell/test/config_patch/test1/sm_server.wrapper.conf.old"));
-//            options.store(new File("/home/rkrell/test/config_patch/test1/sm_server.wrapper.conf.old.stored"));
-//        }
-//        catch (Exception e)
-//        {
-//            e.printStackTrace();
-//        }
-//    }
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Profile.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Profile.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,20 @@
  */
 package com.izforge.izpack.util.config.base;
 
+import java.util.List;
+
 
 public interface Profile extends MultiMap<String, Profile.Section>, CommentedMap<String, Profile.Section>
 {
     char PATH_SEPARATOR = '/';
 
-    String getComment();
+    List<String> getHeaderComment();
 
-    void setComment(String value);
+    void setHeaderComment(List<String> value);
+
+    List<String> getFooterComment();
+
+    void setFooterComment(List<String> value);
 
     Section add(String sectionName);
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/BeanTool.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/BeanTool.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -209,8 +209,7 @@ public class BeanTool
         return (T) o;
     }
 
-    @SuppressWarnings(Warnings.UNCHECKED)
-    protected Object parseSpecialValue(String value, Class clazz) throws IllegalArgumentException
+    protected <T> Object parseSpecialValue(String value, Class<T> clazz) throws IllegalArgumentException
     {
         Object o;
 
@@ -254,7 +253,7 @@ public class BeanTool
         return o;
     }
 
-    private PropertyDescriptor[] getPropertyDescriptors(Class clazz)
+    private <T> PropertyDescriptor[] getPropertyDescriptors(Class<T> clazz)
     {
         try
         {
@@ -266,7 +265,7 @@ public class BeanTool
         }
     }
 
-    private Object parsePrimitiveValue(String value, Class clazz) throws IllegalArgumentException
+    private <T> Object parsePrimitiveValue(String value, Class<T> clazz) throws IllegalArgumentException
     {
         Object o = null;
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/HandlerBase.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/HandlerBase.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,13 @@
 
 package com.izforge.izpack.util.config.base.spi;
 
+import java.util.List;
+
 interface HandlerBase
 {
     void handleEmptyLine();
 
-    void handleComment(String comment);
+    void handleComment(List<String> comment);
 
     void handleOption(String optionName, String optionValue);
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/IniFormatter.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/IniFormatter.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ public class IniFormatter extends AbstractFormatter implements IniHandler
 
     @Override public void startSection(String sectionName)
     {
-        setHeader(false);
         if (!getConfig().isGlobalSection() || !sectionName.equals(getConfig().getGlobalSectionName()))
         {
             getOutput().print(IniParser.SECTION_BEGIN);

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/IniHandler.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/IniHandler.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,15 @@
 
 package com.izforge.izpack.util.config.base.spi;
 
+import java.util.List;
+
 public interface IniHandler extends HandlerBase
 {
     void endIni();
 
     void endSection();
 
-    @Override void handleComment(String comment);
+    @Override void handleComment(List<String> comment);
 
     @Override void handleOption(String optionName, String optionValue);
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/IniSource.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/IniSource.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import java.io.InputStream;
 import java.io.LineNumberReader;
 import java.io.Reader;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.izforge.izpack.util.config.base.Config;
 
@@ -42,6 +44,7 @@ class IniSource
     private final Config _config;
     private final HandlerBase _handler;
     private final LineNumberReader _reader;
+    List<String> comments = new ArrayList<String>();
 
     IniSource(InputStream input, HandlerBase handler, String comments, Config config)
     {
@@ -121,14 +124,14 @@ class IniSource
         if (buff.length() != 0)
         {
             buff.deleteCharAt(buff.length() - 1);
-            _handler.handleComment(buff.toString());
+            comments.add(buff.toString());
             buff.delete(0, buff.length());
         }
     }
 
     private void handleEmptyLine()
     {
-        _handler.handleEmptyLine();
+        comments.add("\0");
     }
 
     private String handleInclude(String input) throws IOException
@@ -199,13 +202,10 @@ class IniSource
             line = line.trim();
             if (line.length() == 0)
             {
-                if (_config.isEmptyLines() && comment.length() == 0)
-                {
-                    handleEmptyLine();
-                }
-                else
+                if (_config.isEmptyLines())
                 {
                     handleComment(comment);
+                    handleEmptyLine();
                 }
             }
             else if ((_commentChars.indexOf(line.charAt(0)) >= 0) && (buff.length() == 0))
@@ -233,6 +233,9 @@ class IniSource
         {
             handleComment(comment);
         }
+
+        _handler.handleComment(comments);
+        comments.clear();
 
         return line;
     }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/OptionsHandler.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/OptionsHandler.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,13 @@
 
 package com.izforge.izpack.util.config.base.spi;
 
+import java.util.List;
+
 public interface OptionsHandler extends HandlerBase
 {
     void endOptions();
 
-    @Override void handleComment(String comment);
+    @Override void handleComment(List<String> comment);
 
     @Override void handleOption(String optionName, String optionValue);
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/RegBuilder.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/RegBuilder.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2014 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,11 +45,6 @@ public class RegBuilder extends AbstractProfileBuilder
     public void setReg(Reg value)
     {
         _reg = value;
-    }
-
-    @Override public void handleEmptyLine()
-    {
-        // do nothing on empty lines for registry
     }
 
     @Override public void handleOption(String rawName, String rawValue)

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/TypeValuesPair.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/TypeValuesPair.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2011 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ public class TypeValuesPair
     private final Type _type;
     private final String[] _values;
 
-    @SuppressWarnings("PMD.ArrayIsStoredDirectly")
     public TypeValuesPair(Type type, String[] values)
     {
         _type = type;

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/UnicodeInputStreamReader.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/UnicodeInputStreamReader.java
@@ -5,7 +5,7 @@
  * http://izpack.codehaus.org/
  *
  * Copyright 2005,2009 Ivan SZKIBA
- * Copyright 2010,2011 Rene Krell
+ * Copyright 2010,2011 René Krell
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ class UnicodeInputStreamReader extends Reader
         private final byte[] _bytes;
         private Charset _charset;
 
-        @SuppressWarnings("PMD.ArrayIsStoredDirectly")
         private Bom(String charsetName, byte[] bytes)
         {
             try

--- a/izpack-util/src/test/java/com/izforge/izpack/util/config/SingleConfigurableTaskTest.java
+++ b/izpack-util/src/test/java/com/izforge/izpack/util/config/SingleConfigurableTaskTest.java
@@ -1,0 +1,167 @@
+package com.izforge.izpack.util.config;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SingleConfigurableTaskTest
+{
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+//    @Test
+//    public void testPropertiesCommentsAtEnd() throws IOException
+//    {
+//        SingleOptionFileTask task = new SingleOptionFileTask();
+//
+//        URL oldFileUrl = getClass().getResource("oldversion.properties");
+//        URL newFileUrl = getClass().getResource("newversion.properties");
+//        URL expectedFileUrl = getClass().getResource("expected_after_merge.properties");
+//        assertNotNull("Old file missing", oldFileUrl);
+//        assertNotNull("New file missing", newFileUrl);
+//        assertNotNull("Expected result file missing", expectedFileUrl);
+//
+//        File oldFile = new File(oldFileUrl.getFile());
+//        File newFile = new File(newFileUrl.getFile());
+//        File expectedFile = new File(expectedFileUrl.getFile());
+//        File toFile = tmpDir.newFile("to.properties");
+//
+//        task.setToFile(toFile);
+//        task.setOldFile(oldFile);
+//        task.setNewFile(newFile);
+//        task.setCleanup(false);
+//        task.setCreate(true);
+//        task.setPatchPreserveEntries(false);
+//        task.setPatchPreserveValues(true);
+//        task.setPatchResolveVariables(false);
+//        task.setOperator("=");
+//
+//        try
+//        {
+//            task.execute();
+//        }
+//        catch (Exception e)
+//        {
+//            fail("Task could not be executed: " + e.getMessage());
+//        }
+//
+//        printFileContent(toFile);
+//        printFileContent(expectedFile);
+//        assertEquals(FileUtils.contentEqualsIgnoreEOL(expectedFile, toFile, "ISO-8859-1"), true);
+//    }
+//
+//    @Test
+//    public void testWrapperCommentsAtEnd() throws IOException
+//    {
+//        SingleOptionFileTask task = new SingleOptionFileTask();
+//
+//        URL oldFileUrl = getClass().getResource("oldversion.wrapper.conf");
+//        URL newFileUrl = getClass().getResource("newversion.wrapper.conf");
+//        URL expectedFileUrl = getClass().getResource("expected_after_merge.wrapper.conf");
+//        assertNotNull("Old file missing", oldFileUrl);
+//        assertNotNull("New file missing", newFileUrl);
+//        assertNotNull("Expected result file missing", expectedFileUrl);
+//
+//        File oldFile = new File(oldFileUrl.getFile());
+//        File newFile = new File(newFileUrl.getFile());
+//        File expectedFile = new File(expectedFileUrl.getFile());
+//        File toFile = tmpDir.newFile("to.wrapper.conf");
+//
+//        task.setToFile(toFile);
+//        task.setOldFile(oldFile);
+//        task.setNewFile(newFile);
+//        task.setCleanup(false);
+//        task.setCreate(true);
+//        task.setPatchPreserveEntries(false);
+//        task.setPatchPreserveValues(true);
+//        task.setPatchResolveVariables(false);
+//        task.setOperator("=");
+//        task.setEncoding(Charset.forName("UTF-8"));
+//        task.setHeaderComment(true);
+//
+//        try
+//        {
+//            task.execute();
+//        }
+//        catch (Exception e)
+//        {
+//            e.printStackTrace();
+//            fail("Task could not be executed: " + e.getMessage());
+//        }
+//
+//        printFileContent(toFile);
+//        printFileContent(expectedFile);
+//        assertEquals(FileUtils.contentEqualsIgnoreEOL(expectedFile, toFile, "UTF-8"), true);
+//    }
+
+    @Test
+    public void testIniCommentsAtEnd() throws IOException
+    {
+        SingleIniFileTask task = new SingleIniFileTask();
+
+        URL oldFileUrl = getClass().getResource("oldversion.ini");
+        URL newFileUrl = getClass().getResource("newversion.ini");
+        URL expectedFileUrl = getClass().getResource("expected_after_merge.ini");
+        assertNotNull("Old file missing", oldFileUrl);
+        assertNotNull("New file missing", newFileUrl);
+        assertNotNull("Expected result file missing", expectedFileUrl);
+
+        File oldFile = new File(oldFileUrl.getFile());
+        File newFile = new File(newFileUrl.getFile());
+        File expectedFile = new File(expectedFileUrl.getFile());
+        File toFile = tmpDir.newFile("to.ini");
+
+        task.setToFile(toFile);
+        task.setOldFile(oldFile);
+        task.setNewFile(newFile);
+        task.setCleanup(false);
+        task.setCreate(true);
+        task.setPatchPreserveEntries(false);
+        task.setPatchPreserveValues(true);
+        task.setPatchResolveVariables(false);
+
+        try
+        {
+            task.execute();
+        }
+        catch (Exception e)
+        {
+            fail("Task could not be executed: " + e.getMessage());
+        }
+
+        printFileContent(toFile);
+        printFileContent(expectedFile);
+        assertEquals(FileUtils.contentEqualsIgnoreEOL(expectedFile, toFile, "ISO-8859-1"), true);
+    }
+
+    private void printFileContent(File file)
+    {
+        BufferedReader br;
+
+        System.out.println();
+        System.out.println("+++ " + file + " +++");
+        try
+        {
+            br = new BufferedReader(new FileReader(file));
+            String line = null;
+            while ((line = br.readLine()) != null)
+            {
+                System.out.println(line);
+            }
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+        }
+    }
+}

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/expected_after_merge.ini
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/expected_after_merge.ini
@@ -1,0 +1,10 @@
+[section1]
+# country mapping
+lang.1.key=de
+lang.2.key=en
+lang.3.key=it
+
+
+# additional countries
+#lang.4.key=at
+#lang.5.key=cs

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/expected_after_merge.properties
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/expected_after_merge.properties
@@ -1,0 +1,8 @@
+# country mapping
+lang.1.key=de
+lang.2.key=en
+lang.3.key=it
+
+# additional countries
+#lang.4.key=at
+#lang.5.key=cs

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/expected_after_merge.wrapper.conf
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/expected_after_merge.wrapper.conf
@@ -1,0 +1,106 @@
+#encoding=UTF-8
+#********************************************************************
+#Wrapper Properties
+#********************************************************************
+
+wrapper.working.dir=%WRAPPER_BIN_DIR%/../../
+
+#include ../../conf/wrapper-license.conf
+
+#Java Application
+set.JAVA_HOME=${wrapper.java.home}
+wrapper.java.command=%JAVA_HOME%/bin/java
+
+#Java Main class.  This class must implement the WrapperListener interface
+#or guarantee that the WrapperManager class is initialized.  Helper
+#classes are provided to do this for you.  See the Integration section
+#of the documentation for details.
+wrapper.java.mainclass=my.application.ApplicationJSW
+
+#Java Classpath (include wrapper.jar)  Add class path elements as
+#needed starting from 1
+#Work directory is where wrapper executable is situated
+wrapper.java.classpath.1=lib/wrapper/*.jar
+wrapper.java.classpath.2=lib/shared/*.jar
+wrapper.java.classpath.3=lib/server/*.jar
+
+#Java Library Path (location of Wrapper.DLL or libwrapper.so)
+wrapper.java.library.path.1=%WRAPPER_BIN_DIR%
+
+#Java Additional Parameters
+wrapper.java.additional.1=-Dlog4j.configuration=file:config/log4j.xml
+wrapper.java.additional.2=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.3=-Djava.io.tmpdir=temp
+
+#Initial Java Heap Size (in MB)
+wrapper.java.initmemory=256
+wrapper.java.maxmemory=2048
+
+#Application parameters.  Add parameters as needed starting from 1
+wrapper.app.parameter.1=-Dstdin.commands=false
+
+#********************************************************************
+#Wrapper Logging Properties
+#********************************************************************
+#Format of output for the console.  (See docs for formats)
+wrapper.console.format=PM
+
+#Log Level for console output.  (See docs for log levels)
+wrapper.console.loglevel=INFO
+
+#Log file to use for wrapper output logging.
+
+wrapper.logfile=log/app_wrapper.log
+#Format of output for the log file.  (See docs for formats)
+wrapper.logfile.format=LPTM
+
+#Log Level for log file output.  (See docs for log levels)
+wrapper.logfile.loglevel=INFO
+
+#Maximum size that the log file will be allowed to grow to before
+#the log is rolled. Size is specified in bytes.  The default value
+#of 0, disables log rolling.  May abbreviate with the 'k' (kb) or
+#'m' (mb) suffix.  For example: 10m = 10 megabytes.
+wrapper.logfile.maxsize=4m
+
+#Maximum number of rolled log files which will be allowed before old
+#files are deleted.  The default value of 0 implies no limit.
+wrapper.logfile.maxfiles=10
+
+#Log Level for sys/event log output.  (See docs for log levels)
+wrapper.syslog.loglevel=NONE
+
+#Number of seconds to allow between the time that the Wrapper launches
+#the JVM process and the time that the JVM side of the Wrapper responds
+#that the application has started. 0 means never time out. Defaults to 30 seconds.
+wrapper.startup.timeout=600
+
+#********************************************************************
+#Wrapper NT Service Properties
+#********************************************************************
+#WARNING - Do not modify any of these properties when an application
+#using this configuration file has been installed as a service.
+#Please uninstall the service before modifying this section.  The
+#service can then be reinstalled.
+
+#Name of the service
+wrapper.ntservice.name=${service.name}
+
+#Display name of the service
+wrapper.ntservice.displayname=${service.description.short}
+
+#Description of the service
+wrapper.ntservice.description=${service.description.long}
+
+#Service dependencies.  Add dependencies as needed starting from 1
+wrapper.ntservice.dependency.1=Tcpip
+
+#Mode in which the service is installed.  AUTO_START or DEMAND_START
+wrapper.ntservice.starttype=AUTO_START
+
+#Allow the service to interact with the desktop.
+wrapper.ntservice.interactive=false
+
+#Automatic restart on System.exit(n!=0)
+wrapper.on_exit.default=RESTART
+wrapper.on_exit.0=SHUTDOWN

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/newversion.ini
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/newversion.ini
@@ -1,0 +1,9 @@
+[section1]
+# country mapping
+lang.1.key=de
+lang.2.key=en
+lang.3.key=it
+
+# additional countries
+#lang.4.key=at
+#lang.5.key=cs

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/newversion.properties
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/newversion.properties
@@ -1,0 +1,8 @@
+# country mapping
+lang.1.key=de
+lang.2.key=en
+lang.3.key=it
+
+# additional countries
+#lang.4.key=at
+#lang.5.key=cs

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/newversion.wrapper.conf
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/newversion.wrapper.conf
@@ -1,0 +1,106 @@
+#encoding=UTF-8
+#********************************************************************
+#Wrapper Properties
+#********************************************************************
+
+wrapper.working.dir=%WRAPPER_BIN_DIR%/../../
+
+#include ../../conf/wrapper-license.conf
+
+#Java Application
+set.JAVA_HOME=${wrapper.java.home}
+wrapper.java.command=%JAVA_HOME%/bin/java
+
+#Java Main class.  This class must implement the WrapperListener interface
+#or guarantee that the WrapperManager class is initialized.  Helper
+#classes are provided to do this for you.  See the Integration section
+#of the documentation for details.
+wrapper.java.mainclass=my.application.ApplicationJSW
+
+#Java Classpath (include wrapper.jar)  Add class path elements as
+#needed starting from 1
+#Work directory is where wrapper executable is situated
+wrapper.java.classpath.1=lib/wrapper/*.jar
+wrapper.java.classpath.2=lib/shared/*.jar
+wrapper.java.classpath.3=lib/server/*.jar
+
+#Java Library Path (location of Wrapper.DLL or libwrapper.so)
+wrapper.java.library.path.1=%WRAPPER_BIN_DIR%
+
+#Java Additional Parameters
+wrapper.java.additional.1=-Dlog4j.configuration=file:config/log4j.xml
+wrapper.java.additional.2=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.3=-Djava.io.tmpdir=temp
+
+#Initial Java Heap Size (in MB)
+wrapper.java.initmemory=256
+wrapper.java.maxmemory=2048
+
+#Application parameters.  Add parameters as needed starting from 1
+wrapper.app.parameter.1=-Dstdin.commands=false
+
+#********************************************************************
+#Wrapper Logging Properties
+#********************************************************************
+#Format of output for the console.  (See docs for formats)
+wrapper.console.format=PM
+
+#Log Level for console output.  (See docs for log levels)
+wrapper.console.loglevel=INFO
+
+#Log file to use for wrapper output logging.
+
+wrapper.logfile=log/app_wrapper.log
+#Format of output for the log file.  (See docs for formats)
+wrapper.logfile.format=LPTM
+
+#Log Level for log file output.  (See docs for log levels)
+wrapper.logfile.loglevel=INFO
+
+#Maximum size that the log file will be allowed to grow to before
+#the log is rolled. Size is specified in bytes.  The default value
+#of 0, disables log rolling.  May abbreviate with the 'k' (kb) or
+#'m' (mb) suffix.  For example: 10m = 10 megabytes.
+wrapper.logfile.maxsize=4m
+
+#Maximum number of rolled log files which will be allowed before old
+#files are deleted.  The default value of 0 implies no limit.
+wrapper.logfile.maxfiles=10
+
+#Log Level for sys/event log output.  (See docs for log levels)
+wrapper.syslog.loglevel=NONE
+
+#Number of seconds to allow between the time that the Wrapper launches
+#the JVM process and the time that the JVM side of the Wrapper responds
+#that the application has started. 0 means never time out. Defaults to 30 seconds.
+wrapper.startup.timeout=600
+
+#********************************************************************
+#Wrapper NT Service Properties
+#********************************************************************
+#WARNING - Do not modify any of these properties when an application
+#using this configuration file has been installed as a service.
+#Please uninstall the service before modifying this section.  The
+#service can then be reinstalled.
+
+#Name of the service
+wrapper.ntservice.name=${service.name}
+
+#Display name of the service
+wrapper.ntservice.displayname=${service.description.short}
+
+#Description of the service
+wrapper.ntservice.description=${service.description.long}
+
+#Service dependencies.  Add dependencies as needed starting from 1
+wrapper.ntservice.dependency.1=Tcpip
+
+#Mode in which the service is installed.  AUTO_START or DEMAND_START
+wrapper.ntservice.starttype=AUTO_START
+
+#Allow the service to interact with the desktop.
+wrapper.ntservice.interactive=false
+
+#Automatic restart on System.exit(n!=0)
+wrapper.on_exit.default=RESTART
+wrapper.on_exit.0=SHUTDOWN

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/oldversion.ini
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/oldversion.ini
@@ -1,0 +1,9 @@
+[section1]
+# country mapping
+lang.1.key=de
+lang.2.key=en
+lang.3.key=it
+
+# additional countries
+#lang.4.key=at
+#lang.5.key=cs

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/oldversion.properties
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/oldversion.properties
@@ -1,0 +1,8 @@
+# country mapping
+lang.1.key=de
+lang.2.key=en
+lang.3.key=it
+
+# additional countries
+#lang.4.key=at
+#lang.5.key=cs

--- a/izpack-util/src/test/resources/com/izforge/izpack/util/config/oldversion.wrapper.conf
+++ b/izpack-util/src/test/resources/com/izforge/izpack/util/config/oldversion.wrapper.conf
@@ -1,0 +1,106 @@
+#encoding=UTF-8
+#********************************************************************
+#Wrapper Properties
+#********************************************************************
+
+wrapper.working.dir=%WRAPPER_BIN_DIR%/../../
+
+#include ../../conf/wrapper-license.conf
+
+#Java Application
+set.JAVA_HOME=${wrapper.java.home}
+wrapper.java.command=%JAVA_HOME%/bin/java
+
+#Java Main class.  This class must implement the WrapperListener interface
+#or guarantee that the WrapperManager class is initialized.  Helper
+#classes are provided to do this for you.  See the Integration section
+#of the documentation for details.
+wrapper.java.mainclass=my.application.ApplicationJSW
+
+#Java Classpath (include wrapper.jar)  Add class path elements as
+#needed starting from 1
+#Work directory is where wrapper executable is situated
+wrapper.java.classpath.1=lib/wrapper/*.jar
+wrapper.java.classpath.2=lib/shared/*.jar
+wrapper.java.classpath.3=lib/server/*.jar
+
+#Java Library Path (location of Wrapper.DLL or libwrapper.so)
+wrapper.java.library.path.1=%WRAPPER_BIN_DIR%
+
+#Java Additional Parameters
+wrapper.java.additional.1=-Dlog4j.configuration=file:config/log4j.xml
+wrapper.java.additional.2=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.3=-Djava.io.tmpdir=temp
+
+#Initial Java Heap Size (in MB)
+wrapper.java.initmemory=256
+wrapper.java.maxmemory=2048
+
+#Application parameters.  Add parameters as needed starting from 1
+wrapper.app.parameter.1=-Dstdin.commands=false
+
+#********************************************************************
+#Wrapper Logging Properties
+#********************************************************************
+#Format of output for the console.  (See docs for formats)
+wrapper.console.format=PM
+
+#Log Level for console output.  (See docs for log levels)
+wrapper.console.loglevel=INFO
+
+#Log file to use for wrapper output logging.
+
+wrapper.logfile=log/app_wrapper.log
+#Format of output for the log file.  (See docs for formats)
+wrapper.logfile.format=LPTM
+
+#Log Level for log file output.  (See docs for log levels)
+wrapper.logfile.loglevel=INFO
+
+#Maximum size that the log file will be allowed to grow to before
+#the log is rolled. Size is specified in bytes.  The default value
+#of 0, disables log rolling.  May abbreviate with the 'k' (kb) or
+#'m' (mb) suffix.  For example: 10m = 10 megabytes.
+wrapper.logfile.maxsize=4m
+
+#Maximum number of rolled log files which will be allowed before old
+#files are deleted.  The default value of 0 implies no limit.
+wrapper.logfile.maxfiles=10
+
+#Log Level for sys/event log output.  (See docs for log levels)
+wrapper.syslog.loglevel=NONE
+
+#Number of seconds to allow between the time that the Wrapper launches
+#the JVM process and the time that the JVM side of the Wrapper responds
+#that the application has started. 0 means never time out. Defaults to 30 seconds.
+wrapper.startup.timeout=600
+
+#********************************************************************
+#Wrapper NT Service Properties
+#********************************************************************
+#WARNING - Do not modify any of these properties when an application
+#using this configuration file has been installed as a service.
+#Please uninstall the service before modifying this section.  The
+#service can then be reinstalled.
+
+#Name of the service
+wrapper.ntservice.name=${service.name}
+
+#Display name of the service
+wrapper.ntservice.displayname=${service.description.short}
+
+#Description of the service
+wrapper.ntservice.description=${service.description.long}
+
+#Service dependencies.  Add dependencies as needed starting from 1
+wrapper.ntservice.dependency.1=Tcpip
+
+#Mode in which the service is installed.  AUTO_START or DEMAND_START
+wrapper.ntservice.starttype=AUTO_START
+
+#Allow the service to interact with the desktop.
+wrapper.ntservice.interactive=false
+
+#Automatic restart on System.exit(n!=0)
+wrapper.on_exit.default=RESTART
+wrapper.on_exit.0=SHUTDOWN


### PR DESCRIPTION
During merging configuration using the ConfigurationInstallerListener, there get lost footer comments not followed by another uncommented key-pair value.

This affects Windows INI files and option files, like Java Service Wrapper configurations and property files.

Added also a unit test for this with several file types.

Additionally fixed all compiler warnings in the appropriate utils.
