### PR TITLE
[IZPACK-1132] - Infinite loop fix

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -52,6 +52,8 @@
          txt="Please enter a number from the selection above."/>
     <str id="TreePacksPanel.required"
          txt="Required"/>
+    <str id="TreePacksPanel.unselectable"
+         txt="Unselectable"/>
     <str id="TreePacksPanel.done"
          txt="Done!"/>
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModel.java
@@ -243,19 +243,37 @@ public class PacksModel extends AbstractTableModel
                         logger.fine(packName + " can be installed optionally.");
                         if (initial)
                         {
-                            checkValues[pos] = DESELECTED;
-                            changes = true;
+                            if (checkValues[pos] != DESELECTED)
+                            {
+                                checkValues[pos] = DESELECTED;
+                                changes = true;
+                            }
                         }
                     }
                     else
                     {
-                        logger.fine("Pack" + packName + " cannot be installed");
-                        checkValues[pos] = DEPENDENT_DESELECTED;
-                        changes = true;
+                        if (checkValues[pos] != DEPENDENT_DESELECTED)
+                        {
+                            logger.fine("Pack" + packName + " cannot be installed");
+                            checkValues[pos] = DEPENDENT_DESELECTED;
+                            changes = true;
+                        }
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Ensure that the table is up to date.
+     * Order does matter
+     */
+    public void updateTable()
+    {
+        updateDeps();
+        updateConditions();
+        updatePacksToInstall();
+        fireTableDataChanged();
     }
 
     /**
@@ -682,7 +700,7 @@ public class PacksModel extends AbstractTableModel
             }
             else if (installedPacks.containsKey(pack.getName()))
             {
-                checkValues[i] = -3;
+                checkValues[i] = REQUIRED_PARTIAL_SELECTED;
             }
         }
 
@@ -718,11 +736,11 @@ public class PacksModel extends AbstractTableModel
         {
             if (statusArray[i] == 0 && checkValues[i] < 0)
             {
-                checkValues[i] += 2;
+                checkValues[i] += PARTIAL_SELECTED;
             }
             if (statusArray[i] == 1 && checkValues[i] >= 0)
             {
-                checkValues[i] = -2;
+                checkValues[i] = DEPENDENT_DESELECTED;
             }
 
         }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModelGUI.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModelGUI.java
@@ -57,12 +57,6 @@ public class PacksModelGUI extends PacksModel
             panel.showSpaceRequired();
 
         }
-        System.out.println("====================== CHECK VALUES ============================");
-        for (int i=0; i<packs.size(); i++)
-        {
-            System.out.println(packs.get(i).getName() + ": " + checkValues[i]);
-        }
-        System.out.println("====================== CHECK VALUES ============================");
     }
 
     private void updateBytes()

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/CheckBoxNodeRenderer.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/CheckBoxNodeRenderer.java
@@ -66,7 +66,7 @@ class CheckBoxNodeRenderer implements TreeCellRenderer
                                                   boolean selected, boolean expanded, boolean leaf, int row,
                                                   boolean hasFocus)
     {
-        treePacksPanel.updateViewFromModel();
+        treePacksPanel.updateViewFromModel(tree);
 
         if (selected)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksConsolePanel.java
@@ -56,6 +56,7 @@ public class TreePacksConsolePanel extends AbstractConsolePanel implements Conso
 
 
     private static final String REQUIRED = "TreePacksPanel.required";
+    private static final String UNSELECTABLE = "TreePacksPanel.unselectable";
     private static final String DEPENDENT = "TreePacksPanel.dependent";
     private static final String CHILDREN = "TreePacksPanel.children";
 
@@ -258,6 +259,11 @@ public class TreePacksConsolePanel extends AbstractConsolePanel implements Conso
         {
             extraRow = extraRow + String.format("\n      >> %s", messages.get(REQUIRED));
         }
+        else if(!packsModel.isCheckBoxSelectable(row))
+        {
+            extraRow = extraRow + String.format("\n      >> %s", messages.get(UNSELECTABLE));
+        }
+
         if (!dependencies.isEmpty())
         {
             extraRow = extraRow + String.format("\n      >> %s", dependencies);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -374,7 +374,7 @@ public class TreePacksPanel extends IzPanel
     /**
      * Synchronize the view with the PacksModel data.
      */
-    public void updateViewFromModel()
+    public void updateViewFromModel(JTree tree)
     {
         TreeModel model = this.packsTree.getModel();
         CheckBoxNode root = (CheckBoxNode) model.getRoot();
@@ -383,6 +383,7 @@ public class TreePacksPanel extends IzPanel
         updateRequiredSpaceLabel();
         showFreeSpace();
         syncPackSizes();
+        tree.treeDidChange();
     }
 
     /**
@@ -613,7 +614,8 @@ public class TreePacksPanel extends IzPanel
     @Override
     public void panelActivate()
     {
-        updateViewFromModel();
+        packsModel.updateTable();
+        updateViewFromModel(getTree());
     }
 
     /*
@@ -763,8 +765,7 @@ class CheckTreeController extends MouseAdapter
         }
 
         treePacksPanel.setModelValue(selectedNode);
-        treePacksPanel.updateViewFromModel();
-        tree.treeDidChange();
+        treePacksPanel.updateViewFromModel(tree);
     }
 
     /**


### PR DESCRIPTION
This is to address http://jira.codehaus.org/browse/IZPACK-1132
1. Fix infinite loop by adding checks

```
   if (initial)
    {
        if (checkValues[pos] != DESELECTED)
        {
            checkValues[pos] = DESELECTED;
            changes = true;
        }
    }
...
    if (checkValues[pos] != DEPENDENT_DESELECTED)
    {
        logger.fine("Pack" + packName + " cannot be installed");
        checkValues[pos] = DEPENDENT_DESELECTED;
        changes = true;
    }
```

2. Ensure TreePacksPanel upates JTree to latest information on activation
3. Add helper text to TreePacksConsolePanel to inform user when a pack is unselectable. (Not required and condition evaluates to false)
