### PR TITLE
[IZPACK-1155] - VariableCondition is missing replace-call

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/VariableCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/VariableCondition.java
@@ -98,7 +98,7 @@ public class VariableCondition extends Condition
             else
             {
                 Variables variables = installData.getVariables();
-                return val.equals(variables.replace(value));
+                return variables.replace(val).equals(variables.replace(value));
             }
         }
         else


### PR DESCRIPTION
Based on a hint in https://jira.codehaus.org/browse/IZPACK-1155:

When using ${SYSTEM[variable.name]} in a condition, the value does not get replaced.
