### PR TITLE
Revert "[IZPACK-1140] - Ensure header is not shifted by 12 pixels"

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -1296,7 +1296,7 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
             northPanel.setBackground(back);
         }
         northPanel.setLayout(new BoxLayout(northPanel, BoxLayout.X_AXIS));
-        northPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
+        northPanel.setBorder(BorderFactory.createEmptyBorder(0, 12, 0, 0));
         if (imageLeft)
         {
             northPanel.add(imgPanel);


### PR DESCRIPTION
Reverts izpack/izpack#243

Must revert this, the inset is necessary to align the header label no directly to the left window border, which is ugly.
