### PR TITLE
[IZPACK-1159] Rule field doesn't show the value of the underlying variable

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleField.java
@@ -119,4 +119,53 @@ public class GUIRuleField extends GUIField
         }
         return result;
     }
+
+    /**
+     * Updates the view from the field.
+     *
+     * @return {@code true} if the view was updated
+     */
+    @Override
+    public boolean updateView()
+    {
+        boolean result = false;
+        String value = getField().getValue();
+
+        if (value != null)
+        {
+            replaceValue(value);
+            result = true;
+        }
+        else
+        {
+            // Set default value here for getting current variable values replaced
+            Field f = getField();
+            String defaultValue = f.getDefaultValue();
+            if (defaultValue != null)
+            {
+                replaceValue(defaultValue);
+            }
+        }
+
+        return result;
+    }
+
+    private void replaceValue(String value)
+    {
+        RuleField f = (RuleField) getField();
+        if (value != null)
+        {
+            ValidationStatus status = f.validateFormatted(value);
+            if (status.isValid())
+            {
+                String[] values = status.getValues();
+                int id = 0;
+                for (JTextField input : component.getInputFields())
+                {
+                    input.setText(values[id]);
+                    id++;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This fixes https://jira.codehaus.org/browse/IZPACK-1159:

Currently, all rule fields in a UserInputPanel are shown empty even if the underlying variable has a valid initial value. Furthermore, the underlying variable is emptied after leaving the according panel.
