### PR TITLE
[IZPACK-1180] ConfigurationInstallerListener: Nested <entry> remains empty if it didn't exist before

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
@@ -761,7 +761,7 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
         private void executeOnOptions(Options configurable) throws Exception
         {
             List<String> values = configurable.getAll(key);
-            String newValue = null;
+            String newValue;
             boolean contains = false;
             if (values != null)
             {
@@ -799,6 +799,7 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
             }
             if (!contains)
             {
+                newValue = execute(value);
                 logger.fine("Set option value for key \"" + key + "\": \"" + newValue + "\"");
                 configurable.put(key, newValue);
             }


### PR DESCRIPTION
Fixes https://jira.codehaus.org/browse/IZPACK-1180:

If a property file is created by ConfigurationListener, or nested <entry> doesn't still exist before applyiong configuration actions, the nested entries are left empty and their value attribute isn't applied at all.
Example

``` xml
<configurable type="options" keepOldKeys="true" keepOldValues="true" tofile="${INSTALL_PATH}/db.properties">
        <entry key="driver" value="org.firebirdsql.jdbc.FBDriver" />
        <entry key="url" value="jdbc:firebirdsql:${db.host}/${db.port}:##user.dir#/" />
        <entry key="file" value="${database.scriptsfolder}/${db.name}.fdb" />
        <entry key="user" value="${db.user}" />
        <entry key="pass" value="${db.password}" />
</configurable>
```

if db.properties doesn't exist the ConfigurationInstallerListener leaves it in this state:

```
driver=
url=
file=
user=
pass=
```
