### PR TITLE
[IZPACK-1146] GUI Installer - UserInputPanel radiobutton/checkbox variables set even though the panel hasn't been visited

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/check/CheckField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/check/CheckField.java
@@ -92,7 +92,6 @@ public class CheckField extends Field
         boolean result = false;
         if (value != null)
         {
-            getInstallData().setVariable(getVariable(), value);
             result = value.equals(trueValue) || Boolean.valueOf(value);
         }
         return result;

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIFieldFactory.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIFieldFactory.java
@@ -61,10 +61,6 @@ import com.izforge.izpack.panels.userinput.gui.statictext.GUIStaticText;
 import com.izforge.izpack.panels.userinput.gui.text.GUITextField;
 import com.izforge.izpack.panels.userinput.gui.title.GUITitleField;
 
-import java.util.ArrayList;
-import java.util.List;
-
-
 /**
  * Factory for {@link GUIField}s.
  *
@@ -134,7 +130,7 @@ public class GUIFieldFactory
         }
         else if (field instanceof RadioField)
         {
-            result = new GUIRadioField((RadioField) field, installData);
+            result = new GUIRadioField((RadioField) field);
         }
         else if (field instanceof PasswordGroupField)
         {
@@ -197,7 +193,6 @@ public class GUIFieldFactory
      */
     public GUIField createCustom(CustomField customField, UserInputPanelSpec userInputPanelSpec, IXMLElement spec)
     {
-        List<Field> fields = customField.getFields();
         FieldCommand fieldCommand = new createFieldCommand(userInputPanelSpec, spec);
         return new GUICustomField(customField, fieldCommand, userInputPanelSpec, spec, installData, parent);
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
@@ -21,7 +21,6 @@
 
 package com.izforge.izpack.panels.userinput.gui.radio;
 
-import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
 import com.izforge.izpack.panels.userinput.field.Choice;
@@ -53,9 +52,8 @@ public class GUIRadioField extends GUIField
      * Constructs a {@code GUIRadioField}.
      *
      * @param field       the field
-     * @param installData the installation data
      */
-    public GUIRadioField(RadioField field, InstallData installData)
+    public GUIRadioField(RadioField field)
     {
         super(field);
         String variable = field.getVariable();
@@ -90,17 +88,11 @@ public class GUIRadioField extends GUIField
             button.setText(choice.getValue());
             button.addActionListener(l);
 
-            String value = choice.getTrueValue();
-
             group.add(button);
             boolean selected = field.getSelectedIndex() == group.getButtonCount() - 1;
 
             if (selected)
             {
-                if (installData.getVariable(variable) == null)
-                {
-                    installData.setVariable(variable, value);
-                }
                 button.setSelected(true);
             }
 


### PR DESCRIPTION
This has introduced since 5.0.0-rc2:

For UserInputPanels in GUI/Swing installers the variables for radiobuttons and checkboxes are already set to the default values although the panel hasn't been reached. This is not the behavior like originally designed in IzPack. Variables should be unset as long as the panel that sets them hasn't been left or as long as an explicit variable or dynamicvariable definition doesn't set them explicitly.

This breaks existing installers in a nasty way, especially if there are conditions bound to such variables that rely on the original behavior.

The background of NOT setting UserInputVariables to its defaults from the beginning is that you are able to run the installer in different modes (e.g. update vs. installation or MSSQL vs. Oracle DB) by skipping certain panels according to the input the user made, in most cases utilizing conditions or pack selection conditions. If a panel is skipped and thus not valid for that mode then the according variables should not even been touched or set along with the panel definition.
