### PR TITLE
Allow for lower-case drive letters in TargetPanel directory validation.

### DIFF
--- a/izpack-tools/src/main/java/com/izforge/izpack/util/Platform.java
+++ b/izpack-tools/src/main/java/com/izforge/izpack/util/Platform.java
@@ -401,7 +401,7 @@ public class Platform
         String filteredPath = directoryPath;
         if (name == Name.WINDOWS)
         {
-            if (!directoryPath.matches("^[A-Z]:.*"))
+            if (!directoryPath.matches("^[a-zA-Z]:.*"))
             {
                 return false;
             }

--- a/izpack-tools/src/test/java/com/izforge/izpack/util/PlatformTest.java
+++ b/izpack-tools/src/test/java/com/izforge/izpack/util/PlatformTest.java
@@ -233,4 +233,18 @@ public class PlatformTest extends AbstractPlatformTest
         Platform platform2 = new Platform(Name.SUNOS);
         assertEquals("sunos,version=null,arch=unknown,symbolicName=null,javaVersion=null", platform2.toString());
     }
+
+    /**
+     * Tests the {@link Platform#isValidDirectoryPath(String)} method.
+     */
+    @Test
+    public void testIsValidDirectoryPath()
+    {
+        Platform platform1 = new Platform(Name.WINDOWS);
+	//ensure case insensitivity
+        assertTrue(platform1.isValidDirectoryPath("C:\\test"));
+        assertTrue(platform1.isValidDirectoryPath("c:\\test"));
+	//screen invalid characters
+        assertFalse(platform1.isValidDirectoryPath("C:\\*<>"));
+    }
 }


### PR DESCRIPTION
Fix for case sensitivity issue with TargetPanel directory validation on Windows

Issue posted here:   https://github.com/izpack/izpack.github.com/issues/13
