### PR TITLE
proposed fix for IZPACK-1129  Unattended install still prompts user for decision on overriding files

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
@@ -163,19 +163,10 @@ public class ConsolePrompt extends AbstractPrompt
         }
         else
         {
-            String defaultValue = no;
+        	result = Option.NO;
             if (defaultOption != null && defaultOption == Option.YES)
             {
-                defaultValue = yes;
-            }
-            String selected = console.prompt(yesNoPrompt, new String[]{yes, no}, defaultValue);
-            if (yes.equals(selected))
-            {
-                result = Option.YES;
-            }
-            else
-            {
-                result = Option.NO;
+            	 result = Option.YES;
             }
         }
         return result;


### PR DESCRIPTION
when override pack parameter is set to asktrue or askfalse when running unattended installer, don't prompt for override confirmation (IZPACK-1129 - Unattended install still prompts user for decision on overriding files)
