### PR TITLE
[IZPACK-794] Pressing "Generating automatic installation script" throws java.lang.NoClassDefFoundError: com/izforge/izpack/panels/imgpacks/ImgPacksPanelAutomationHelper

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -44,8 +44,8 @@ import com.izforge.izpack.installer.gui.InstallerFrame;
 import com.izforge.izpack.installer.gui.IzPanel;
 import com.izforge.izpack.installer.util.PackHelper;
 import com.izforge.izpack.installer.web.WebAccessor;
-import com.izforge.izpack.panels.imgpacks.ImgPacksPanelAutomationHelper;
 import com.izforge.izpack.panels.packs.PacksModel;
+import com.izforge.izpack.panels.packs.PacksPanelAutomationHelper;
 import com.izforge.izpack.util.IoHelper;
 import com.izforge.izpack.util.file.FileUtils;
 
@@ -345,7 +345,7 @@ public class TreePacksPanel extends IzPanel
     @Override
     public void createInstallationRecord(IXMLElement panelRoot)
     {
-        new ImgPacksPanelAutomationHelper().createInstallationRecord(this.installData, panelRoot);
+        new PacksPanelAutomationHelper().createInstallationRecord(this.installData, panelRoot);
     }
 
 


### PR DESCRIPTION
Post-fix for TreePacksPanel and the following stacktrace (reported by mail):

```
Exception in thread "AWT-EventQueue-0" java.lang.NoClassDefFoundError: com/izforge/izpack/panels/imgpacks/ImgPacksPanelAutomationHelper
        at com.izforge.izpack.panels.packs.PacksPanelBase.makeXMLData(PacksPanelBase.java:322)
        at com.izforge.izpack.installer.base.InstallerFrame.writeXMLTree(InstallerFrame.java:868)
        at com.izforge.izpack.panels.finish.FinishPanel.actionPerformed(FinishPanel.java:173)
        at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1995)
        at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2318)
        at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:387)
        at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:242)
        at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:236)
        at java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:272)
        at java.awt.Component.processMouseEvent(Component.java:6290)
        at javax.swing.JComponent.processMouseEvent(JComponent.java:3267)
        at java.awt.Component.processEvent(Component.java:6055)
        at java.awt.Container.processEvent(Container.java:2039)
        at java.awt.Component.dispatchEventImpl(Component.java:4653)
        at java.awt.Container.dispatchEventImpl(Container.java:2097)
        at java.awt.Component.dispatchEvent(Component.java:4481)
        at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4575)
        at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4236)
        at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4166)
        at java.awt.Container.dispatchEventImpl(Container.java:2083)
        at java.awt.Window.dispatchEventImpl(Window.java:2482)
        at java.awt.Component.dispatchEvent(Component.java:4481)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:648)
        at java.awt.EventQueue.access$000(EventQueue.java:84)
        at java.awt.EventQueue$1.run(EventQueue.java:607)
        at java.awt.EventQueue$1.run(EventQueue.java:605)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
        at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:98)
        at java.awt.EventQueue$2.run(EventQueue.java:621)
        at java.awt.EventQueue$2.run(EventQueue.java:619)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:618)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:269)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:184)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:174)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:169)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:161)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:122)
Caused by: java.lang.ClassNotFoundException: com.izforge.izpack.panels.imgpacks.ImgPacksPanelAutomationHelper
        at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:301)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
        ... 40 more
```
