### PR TITLE
 IZPACK-1169

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -150,7 +150,7 @@ public abstract class UnpackerBase implements IUnpacker
     /**
      * The unpacking state.
      */
-    private enum State
+    protected enum State
     {
         READY, UNPACKING, INTERRUPT, INTERRUPTED
     }
@@ -1377,6 +1377,44 @@ public abstract class UnpackerBase implements IUnpacker
         return unpacker;
     }
 
+    protected RulesEngine getRules() {
+        return rules;
+    }
 
+    protected FileQueueFactory getQueueFactory() {
+        return queueFactory;
+    }
+
+    protected Housekeeper getHousekeeper() {
+        return housekeeper;
+    }
+
+    protected InstallerListeners getListeners() {
+        return listeners;
+    }
+
+    protected ProgressListener getListener() {
+        return listener;
+    }
+
+    protected PlatformModelMatcher getMatcher() {
+        return matcher;
+    }
+
+    protected boolean isResult() {
+        return result;
+    }
+
+    protected Cancellable getCancellable() {
+        return cancellable;
+    }
+
+    protected State getState() {
+        return state;
+    }
+
+    public void setState(State state) {
+        this.state = state;
+    }
 }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -1401,10 +1401,6 @@ public abstract class UnpackerBase implements IUnpacker
         return matcher;
     }
 
-    protected boolean isResult() {
-        return result;
-    }
-
     protected Cancellable getCancellable() {
         return cancellable;
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -75,82 +75,82 @@ public abstract class UnpackerBase implements IUnpacker
     /**
      * The installation data.
      */
-    protected final InstallData installData;
+    private final InstallData installData;
 
     /**
      * The uninstallation data.
      */
-    protected final UninstallData uninstallData;
+    private final UninstallData uninstallData;
 
     /**
      * The pack resources.
      */
-    protected final PackResources resources;
+    private final PackResources resources;
 
     /**
      * The rules engine.
      */
-    protected final RulesEngine rules;
+    private final RulesEngine rules;
 
     /**
      * The variable replacer.
      */
-    protected final VariableSubstitutor variableSubstitutor;
+    private final VariableSubstitutor variableSubstitutor;
 
     /**
      * The file queue factory.
      */
-    protected final FileQueueFactory queueFactory;
+    private final FileQueueFactory queueFactory;
 
     /**
      * The housekeeper.
      */
-    protected final Housekeeper housekeeper;
+    private final Housekeeper housekeeper;
 
     /**
      * The listeners.
      */
-    protected final InstallerListeners listeners;
+    private final InstallerListeners listeners;
 
     /**
      * The installer listener.
      */
-    protected ProgressListener listener;
+    private ProgressListener listener;
 
     /**
      * The absolute path of the source installation jar.
      */
-    protected File absoluteInstallSource;
+    private File absoluteInstallSource;
 
     /**
      * The Pack200 unpacker.
      */
-    protected Pack200.Unpacker unpacker;
+    private Pack200.Unpacker unpacker;
 
     /**
      * The prompt.
      */
-    protected final Prompt prompt;
+    private final Prompt prompt;
 
     /**
      * The platform-model matcher.
      */
-    protected final PlatformModelMatcher matcher;
+    private final PlatformModelMatcher matcher;
 
     /**
      * The result of the operation.
      */
-    protected boolean result = true;
+    private boolean result = true;
 
     /**
      * Determines if unpack operations should be cancelled.
      */
-    protected final Cancellable cancellable;
+    private final Cancellable cancellable;
 
     /**
      * The unpacking state.
      */
-    protected enum State
+    private enum State
     {
         READY, UNPACKING, INTERRUPT, INTERRUPTED
     }
@@ -158,12 +158,12 @@ public abstract class UnpackerBase implements IUnpacker
     /**
      * The current unpacking state.
      */
-    protected State state = State.READY;
+    private State state = State.READY;
 
     /**
      * If <tt>true</tt>, prevent interrupts.
      */
-    protected boolean disableInterrupt = false;
+    private boolean disableInterrupt = false;
 
     /**
      * The logger.

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -75,82 +75,82 @@ public abstract class UnpackerBase implements IUnpacker
     /**
      * The installation data.
      */
-    private final InstallData installData;
+    protected final InstallData installData;
 
     /**
      * The uninstallation data.
      */
-    private final UninstallData uninstallData;
+    protected final UninstallData uninstallData;
 
     /**
      * The pack resources.
      */
-    private final PackResources resources;
+    protected final PackResources resources;
 
     /**
      * The rules engine.
      */
-    private final RulesEngine rules;
+    protected final RulesEngine rules;
 
     /**
      * The variable replacer.
      */
-    private final VariableSubstitutor variableSubstitutor;
+    protected final VariableSubstitutor variableSubstitutor;
 
     /**
      * The file queue factory.
      */
-    private final FileQueueFactory queueFactory;
+    protected final FileQueueFactory queueFactory;
 
     /**
      * The housekeeper.
      */
-    private final Housekeeper housekeeper;
+    protected final Housekeeper housekeeper;
 
     /**
      * The listeners.
      */
-    private final InstallerListeners listeners;
+    protected final InstallerListeners listeners;
 
     /**
      * The installer listener.
      */
-    private ProgressListener listener;
+    protected ProgressListener listener;
 
     /**
      * The absolute path of the source installation jar.
      */
-    private File absoluteInstallSource;
+    protected File absoluteInstallSource;
 
     /**
      * The Pack200 unpacker.
      */
-    private Pack200.Unpacker unpacker;
+    protected Pack200.Unpacker unpacker;
 
     /**
      * The prompt.
      */
-    private final Prompt prompt;
+    protected final Prompt prompt;
 
     /**
      * The platform-model matcher.
      */
-    private final PlatformModelMatcher matcher;
+    protected final PlatformModelMatcher matcher;
 
     /**
      * The result of the operation.
      */
-    private boolean result = true;
+    protected boolean result = true;
 
     /**
      * Determines if unpack operations should be cancelled.
      */
-    private final Cancellable cancellable;
+    protected final Cancellable cancellable;
 
     /**
      * The unpacking state.
      */
-    private enum State
+    protected enum State
     {
         READY, UNPACKING, INTERRUPT, INTERRUPTED
     }
@@ -158,12 +158,12 @@ public abstract class UnpackerBase implements IUnpacker
     /**
      * The current unpacking state.
      */
-    private State state = State.READY;
+    protected State state = State.READY;
 
     /**
      * If <tt>true</tt>, prevent interrupts.
      */
-    private boolean disableInterrupt = false;
+    protected boolean disableInterrupt = false;
 
     /**
      * The logger.

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -1413,7 +1413,7 @@ public abstract class UnpackerBase implements IUnpacker
         return state;
     }
 
-    public void setState(State state) {
+    protected void setState(State state) {
         this.state = state;
     }
 }


### PR DESCRIPTION
This is a very simple change to make the UnpackerBase abstract class easier to sub class.  The only changes are switching the fields from private to protected.
