### PR TITLE
[IZPACK-1137] Variables not resolved in default values and labels of user input fields

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
@@ -30,6 +30,7 @@ import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.util.HyperlinkHandler;
 
 import javax.swing.*;
+
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -163,6 +164,22 @@ public abstract class GUIField extends AbstractFieldView
     protected void addComponent(JComponent component, Object constraints)
     {
         components.add(new Component(component, constraints));
+    }
+
+    /**
+     * Refresh JLabel texts to replace variables
+     */
+    protected void refreshStaticText()
+    {
+        for (Component c : components)
+        {
+            JComponent jc = c.getComponent();
+            if (jc instanceof JTextPane)
+            {
+                JTextPane pane = (JTextPane)jc;
+                pane.setText(replaceVariables(pane.getText()));
+            }
+        }
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/AbstractGUIFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/AbstractGUIFileField.java
@@ -25,6 +25,7 @@ import java.io.File;
 
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
+import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.panels.userinput.field.file.AbstractFileField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
@@ -98,6 +99,16 @@ public abstract class AbstractGUIFileField extends GUIField
         {
             fileInput.setFile(value);
             result = true;
+        }
+        else
+        {
+            // Set default value here for getting current variable values replaced
+            Field field = getField();
+            String defaultValue = field.getDefaultValue();
+            if (defaultValue != null)
+            {
+                fileInput.setFile(defaultValue);
+            }
         }
 
         return result;

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/DirInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/DirInputField.java
@@ -27,8 +27,6 @@ import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.IzPanel;
 import com.izforge.izpack.panels.userinput.field.file.DirFieldView;
 
-import java.io.Serializable;
-
 public class DirInputField extends FileInputField
 {
     private static final long serialVersionUID = 8494549823214831160L;

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/FileInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/FileInputField.java
@@ -143,7 +143,7 @@ public class FileInputField extends JPanel implements ActionListener
     private void initialize()
     {
         int size = field.getSize() < 0 ? 0 : field.getSize();
-        filetxt = new JTextField(field.getDefaultValue(), size);
+        filetxt = new JTextField(size);
         filetxt.setName(field.getVariable());
         filetxt.setCaretPosition(0);
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/GUIMultipleFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/GUIMultipleFileField.java
@@ -25,6 +25,7 @@ import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
+import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.panels.userinput.field.file.MultipleFileField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
@@ -102,38 +103,53 @@ public class GUIMultipleFileField extends GUIField
 
         if (value != null)
         {
-            fileInput.clearFiles();
-            if (fileInput.isCreateMultipleVariables())
-            {
-                fileInput.addFile(value);
-                // try to read more files
-                String basevariable = getVariable();
-                int index = 1;
-
-                while (value != null)
-                {
-                    StringBuilder builder = new StringBuilder(basevariable);
-                    builder.append("_");
-                    builder.append(index++);
-                    value = getInstallData().getVariable(builder.toString());
-                    if (value != null)
-                    {
-                        fileInput.addFile(value);
-                    }
-                }
-            }
-            else
-            {
-                // split file string
-                String[] files = value.split(";");
-                for (String file : files)
-                {
-                    fileInput.addFile(file);
-                }
-            }
+            splitValue(value);
             result = true;
         }
+        else
+        {
+            // Set default value here for getting current variable values replaced
+            Field field = getField();
+            String defaultValue = field.getDefaultValue();
+            if (defaultValue != null)
+            {
+                splitValue(defaultValue);
+            }
+        }
         return result;
+    }
+
+    private void splitValue(String value)
+    {
+        fileInput.clearFiles();
+        if (fileInput.isCreateMultipleVariables())
+        {
+            fileInput.addFile(value);
+            // try to read more files
+            String basevariable = getVariable();
+            int index = 1;
+
+            while (value != null)
+            {
+                StringBuilder builder = new StringBuilder(basevariable);
+                builder.append("_");
+                builder.append(index++);
+                value = getInstallData().getVariable(builder.toString());
+                if (value != null)
+                {
+                    fileInput.addFile(value);
+                }
+            }
+        }
+        else
+        {
+            // split file string
+            String[] files = value.split(";");
+            for (String file : files)
+            {
+                fileInput.addFile(file);
+            }
+        }
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/password/GUIPasswordGroupField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/password/GUIPasswordGroupField.java
@@ -30,6 +30,7 @@ import com.izforge.izpack.panels.userinput.field.password.PasswordGroupField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
 import javax.swing.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -122,6 +123,17 @@ public class GUIPasswordGroupField extends GUIField
             passwords.get(0).setText(replaceVariables(value));
             result = true;
         }
+        else
+        {
+            // Set default value here for getting current variable values replaced
+            Field field = getField();
+            String defaultValue = field.getDefaultValue();
+            if (defaultValue != null)
+            {
+                passwords.get(0).setText(defaultValue);
+            }
+        }
+
         return result;
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
@@ -25,10 +25,12 @@ import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
 import com.izforge.izpack.panels.userinput.field.Choice;
+import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.panels.userinput.field.radio.RadioField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
 import javax.swing.*;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -155,20 +157,35 @@ public class GUIRadioField extends GUIField
 
         if (value != null)
         {
-            for (RadioChoiceView view : choices)
-            {
-                if (value.equals(view.choice.getTrueValue()))
-                {
-                    view.button.setSelected(true);
-                }
-                else
-                {
-                    view.button.setSelected(false);
-                }
-            }
+            splitValue(value);
             result = true;
         }
+        else
+        {
+            // Set default value here for getting current variable values replaced
+            Field f = getField();
+            String defaultValue = f.getDefaultValue();
+            if (defaultValue != null)
+            {
+                splitValue(defaultValue);
+            }
+        }
         return result;
+    }
+
+    private void splitValue(String value)
+    {
+        for (RadioChoiceView view : choices)
+        {
+            if (value.equals(view.choice.getTrueValue()))
+            {
+                view.button.setSelected(true);
+            }
+            else
+            {
+                view.button.setSelected(false);
+            }
+        }
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/statictext/GUIStaticText.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/statictext/GUIStaticText.java
@@ -32,7 +32,6 @@ import com.izforge.izpack.panels.userinput.gui.GUIField;
  */
 public class GUIStaticText extends GUIField
 {
-
     /**
      * Constructs a {@code GUIStaticText}.
      *
@@ -45,4 +44,10 @@ public class GUIStaticText extends GUIField
         addTooltip();
     }
 
+    @Override
+    public boolean updateView()
+    {
+        refreshStaticText();
+        return false;
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.gui.text;
 
 import com.izforge.izpack.api.handler.Prompt;
+import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.panels.userinput.field.ValidationStatus;
 import com.izforge.izpack.panels.userinput.field.text.TextField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
@@ -29,6 +30,7 @@ import com.izforge.izpack.panels.userinput.gui.GUIField;
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 
@@ -110,15 +112,30 @@ public class GUITextField extends GUIField implements FocusListener, DocumentLis
 
         if (value != null)
         {
-            text.getDocument().removeDocumentListener(this);
-            text.setText(replaceVariables(value));
-            text.getDocument().addDocumentListener(this);
-            setChanged(false);
+            replaceValue(value);
             result = true;
         }
+        else
+        {
+            // Set default value here for getting current variable values replaced
+            Field f = getField();
+            String defaultValue = f.getDefaultValue();
+            if (defaultValue != null)
+            {
+                replaceValue(defaultValue);
+            }
+        }
+
         return result;
     }
 
+    private void replaceValue(String value)
+    {
+        text.getDocument().removeDocumentListener(this);
+        text.setText(replaceVariables(value));
+        text.getDocument().addDocumentListener(this);
+        setChanged(false);
+    }
 
     public synchronized void setChanged(boolean changed)
     {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/title/GUITitleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/title/GUITitleField.java
@@ -30,6 +30,7 @@ import com.izforge.izpack.panels.userinput.field.title.TitleField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
 import javax.swing.*;
+
 import java.awt.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -47,6 +48,8 @@ public class GUITitleField extends GUIField
      */
     private static final Logger logger = Logger.getLogger(GUITitleField.class.getName());
 
+    private JLabel label = null;
+
     /**
      * Constructs a {@code GUITitleField}.
      *
@@ -61,7 +64,6 @@ public class GUITitleField extends GUIField
 
         if (title != null)
         {
-            JLabel label = null;
             ImageIcon icon;
             String iconName = field.getIconName(installData.getMessages());
             if (iconName != null)
@@ -103,6 +105,20 @@ public class GUITitleField extends GUIField
             addComponent(label, constraints);
         }
         addTooltip();
+    }
+
+    @Override
+    public boolean updateView()
+    {
+        String value = getField().getLabel();
+
+        if (value != null)
+        {
+            // Set value here for getting current variable values replaced
+            label.setText(replaceVariables(value));
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Currently, there are no current variable values replaced in default values ('set' attribute) and in static label text. This has probably gone lost with some recent merges.

Make this working again.
