### PR TITLE
[IZPACK-1194] "contains" condition does not work for checking plain <variable> values

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
@@ -56,10 +56,6 @@ public class ContainsCondition extends Condition {
     }
 
     Variables variables = getInstallData().getVariables();
-    if (isRegEx)
-    {
-        pattern = Pattern.compile(value);
-    }
 
     switch (contentType) {
     case STRING:
@@ -128,9 +124,17 @@ public class ContainsCondition extends Condition {
     if (content == null)
       return false;
 
-    if (isByLine)
+    if (isRegEx && isByLine)
     {
         return matchesByLine(new StringReader(content));
+    }
+    if (isRegEx)
+    {
+        if (isByLine)
+        {
+            return matchesByLine(new StringReader(content));
+        }
+        pattern = Pattern.compile(value);
     }
 
     return matchesString(content);


### PR DESCRIPTION
Implements http://jira.codehaus.org/browse/IZPACK-1194:

The "contains" condition, introduced in 5.0, does not work for the following example:

``` xml
<condition type="contains" id="mssqlUrlFound">
   <variable>jdbc.url</variable>
   <value>jdbc:jtds:sqlserver</value>
</condition>
```

This affects probably more usecases using plain value checks, because an invalid check causes the condition to make a regex check due to the default byLine="true" instead of comparing plain values. This failed due to an uninitialized regex pattern.
