### PR TITLE
[IZPACK-1140] - Ensure header is not shifted by 12 pixels

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -1295,7 +1295,7 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
             northPanel.setBackground(back);
         }
         northPanel.setLayout(new BoxLayout(northPanel, BoxLayout.X_AXIS));
-        northPanel.setBorder(BorderFactory.createEmptyBorder(0, 12, 0, 0));
+        northPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
         if (imageLeft)
         {
             northPanel.add(imgPanel);


### PR DESCRIPTION
This is to address: http://jira.codehaus.org/browse/IZPACK-1140

I have been looking through the documentation to try and find a way to stop the heading from being shifted, but did not find a way. I do not understand why it is shifted by 12 in the first place. Let me know if I'm missing something, thanks.
