### PR TITLE
Izpack 1178 - Cannot create shortcuts on unix platforms.

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanel.java
@@ -235,7 +235,7 @@ public class ShortcutPanel extends IzPanel implements ActionListener, ListSelect
                 programGroup.setText(suggestedProgramGroup);
             }
 
-            if(groupList.getSelectedIndex() < 0)
+            if(groupList != null && groupList.getSelectedIndex() < 0)
             {
                 groupList.setSelectedIndex(0);
             }


### PR DESCRIPTION
Add null checking to avoid skipping shortcut panel on unix platforms.
