### PR TITLE
[IZPACK-1090] Allow tab completion and password masking in console mode

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
@@ -61,13 +61,13 @@ public class Console
     {
         try
         {
-            this.consoleReader = new ConsoleReader("IzPack", in, out, null);
             Log.setOutput(new PrintStream(new OutputStream() {
                 @Override
                 public void write(int b) throws IOException
                 {
                 }
             }));
+            this.consoleReader = new ConsoleReader("IzPack", in, out, null);
             this.out = new PrintWriter(consoleReader.getOutput(), true);
         }
         catch (Throwable t)


### PR DESCRIPTION
Post-fix: Really suppress logging from the beginning (there are cases
when the ConsoleReader doesn't throw any error but still doesn't work.
