### PR TITLE
[IZPACK-1173] Make single-instance locking of the installer configurable

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Info.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Info.java
@@ -123,6 +123,8 @@ public class Info implements Serializable
 
     private boolean writeInstallationInformation = true;
 
+    private boolean isSingleInstance = true;
+
     private boolean pack200Compression;
 
     private boolean requirePrivilegedExecution = false;
@@ -583,7 +585,6 @@ public class Info implements Serializable
         return unpackerClassName;
     }
 
-
     public void setUnpackerClassName(String unpackerClassName)
     {
         this.unpackerClassName = unpackerClassName;
@@ -595,10 +596,21 @@ public class Info implements Serializable
         return writeInstallationInformation;
     }
 
-
     public void setWriteInstallationInformation(boolean writeInstallationInformation)
     {
         this.writeInstallationInformation = writeInstallationInformation;
+    }
+
+
+    public boolean isSingleInstance()
+    {
+        return this.isSingleInstance;
+    }
+
+    public void setSingleInstance(boolean flag)
+    {
+        this.isSingleInstance = flag;
+
     }
 
 
@@ -607,11 +619,11 @@ public class Info implements Serializable
         return uninstallerCondition;
     }
 
-
     public void setUninstallerCondition(String uninstallerCondition)
     {
         this.uninstallerCondition = uninstallerCondition;
     }
+
 
     public void addTempDir(TempDir tempDir)
     {
@@ -624,7 +636,7 @@ public class Info implements Serializable
     }
 
     public Set<TempDir> getTempDirs()
-	{
-		return tempdirs;
-	}
+    {
+        return tempdirs;
+    }
 }

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -2050,6 +2050,13 @@ public class CompilerConfig extends Thread
             info.setWriteInstallationInformation(validateYesNo(writeInstallInfoString));
         }
 
+        IXMLElement isSingleInstance = root.getFirstChildNamed("singleinstance");
+        if (isSingleInstance != null)
+        {
+            String isSingleInstanceString = xmlCompilerHelper.requireContent(isSingleInstance);
+            info.setSingleInstance(validateYesNo(isSingleInstanceString));
+        }
+
         // look for an unpacker class
         String unpackerclass = propertyManager.getProperty("UNPACKER_CLASS");
         info.setUnpackerClassName(unpackerclass);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/language/ConditionCheck.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/language/ConditionCheck.java
@@ -8,6 +8,7 @@ import java.util.logging.Logger;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
+import com.izforge.izpack.api.data.Info;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.InstallerRequirement;
 import com.izforge.izpack.api.exception.IzPackException;
