### PR TITLE
[IZPACK-1442] - FIX

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/SplashScreen.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/SplashScreen.java
@@ -31,16 +31,16 @@ public class SplashScreen extends JFrame
      */
     public void displaySplashScreen()
     {
-        ImageIcon splashIcon = resources.getImageIcon("/resources/Splash.image");
-        if (splashIcon != null)
-        {
-            this.add(new JLabel(splashIcon));
-            this.setSize(splashIcon.getIconWidth(), splashIcon.getIconHeight());
-            this.setLocationRelativeTo(null);
-        }
-
         if (installData.guiPrefs.modifier.containsKey("useSplashScreen"))
         {
+            ImageIcon splashIcon = resources.getImageIcon("/resources/Splash.image");
+            if (splashIcon != null)
+            {
+                this.add(new JLabel(splashIcon));
+                this.setSize(splashIcon.getIconWidth(), splashIcon.getIconHeight());
+                this.setLocationRelativeTo(null);
+            }
+
             this.setVisible(true);
             try
             {
@@ -54,6 +54,7 @@ public class SplashScreen extends JFrame
             {
                 //Failed to sleep
                 //Failed to get duration
+                //Failed to get splash screen resource
             }
         }
     }


### PR DESCRIPTION
http://jira.codehaus.org/browse/IZPACK-1142

Only try to load splash screen resource if defined in guiprefs.
Please apply fix, this error means installers cannot build if the Splash.image resource is not defined.
Now it should fail only if you specify the splash screen as a guipref but had not added the appropriate resource, which is a good check to ensure user's have defined their splash screen if it were intended.
