### PR TITLE
[IZPACK-1149] - Allow ability to generate automatic installation file when shortcuts not selected in console mode

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishConsolePanel.java
@@ -182,47 +182,8 @@ public class FinishConsolePanel extends AbstractConsolePanel
         }
         catch (Exception err)
         {
-            System.out.println("ERROR");
+            console.println("failed to save the installation into file [" + file.getAbsolutePath() + "]");
         }
-        /*
-        BufferedOutputStream outputStream;
-        outputStream = null;
-
-        try
-        {
-            outputStream = new BufferedOutputStream(new FileOutputStream(file), 5120);
-
-            IXMLWriter writer;
-            writer = new XMLWriter(outputStream);
-
-            IXMLElement root;
-            root = installData.getInstallationRecord();
-
-            AutomatedPanels automatedPanels;
-            automatedPanels = getAutomatedPanels(installData);
-
-            List<AutomatedPanelView> panelViews;
-            panelViews = automatedPanels.getPanelViews();
-
-            int index = 0;
-            for (AutomatedPanelView panelView : panelViews)
-            {
-                makeXML(panelView, installData, root.getChildAtIndex(index));
-                index = index + 1;
-            }
-            writer.write(root);
-            outputStream.flush();
-
-        }
-        catch (Exception e)
-        {
-            console.println("failed to save the installation into file [" + file.getAbsolutePath()
-                    + "]");
-        }
-        finally
-        {
-            FileUtils.close(outputStream);
-        }*/
     }
 
     protected AutomatedPanels getAutomatedPanels(final InstallData aInstallData)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConsolePanel.java
@@ -146,6 +146,10 @@ public class ShortcutConsolePanel extends AbstractConsolePanel
                 {
                     result = createShortcuts(installData, console);
                 }
+                else
+                {
+                    shortcutPanelLogic.setCreateShortcuts(false);
+                }
             }
             else if (!shortcutPanelLogic.isSkipIfNotSupported())
             {


### PR DESCRIPTION
This is to address: http://jira.codehaus.org/browse/IZPACK-1149

Added missing logic to the ShortcutPanelConsoleHelper so that the ShortcutPanelLogic is informed that shortcuts should not be installed. This should fix the issue of the automatic installation file failing to generate.