@@ -59,66 +60,71 @@ public class ConditionCheck
      */
     public void checkLockFile() throws Exception
     {
-        String appName = installdata.getInfo().getAppName();
-        File file = FileUtil.getLockFile(appName);
-        if (file.exists())
+        Info installationInfo = installdata.getInfo();
+
+        if (installationInfo.isSingleInstance() && !Boolean.getBoolean("MULTIINSTANCE"))
         {
-            // Ask user if they want to proceed.
-            logger.fine("Lock File Exists, asking user for permission to proceed.");
-            StringBuilder msg = new StringBuilder();
-            msg.append("<html>");
-            msg.append("The ").append(appName).append(
-                    " installer you are attempting to run seems to have a copy already running.<br><br>");
-            msg.append(
-                    "This could be from a previous failed installation attempt or you may have accidentally launched <br>");
-            msg.append(
-                    "the installer twice. <b>The recommended action is to select 'Exit'</b> and wait for the other copy of <br>");
-            msg.append(
-                    "the installer to start. If you are sure there is no other copy of the installer running, click <br>");
-            msg.append("the 'Continue' button to allow this installer to run. <br><br>");
-            msg.append("Are you sure you want to continue with this installation?");
-            msg.append("</html>");
-            JLabel label = new JLabel(msg.toString());
-            label.setFont(new Font("Sans Serif", Font.PLAIN, 12));
-            Object[] optionValues = {"Continue", "Exit"};
-            int selectedOption = JOptionPane.showOptionDialog(null, label, "Warning",
-                                                              JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
-                                                              null, optionValues,
-                                                              optionValues[1]);
-            logger.fine("Selected option: " + selectedOption);
-            if (selectedOption == 0)
+            String appName = installdata.getInfo().getAppName();
+            File file = FileUtil.getLockFile(appName);
+            if (file.exists())
             {
-                // Take control of the file so it gets deleted after this installer instance exits.
-                logger.fine("Setting temporary file to delete on exit");
-                file.deleteOnExit();
-            }
-            else
-            {
-                // Leave the file as it is.
-                logger.fine("Leaving temporary file alone and exiting");
-                System.exit(1);
-            }
-        }
-        else
-        {
-            try
-            {
-                // Create the new lock file
-                if (file.createNewFile())
+                // Ask user if they want to proceed.
+                logger.fine("Lock File Exists, asking user for permission to proceed.");
+                StringBuilder msg = new StringBuilder();
+                msg.append("<html>");
+                msg.append("The ").append(appName).append(
+                        " installer you are attempting to run seems to have a copy already running.<br><br>");
+                msg.append(
+                        "This could be from a previous failed installation attempt or you may have accidentally launched <br>");
+                msg.append(
+                        "the installer twice. <b>The recommended action is to select 'Exit'</b> and wait for the other copy of <br>");
+                msg.append(
+                        "the installer to start. If you are sure there is no other copy of the installer running, click <br>");
+                msg.append("the 'Continue' button to allow this installer to run. <br><br>");
+                msg.append("Are you sure you want to continue with this installation?");
+                msg.append("</html>");
+                JLabel label = new JLabel(msg.toString());
+                label.setFont(new Font("Sans Serif", Font.PLAIN, 12));
+                Object[] optionValues = {"Continue", "Exit"};
+                int selectedOption = JOptionPane.showOptionDialog(null, label, "Warning",
+                                                                  JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
+                                                                  null, optionValues,
+                                                                  optionValues[1]);
+                logger.fine("Selected option: " + selectedOption);
+                if (selectedOption == 0)
                 {
-                    logger.fine("Temporary file created");
+                    // Take control of the file so it gets deleted after this installer instance exits.
+                    logger.fine("Setting temporary file to delete on exit");
                     file.deleteOnExit();
                 }
                 else
                 {
-                    logger.warning("Temporary file could not be created");
-                    logger.warning("*** Multiple instances of installer will be allowed ***");
+                    // Leave the file as it is.
+                    logger.fine("Leaving temporary file alone and exiting");
+                    System.exit(1);
                 }
             }
-            catch (Exception e)
+            else
             {
-                logger.log(Level.WARNING, "Temporary file could not be created: " + e.getMessage(), e);
-                logger.warning("*** Multiple instances of installer will be allowed ***");
+                try
+                {
+                    // Create the new lock file
+                    if (file.createNewFile())
+                    {
+                        logger.fine("Temporary file created");
+                        file.deleteOnExit();
+                    }
+                    else
+                    {
+                        logger.warning("Temporary file could not be created");
+                        logger.warning("*** Multiple instances of installer will be allowed ***");
+                    }
+                }
+                catch (Exception e)
+                {
+                    logger.log(Level.WARNING, "Temporary file could not be created: " + e.getMessage(), e);
+                    logger.warning("*** Multiple instances of installer will be allowed ***");
+                }
             }
         }
     }


### PR DESCRIPTION
This pull requests implements https://jira.codehaus.org/browse/IZPACK-1173:

There is a built-in feature of popping up a message which asks the user whether an already running instance of the same installer should be ignored or rather whether to abort (see attachment).

This can be inconvenient for some use cases (clustering, sub-calls when an installer calls itself with different options,...).

Allow to disable this behavior, the default of enabling it should be unchanged.
