### PR TITLE
[IZPACK-1090] Allow tab completion and password masking in console mode

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleFieldFactory.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleFieldFactory.java
@@ -55,7 +55,6 @@ import com.izforge.izpack.panels.userinput.field.space.Spacer;
 import com.izforge.izpack.panels.userinput.field.statictext.StaticText;
 import com.izforge.izpack.panels.userinput.field.text.TextField;
 import com.izforge.izpack.panels.userinput.field.title.TitleField;
-import com.izforge.izpack.panels.userinput.gui.GUIField;
 import com.izforge.izpack.util.Console;
 
 


### PR DESCRIPTION
Post-fixes:
- Really recognize fallback if ConsoleReader cannot be initialized.
  On Windows, in some cases it didn't throw an error but initialized an UnsupportedTerminal which made the password field masking not working
- Use System.console() from JDK 1.6 instead of accessing System.in and System.out. Old style left als fallback for unit tests, which can't read System.console().
