### PR TITLE
Izpack 1183: Avoid NPE in DynamicVariableImpl.hashCode() and correct implementation of DynamicVariableImpl.equals()

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -257,7 +257,9 @@ public class DynamicVariableImpl implements DynamicVariable
         }
         DynamicVariable compareObj = (DynamicVariable) obj;
         return (name.equals(compareObj.getName())
-                && (conditionid == null || conditionid.equals(compareObj.getConditionid())));
+                && (   (conditionid == null && compareObj.getConditionid() == null)
+                    || (conditionid != null && conditionid.equals(compareObj.getConditionid()))
+                   ));
     }
 
     @Override


### PR DESCRIPTION
The conditionid can be null (and is null, when no condition attribut was present). This must be handled correct in .hashCode() and .equals()
