### PR TITLE
Izpack 1140

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -1296,15 +1296,17 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
             northPanel.setBackground(back);
         }
         northPanel.setLayout(new BoxLayout(northPanel, BoxLayout.X_AXIS));
-        northPanel.setBorder(BorderFactory.createEmptyBorder(0, 12, 0, 0));
+
         if (imageLeft)
         {
+            northPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
             northPanel.add(imgPanel);
             northPanel.add(Box.createHorizontalGlue());
             northPanel.add(leftHeadingPanel);
         }
         else
         {
+            northPanel.setBorder(BorderFactory.createEmptyBorder(0, 12, 0, 0));
             northPanel.add(leftHeadingPanel);
             northPanel.add(Box.createHorizontalGlue());
             northPanel.add(imgPanel);


### PR DESCRIPTION
This PR is for IZPACK-1140.

The change will just allow images to be pressed against the left edge of the installer frame if the user uses the modifier, <modifier key="headingImageOnLeft" value="yes"/> in the guiprefs.
