### PR TITLE
add @SuppressWarnings("unused")

### DIFF
--- a/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
@@ -173,7 +173,7 @@ public class RulesEngineImplTest
     }
 
     @Test
-    @SuppressWarnings("PointlessBooleanExpression")
+    @SuppressWarnings({ "PointlessBooleanExpression", "unused"})
     public void testSimpleAnd() throws Exception
     {
         Condition condition;
@@ -192,7 +192,7 @@ public class RulesEngineImplTest
     }
 
     @Test
-    @SuppressWarnings("PointlessBooleanExpression")
+    @SuppressWarnings({ "PointlessBooleanExpression", "unused"})
     public void testSimpleOr() throws Exception
     {
         Condition condition;
@@ -231,7 +231,7 @@ public class RulesEngineImplTest
 
 
     @Test
-    @SuppressWarnings("PointlessBooleanExpression")
+    @SuppressWarnings({ "PointlessBooleanExpression", "unused"})
     public void testComplexNot() throws Exception
     {
         Condition condition;
@@ -257,7 +257,7 @@ public class RulesEngineImplTest
     }
 
     @Test
-    @SuppressWarnings("PointlessBooleanExpression")
+    @SuppressWarnings({ "PointlessBooleanExpression", "unused"})
     public void testComplexAnd() throws Exception
     {
         Condition condition;
@@ -319,7 +319,7 @@ public class RulesEngineImplTest
     }
 
     @Test
-    @SuppressWarnings("PointlessBooleanExpression")
+    @SuppressWarnings({ "PointlessBooleanExpression", "unused"})
     public void testComplexOr() throws Exception
     {
         Condition condition;
@@ -380,7 +380,7 @@ public class RulesEngineImplTest
     }
 
     @Test
-    @SuppressWarnings("PointlessBooleanExpression")
+    @SuppressWarnings({ "PointlessBooleanExpression", "unused"})
     public void testComplexXor() throws Exception
     {
         Condition condition;


### PR DESCRIPTION
because @SuppressWarnings("PointlessBooleanExpression") is not understood by
Eclipse. This does eliminate 64 warnings in the eclipse IDE.
I do not remove the @SuppressWarnings("PointlessBooleanExpression"), because I cannot test, whether other IDE's (IDEA?) will be happy with only SuppressWarnings("unused")

(sorry, I have to reapply this change, because I did remove this feature with PR #274 yesterday. I did the wrong solution to get PR#274 clean ...)
