### PR TITLE
IZPACK-1168 Bugfixing sprint week 38

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
@@ -462,41 +462,37 @@ public abstract class IzPanel extends JPanel implements AbstractUIHandler, Layou
     {
         String retval = null;
 
-        List<String> panelIdParts = new ArrayList<String>();
-        if (getMetadata().hasPanelId())
-        {
-            panelIdParts.add("." + getMetadata().getPanelId());
-        }
-        panelIdParts.add("");
+        List<String> prefixes = new ArrayList<String>();
+        String panelId = getMetadata().getPanelId();
+        Class<?> clazz = this.getClass();
 
-        for (String panelIdPart : panelIdParts)
+        String fullClassname = alternateClass==null?clazz.getName():alternateClass;
+        String simpleClassname = alternateClass==null?clazz.getSimpleName():alternateClass;
+
+        do
         {
-          Class<?> clazz = this.getClass();
-          while (retval == null && !clazz.equals(IzPanel.class))
-          {
-            // Try <full class name>[.<panel id>].<subkey>
-            String className = alternateClass==null?clazz.getName():alternateClass;
-            String searchkey = className + panelIdPart + "." + subkey;
+            prefixes.add(fullClassname + "." + panelId);
+            prefixes.add(simpleClassname + "." + panelId);
+            prefixes.add(fullClassname);
+            prefixes.add(simpleClassname);
+
+            clazz = clazz.getSuperclass();
+            fullClassname = clazz.getName();
+            simpleClassname = clazz.getSimpleName();
+        } while (alternateClass == null && !clazz.equals(IzPanel.class));
+        prefixes.add(2, panelId);
+
+        for (String prefix : prefixes)
+        {
+            String searchkey = prefix + "." + subkey;
             if (installData.getMessages().getMessages().containsKey(searchkey))
             {
                 retval = getString(searchkey);
             }
-            if (retval == null)
-            {
-                // Try <simple class name>[.<panel id>].<subkey>
-                className = alternateClass==null?clazz.getSimpleName():alternateClass;            // Try <simple class name>.<panel id>.<subkey>
-                searchkey = className + panelIdPart + "." + subkey;
-                if (installData.getMessages().getMessages().containsKey(searchkey))
-                {
-                    retval = getString(searchkey);
-                }
-            }
-            if (alternateClass != null)
+            if (retval != null)
             {
                 break;
             }
-            clazz = clazz.getSuperclass();
-          }
         }
 
         if (retval != null && retval.indexOf('$') > -1)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -166,6 +166,11 @@ public abstract class UnpackerBase implements IUnpacker
     private boolean disableInterrupt = false;
 
     /**
+     * Translation cache for packs
+     */
+    private Messages packMessages;
+
+    /**
      * The logger.
      */
     private static final Logger logger = Logger.getLogger(UnpackerBase.class.getName());
@@ -795,8 +800,17 @@ public abstract class UnpackerBase implements IUnpacker
      */
     protected String getStepName(Pack pack)
     {
+        if (packMessages == null)
+        {
+            Messages messages = installData.getMessages();
+            if (messages != null)
+            {
+                packMessages = messages.newMessages(PackHelper.LANG_FILE_NAME);
+            }
+        }
+
         // hide pack name if it is hidden
-        return pack.isHidden() ? "" : PackHelper.getPackName(pack, installData.getMessages());
+        return pack.isHidden() ? "" : PackHelper.getPackName(pack, packMessages);
     }
 
     /**
@@ -1111,12 +1125,15 @@ public abstract class UnpackerBase implements IUnpacker
             {
                 throw new InstallerException("Failed to read previous installation information", exception);
             }
+            finally
+            {
+                FileUtils.close(oin);
+                FileUtils.close(fin);
+            }
             for (Pack pack : packs)
             {
                 installedPacks.add(pack);
             }
-            FileUtils.close(oin);
-            FileUtils.close(fin);
         }
 
         FileOutputStream fout = new FileOutputStream(installationInfo);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PackHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PackHelper.java
@@ -31,6 +31,10 @@ import com.izforge.izpack.api.resource.Messages;
  */
 public class PackHelper
 {
+    /**
+     * The name of the XML file that specifies the panel langpack
+     */
+    public static final String LANG_FILE_NAME = "packsLang.xml";
 
     /**
      * Returns a localised name for a pack.

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishPanel.java
@@ -103,7 +103,7 @@ public class FinishPanel extends IzPanel implements ActionListener
     {
         parent.lockNextButton();
         parent.lockPrevButton();
-        parent.setQuitButtonText(getString("FinishPanel.done"));
+        parent.setQuitButtonText(getI18nStringForClass("done"));
         parent.setQuitButtonIcon("done");
         Insets inset = new Insets(10, 20, 2, 2);
         GridBagConstraints constraints = new GridBagConstraints(0, 0, 1, 1, 0, 0, GridBagConstraints.LINE_START,
@@ -111,7 +111,7 @@ public class FinishPanel extends IzPanel implements ActionListener
         if (this.installData.isInstallSuccess())
         {
             // We set the information
-            JLabel jLabel = LabelFactory.create(getString("FinishPanel.success"), parent.getIcons().get("preferences"),
+            JLabel jLabel = LabelFactory.create(getI18nStringForClass("success"), parent.getIcons().get("preferences"),
                                                 LEADING);
             jLabel.setName(GuiId.FINISH_PANEL_LABEL.id);
             add(jLabel, constraints);
@@ -121,7 +121,7 @@ public class FinishPanel extends IzPanel implements ActionListener
                 // We prepare a message for the uninstaller feature
                 String path = translatePath("$INSTALL_PATH") + File.separator + "Uninstaller";
 
-                add(LabelFactory.create(getString("FinishPanel.uninst.info"), parent.getIcons()
+                add(LabelFactory.create(getI18nStringForClass("uninst.info"), parent.getIcons()
                         .get("preferences"), LEADING), constraints);
                 constraints.gridy++;
                 add(LabelFactory.create(path, parent.getIcons().get("empty"),
@@ -129,17 +129,17 @@ public class FinishPanel extends IzPanel implements ActionListener
                 constraints.gridy++;
             }
             // We add the autoButton
-            autoButton = ButtonFactory.createButton(getString("FinishPanel.auto"),
+            autoButton = ButtonFactory.createButton(getI18nStringForClass("auto"),
                                                     parent.getIcons().get("edit"), this.installData.buttonsHColor);
             autoButton.setName(GuiId.FINISH_PANEL_AUTO_BUTTON.id);
-            autoButton.setToolTipText(getString("FinishPanel.auto.tip"));
+            autoButton.setToolTipText(getI18nStringForClass("auto.tip"));
             autoButton.addActionListener(this);
             add(autoButton, constraints);
             constraints.gridy++;
         }
         else
         {
-            add(LabelFactory.create(getString("FinishPanel.fail"), parent.getIcons().get("stop"), LEADING),
+            add(LabelFactory.create(getI18nStringForClass("fail"), parent.getIcons().get("stop"), LEADING),
                 constraints);
         }
         getLayoutHelper().completeLayout(); // Call, or call not?

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanel.java
@@ -102,21 +102,21 @@ public class InstallPanel extends IzPanel implements ProgressListener
     public InstallPanel(Panel panel, InstallerFrame parent, GUIInstallData installData, Resources resources, Log log)
     {
         super(panel, parent, installData, new IzPanelLayout(log), resources);
-        this.tipLabel = LabelFactory.create(getString("InstallPanel.tip"), parent.getIcons().get(iconName), LEADING);
+        this.tipLabel = LabelFactory.create(getI18nStringForClass("tip"), parent.getIcons().get(iconName), LEADING);
         add(this.tipLabel, IzPanelLayout.getDefaultConstraint(FULL_LINE_CONTROL_CONSTRAINT));
         packOpLabel = LabelFactory.create(" ", LEADING);
         add(packOpLabel, IzPanelLayout.getDefaultConstraint(FULL_LINE_CONTROL_CONSTRAINT));
 
         packProgressBar = new JProgressBar();
         packProgressBar.setStringPainted(true);
-        packProgressBar.setString(getString("InstallPanel.begin"));
+        packProgressBar.setString(getI18nStringForClass("begin"));
         packProgressBar.setValue(0);
         add(packProgressBar, IzPanelLayout.getDefaultConstraint(FULL_LINE_CONTROL_CONSTRAINT));
         // make sure there is some space between the progress bars
         add(IzPanelLayout.createVerticalStrut(5));
         //add(IzPanelLayout.createParagraphGap());
 
-        overallOpLabel = LabelFactory.create(getString("InstallPanel.progress"), parent.getIcons().get(iconName),
+        overallOpLabel = LabelFactory.create(getI18nStringForClass("progress"), parent.getIcons().get(iconName),
                                              LEADING);
         add(this.overallOpLabel, IzPanelLayout.getDefaultConstraint(FULL_LINE_CONTROL_CONSTRAINT));
 
@@ -188,7 +188,7 @@ public class InstallPanel extends IzPanel implements ProgressListener
 
                 if (installData.isInstallSuccess())
                 {
-                    packProgressBar.setString(getString("InstallPanel.finished"));
+                    packProgressBar.setString(getI18nStringForClass("finished"));
                 }
                 else
                 {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModel.java
@@ -82,7 +82,7 @@ public class PacksModel extends AbstractTableModel
     {
         this.installData = idata;
         this.rules = idata.getRules();
-        this.messages = idata.getMessages();
+        this.messages = idata.getMessages().newMessages(PackHelper.LANG_FILE_NAME);
         this.variables = idata.getVariables();
         this.packsToInstall = idata.getSelectedPacks();
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelBase.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelBase.java
@@ -163,11 +163,6 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
      */
     private Messages messages = null;
 
-    /**
-     * The name of the XML file that specifies the panel langpack
-     */
-    private static final String LANG_FILE_NAME = "packsLang.xml";
-
     private Debugger debugger;
 
     /**
@@ -197,7 +192,7 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
 
         try
         {
-            messages = installData.getMessages().newMessages(LANG_FILE_NAME);
+            messages = installData.getMessages().newMessages(PackHelper.LANG_FILE_NAME);
         }
         catch (ResourceNotFoundException exception)
         {


### PR DESCRIPTION
Fixes at the moment:
- IZPACK-1165 Package names not translated
- IZPACK-1166 Re-introduce panel translations using the panel id as key without the classname as prefix
- IZPACK-1167 Avoid unclosed stream during unpacking
