### PR TITLE
[IZPACK-1152] - Default value selection of choice fields (radio, combo) broken - set attribute does not work like in RC2

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/ChoiceFieldConfig.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/ChoiceFieldConfig.java
@@ -23,8 +23,6 @@ package com.izforge.izpack.panels.userinput.field;
 
 import java.util.List;
 
-import com.izforge.izpack.api.rules.RulesEngine;
-
 
 /**
  * Configuration for fields that have a set of pre-defined choices.

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -114,10 +114,6 @@ public abstract class Field
     private final InstallData installData;
 
     /**
-     * Field configuration
-     */
-    private final FieldConfig config;
-    /**
      * The logger.
      */
     private static final Logger logger = Logger.getLogger(Field.class.getName());
@@ -131,7 +127,6 @@ public abstract class Field
      */
     public Field(FieldConfig config, InstallData installData)
     {
-        this.config = config;
         variable = config.getVariable();
         summaryKey = config.getSummaryKey();
         set = config.getDefaultValue();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/radio/RadioField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/radio/RadioField.java
@@ -23,7 +23,6 @@ package com.izforge.izpack.panels.userinput.field.radio;
 
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.IzPackException;
-import com.izforge.izpack.panels.userinput.field.Choice;
 import com.izforge.izpack.panels.userinput.field.ChoiceField;
 import com.izforge.izpack.panels.userinput.field.ChoiceFieldConfig;
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
@@ -24,7 +24,6 @@ package com.izforge.izpack.panels.userinput.gui.radio;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
 import com.izforge.izpack.panels.userinput.field.Choice;
-import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.panels.userinput.field.radio.RadioField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
@@ -149,35 +148,36 @@ public class GUIRadioField extends GUIField
 
         if (value != null)
         {
-            splitValue(value);
-            result = true;
+            result = splitValue(value);
         }
-        else
+
+        if (!result) // fallback for invalid values
         {
             // Set default value here for getting current variable values replaced
-            Field f = getField();
-            String defaultValue = f.getDefaultValue();
+            String defaultValue = field.getDefaultValue();
             if (defaultValue != null)
             {
-                splitValue(defaultValue);
+                result = splitValue(defaultValue);
             }
         }
         return result;
     }
 
-    private void splitValue(String value)
+    private boolean splitValue(String value)
     {
         for (RadioChoiceView view : choices)
         {
             if (value.equals(view.choice.getTrueValue()))
             {
                 view.button.setSelected(true);
+                return true;
             }
             else
             {
                 view.button.setSelected(false);
             }
         }
+        return false;
     }
 
     /**


### PR DESCRIPTION
According to http://jira.codehaus.org/browse/IZPACK-1152:

Currently, the default value selection of radio and combo fields does not work any longer like in RC2.
For example, instead of marking a radio choice selected like this:

```
<field type="radio" variable="dbms" summaryKey="key.dbms">
    <spec>
        <choice txt="MSSQL" value="mssql" id="text.dbsystemsettings.mssql" />
        <choice txt="Oracle" value="oracle" id="text.dbsystemsettings.oracle" set="true" />
        <choice txt="SAP Hana" value="hdb" id="text.dbsystemsettings.hana" />
    </spec>
</field>
```

the installer expects the default value to be set as as variable value in the "set" attribute of the <spec> tag.
This breaks existing installers.
