### PR TITLE
[IZPACK-1143] - Ensure custom field's cannot go below its defined minimum row

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputField.java
@@ -91,6 +91,7 @@ public class CustomInputField extends JPanel implements ActionListener
 
         add(rows, rowConstraints);
 
+
         GridBagConstraints controlPanelConstraints = new GridBagConstraints();
         controlPanelConstraints.fill = GridBagConstraints.NONE;
         controlPanelConstraints.anchor = GridBagConstraints.EAST;
@@ -151,8 +152,16 @@ public class CustomInputField extends JPanel implements ActionListener
      */
     private void updateControlPanel()
     {
-        controlPanel.getComponent(0).setEnabled(rows.atMax());
-        controlPanel.getComponent(1).setEnabled(rows.atMin());
+        if (rows.hideRowControls())
+        {
+            controlPanel.getComponent(0).setVisible(false);
+            controlPanel.getComponent(1).setVisible(false);
+        }
+        else
+        {
+            controlPanel.getComponent(0).setEnabled(rows.atMax());
+            controlPanel.getComponent(1).setEnabled(rows.atMin());
+        }
         revalidate();
         repaint();
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputRows.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputRows.java
@@ -163,6 +163,11 @@ public class CustomInputRows extends JPanel
         return (numberOfRows > minRow);
     }
 
+    public boolean hideRowControls()
+    {
+        return (maxRow == minRow);
+    }
+
     /**
      * Validate and update installData
      * @param prompt


### PR DESCRIPTION
This is to address: http://jira.codehaus.org/browse/IZPACK-1143
- Ensure custom field's cannot go below its defined minimum row
- Hide buttons to control amount of rows when minRow and maxRow are of the same value
  - No use for buttons in this case
