### PR TITLE
IZPACK-1139 - Ignore agentpath argument to jvm

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/JVMHelper.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/JVMHelper.java
@@ -56,7 +56,7 @@ class JVMHelper
         for (String arg : inputArguments)
         {
             if (!arg.startsWith("-Dself.mod.") && !arg.equals("-Xdebug") && !arg.startsWith("-Xrunjdwp")
-                    && !arg.startsWith("-Dizpack.mode") && !arg.startsWith("-agentlib")
+                    && !arg.startsWith("-Dizpack.mode") && !arg.startsWith("-agentlib") && !arg.startsWith("-agentpath")
                     && !arg.startsWith("-javaagent"))
             {
                 result.add(arg);


### PR DESCRIPTION
Ignoring the -agentpath argument will allow users who have the abrt-java-connector package to successfully build the izpack.
