### PR TITLE
[IZPACK-1195] Improve and enhance displaying of readonly UserInputPanels

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
@@ -63,6 +63,26 @@ public class Panel implements Serializable
     private String condition;
 
     /**
+     * Condition whether the panel should be shown read-only in otherwise hidden.
+     */
+    private String displayHiddenCondition;
+
+    /**
+     * Whether the panel including all fields is read-only if otherwise hidden.
+     */
+    private boolean displayHidden = false;
+
+    /**
+     * Whether the panel including all fields is read-only as a whole.
+     */
+    private boolean readonly = false;
+
+    /**
+     * Condition whether the panel should be shown read-only.
+     */
+    private String readonlyCondition;
+
+    /**
      * The list of validators for this panel
      */
     private List<String> validators = new ArrayList<String>();
@@ -110,6 +130,7 @@ public class Panel implements Serializable
      * Contains configuration values for a panel.
      */
     private Map<String, String> configuration = null;
+
 
     public String getClassName()
     {
@@ -168,6 +189,91 @@ public class Panel implements Serializable
     {
         return this.condition != null;
     }
+
+
+    /**
+     * Get the 'displayHiddenCondition' of this panel.
+     *
+     * @return the condition to set when the panel should be shown read-only in otherwise hidden state
+     */
+    public String getDisplayHiddenCondition()
+    {
+        return this.displayHiddenCondition;
+    }
+
+    /**
+     * Set the 'displayHiddenCondition' of this panel.
+     *
+     * @param condition the condition to set when the panel should be shown read-only in otherwise hidden state
+     */
+    public void setDisplayHiddenCondition(String condition)
+    {
+        this.displayHiddenCondition = condition;
+    }
+
+    /**
+     * Whether the 'displayHiddenCondition' is set for this panel.
+     *
+     * @return the condition to set when the panel should be shown read-only in otherwise hidden state
+     */
+    public boolean hasDisplayHiddenCondition()
+    {
+        return this.displayHiddenCondition != null;
+    }
+
+
+    public boolean isDisplayHidden()
+    {
+        return displayHidden;
+    }
+
+    public void setDisplayHidden(boolean flag)
+    {
+        this.displayHidden = flag;
+    }
+
+
+    public boolean isReadonly()
+    {
+        return readonly;
+    }
+
+    public void setReadonly(boolean flag)
+    {
+        this.readonly = flag;
+    }
+
+
+    /**
+     * Get the 'readonlyCondition' of this panel.
+     *
+     * @return the condition to set when the panel should be shown read-only
+     */
+    public String getReadonlyCondition()
+    {
+        return this.readonlyCondition;
+    }
+
+    /**
+     * Set the 'readonlyCondition' of this panel.
+     *
+     * @param condition the condition to set when the panel should be shown read-only
+     */
+    public void setReadonlyCondition(String condition)
+    {
+        this.readonlyCondition = condition;
+    }
+
+    /**
+     * Whether the 'readonlyCondition' is set for this panel.
+     *
+     * @return the condition to set when the panel should be shown read-only
+     */
+    public boolean hasReadonlyCondition()
+    {
+        return this.readonlyCondition != null;
+    }
+
 
     /**
      * Get validator and validator condition entries for this panel

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -610,6 +610,8 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
             performHeading(newPanel);
             performHeadingCounter(newPanel);
             newPanel.executePreActivationActions();
+            Panel panel = newPanel.getPanel();
+            newView.setReadonly(panel.isReadonly() || panel.isDisplayHidden());
             newView.panelActivate();
             panelsContainer.setVisible(true);
             if (iconLabel != null)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
@@ -104,6 +104,11 @@ public abstract class IzPanel extends JPanel implements AbstractUIHandler, Layou
     private boolean hidden;
 
     /**
+     * Is this panel to be shown read-only (at the moment)
+     */
+    private boolean readonly;
+
+    /**
      * HEADLINE = "headline"
      */
     public final static String HEADLINE = "headline";
@@ -895,6 +900,26 @@ public abstract class IzPanel extends JPanel implements AbstractUIHandler, Layou
     public void setHidden(boolean hidden)
     {
         this.hidden = hidden;
+    }
+
+    /**
+     * Returns whether this panel should be displayed read-only.
+     *
+     * @return whether this panel will be hidden general or not
+     */
+    public boolean isReadonly()
+    {
+        return readonly;
+    }
+
+    /**
+     * Set whether this panel should be displayed read-only.
+     *
+     * @param hidden flag to be set
+     */
+    public void setReadonly(boolean readonly)
+    {
+        this.readonly = readonly;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
@@ -168,6 +168,7 @@ public class UserInputConsolePanel extends AbstractConsolePanel
             boolean rerun = false;
             for (ConsoleField field : fields)
             {
+                field.setReadonly(field.getField().isDisplayHidden());
                 if (field.getField().isConditionTrue() && !field.display())
                 {
                     // field is invalid

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleChoiceField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleChoiceField.java
@@ -54,7 +54,6 @@ public abstract class ConsoleChoiceField<T extends Choice> extends ConsoleField
      * @return the field
      */
     @Override
-    @SuppressWarnings("unchecked")
     public ChoiceField getField()
     {
         return (ChoiceField) super.getField();
@@ -73,16 +72,24 @@ public abstract class ConsoleChoiceField<T extends Choice> extends ConsoleField
         ChoiceField field = getField();
         printDescription();
 
-        List<Choice> choices = field.getChoices();
-        listChoices(choices, field.getSelectedIndex());
-
-        int selected = getConsole().prompt("input selection: ", 0, choices.size() - 1, field.getSelectedIndex(), -1);
-        if (selected == -1)
+        if (isReadonly())
         {
-            return false;
+            println(field.getValue());
+            return true;
         }
-        field.setValue(choices.get(selected).getKey());
-        return true;
+        else
+        {
+            List<Choice> choices = field.getChoices();
+            listChoices(choices, field.getSelectedIndex());
+
+            int selected = getConsole().prompt("input selection: ", 0, choices.size() - 1, field.getSelectedIndex(), -1);
+            if (selected == -1)
+            {
+                return false;
+            }
+            field.setValue(choices.get(selected).getKey());
+            return true;
+        }
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleInputField.java
@@ -59,25 +59,34 @@ public abstract class ConsoleInputField extends ConsoleField
         boolean result = false;
         printDescription();
         Field field = getField();
-        String initialValue = field.getInitialValue();
-        if (initialValue == null)
+        if (isReadonly())
         {
-            initialValue = "";
+            println(field.getLabel() + " [" + field.getValue() + "] ");
+            return true;
         }
-        String value = getConsole().prompt(field.getLabel() + " [" + initialValue + "] ", initialValue, null);
-        if (value != null)
+        else
         {
-            ValidationStatus status = validate(value);
-            if (!status.isValid())
+            String initialValue = field.getInitialValue();
+            if (initialValue == null)
             {
-                error(status.getMessage());
+                initialValue = "";
             }
-            else
+            String value = getConsole().prompt(field.getLabel() + " [" + initialValue + "] ", initialValue, null);
+            if (value != null)
             {
-                field.setValue(value);
-                result = true;
+                ValidationStatus status = validate(value);
+                if (!status.isValid())
+                {
+                    error(status.getMessage());
+                }
+                else
+                {
+                    field.setValue(value);
+                    result = true;
+                }
             }
         }
+
         return result;
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/button/ConsoleButtonField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/button/ConsoleButtonField.java
@@ -37,23 +37,32 @@ public class ConsoleButtonField  extends ConsoleField
         boolean proceed = true;
 
         println(getField().getLabel());
-        String value = getConsole().prompt(field.getButtonName() + " [y/n]: [n]", "n", "n");
 
-        if(value.equalsIgnoreCase("y"))
+        if (isReadonly())
         {
-            for(ButtonAction buttonAction : field.getButtonActions())
+            println("field.getButtonName() + " + getField());
+            return true;
+        }
+        else
+        {
+            String value = getConsole().prompt(field.getButtonName() + " [y/n]: [n]", "n", "n");
+
+            if(value.equalsIgnoreCase("y"))
             {
-                proceed = buttonAction.execute(getConsole());
-                if (!proceed)
+                for(ButtonAction buttonAction : field.getButtonActions())
                 {
-                    break;
+                    proceed = buttonAction.execute(getConsole());
+                    if (!proceed)
+                    {
+                        break;
+                    }
+                }
+                if(proceed)
+                {
+                    println(field.getSucessMsg());
                 }
             }
-            if(proceed)
-            {
-                println(field.getSucessMsg());
-            }
+            return true;
         }
-        return true;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/check/ConsoleCheckField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/check/ConsoleCheckField.java
@@ -72,13 +72,20 @@ public class ConsoleCheckField extends ConsoleField
         printDescription();
         println("  [" + (selected ? "x" : " ") + "] " + field.getLabel());
 
-        int defaultValue = field.getInitialSelection() ? 1 : 0;
-        int value = getConsole().prompt("Enter 1 to select, 0 to deselect: ", 0, 1, defaultValue, -1);
-        if (value == -1)
+        if (isReadonly())
         {
-            return false;
+            return true;
         }
-        field.setValue(value == 1 ? field.getTrueValue() : field.getFalseValue());
-        return true;
+        else
+        {
+            int defaultValue = field.getInitialSelection() ? 1 : 0;
+            int value = getConsole().prompt("Enter 1 to select, 0 to deselect: ", 0, 1, defaultValue, -1);
+            if (value == -1)
+            {
+                return false;
+            }
+            field.setValue(value == 1 ? field.getTrueValue() : field.getFalseValue());
+            return true;
+        }
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/custom/ConsoleCustomField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/custom/ConsoleCustomField.java
@@ -79,7 +79,7 @@ public class ConsoleCustomField extends ConsoleField implements CustomFieldType
     /**
      * Ensure to display the minimum amount of rows required.
      */
-    private void addInitialRows()
+    private void addInitialRows(boolean readonly)
     {
         for (int count = minRow; count > 1; count--)
         {
@@ -124,25 +124,32 @@ public class ConsoleCustomField extends ConsoleField implements CustomFieldType
             }
 
 
-            while (value == INVALID)
+            if (isReadonly())
             {
-                // Only give options to continue or redisplay when you need to meet the minimum amount of rows
-                // or you are at the max amount of rows
-                if (initial || numberOfRows == maxRow)
-                {
-                    value = getConsole().prompt("Enter 1 continue, or 2 to redisplay", 1, 2, -1, -1);
-                    if (value == 2)
-                    {
-                        value = REDISPLAY;
-                    }
-                } else
-                {
-                    value = getConsole().prompt("Enter 1 continue, or 2 to add another module, 3 to redisplay", 1, 3, -1, -1);
-                }
+                return false;
             }
-            if (value != REDISPLAY)
+            else
             {
-                onModule = false;
+                while (value == INVALID)
+                {
+                    // Only give options to continue or redisplay when you need to meet the minimum amount of rows
+                    // or you are at the max amount of rows
+                    if (initial || numberOfRows == maxRow)
+                    {
+                        value = getConsole().prompt("Enter 1 continue, or 2 to redisplay", 1, 2, -1, -1);
+                        if (value == 2)
+                        {
+                            value = REDISPLAY;
+                        }
+                    } else
+                    {
+                        value = getConsole().prompt("Enter 1 continue, or 2 to add another module, 3 to redisplay", 1, 3, -1, -1);
+                    }
+                }
+                if (value != REDISPLAY)
+                {
+                    onModule = false;
+                }
             }
         }
 
@@ -169,9 +176,10 @@ public class ConsoleCustomField extends ConsoleField implements CustomFieldType
     {
         numberOfRows = 0;
         consoleFields = new HashMap<Integer, List<ConsoleField>>();
+        boolean readonly = isReadonly();
 
-        addInitialRows();
-        while (addRow())
+        addInitialRows(readonly);
+        while (addRow(readonly))
         {
             //Keep adding rows until the user is done or max limit is reached
         }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/file/AbstractConsoleFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/file/AbstractConsoleFileField.java
@@ -73,23 +73,30 @@ public class AbstractConsoleFileField extends ConsoleField
         {
             label = "";
         }
-        String prompt = label + "[" + ((initialValue != null) ? initialValue : "") + "] ";
-        String path = getConsole().promptLocation(prompt, null);
-        if (path != null)
+        if (isReadonly())
         {
-            path = path.trim();
-            if ("".equals(path))
+            println(label + (label.isEmpty()?" ":"") + "[" + field.getValue() + "]");
+        }
+        else
+        {
+            String prompt = label + (label.isEmpty()?" ":"") + "[" + ((initialValue != null) ? initialValue : "") + "] ";
+            String path = getConsole().promptLocation(prompt, null);
+            if (path != null)
             {
-                path = initialValue;
-            }
-            if (path != null && !"".equals(path))
-            {
-                path = field.getAbsoluteFile(path).toString();
-            }
-            if (view.validate(path))
-            {
-                field.setValue(path);
-                result = true;
+                path = path.trim();
+                if ("".equals(path))
+                {
+                    path = initialValue;
+                }
+                if (path != null && !"".equals(path))
+                {
+                    path = field.getAbsoluteFile(path).toString();
+                }
+                if (view.validate(path))
+                {
+                    field.setValue(path);
+                    result = true;
+                }
             }
         }
         return result;

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/file/ConsoleSearchField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/file/ConsoleSearchField.java
@@ -12,8 +12,8 @@ import com.izforge.izpack.util.Console;
  * Based on {@link ConsoleChoiceField}
  */
 public class ConsoleSearchField extends ConsoleField { // ConsoleComboField { //AbstractConsoleFileField {
-	
-	/**
+
+    /**
      * Constructs a {@link ConsoleSearchField}.
      *
      * @param field   the field
@@ -23,14 +23,20 @@ public class ConsoleSearchField extends ConsoleField { // ConsoleComboField { //
     public ConsoleSearchField(SearchField field, Console console, Prompt prompt)
     {
         //super(new SearchFieldView(field, prompt), console, prompt);
-    	super(field, console, prompt);
+        super(field, console, prompt);
     }
 
     @Override
     public boolean display()
     {
-    	SearchField field = (SearchField)getField();
+        SearchField field = (SearchField)getField();
         printDescription();
+
+        if (isReadonly())
+        {
+            println(field.getValue());
+            return true;
+        }
 
         List<String> choices = field.getChoices();
         listChoices(choices, field.getSelectedIndex());
@@ -43,7 +49,7 @@ public class ConsoleSearchField extends ConsoleField { // ConsoleComboField { //
         field.setValue(choices.get(selected));
         return true;
     }
-    
+
     /**
      * Displays the choices.
      *

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/password/ConsolePasswordGroupField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/password/ConsolePasswordGroupField.java
@@ -73,6 +73,12 @@ public class ConsolePasswordGroupField extends ConsoleField
     @Override
     public boolean display()
     {
+        if (isReadonly())
+        {
+            // Do not display password fields in read-only mode
+            return true;
+        }
+
         boolean result = false;
         printDescription();
         String[] passwords = getPasswords();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/AbstractFieldView.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/AbstractFieldView.java
@@ -39,6 +39,11 @@ public abstract class AbstractFieldView implements FieldView
      */
     private boolean displayed = false;
 
+    /**
+     * Determines if the view is readonly.
+     */
+    private boolean readonly = false;
+
 
     /**
      * Constructs an {@link AbstractFieldView}.
@@ -86,25 +91,27 @@ public abstract class AbstractFieldView implements FieldView
         return field.getSummaryKey();
     }
 
-    /**
-     * Determines if the view is being displayed.
-     *
-     * @return {@code true} if the view is being displayed
-     */
     @Override
     public boolean isDisplayed()
     {
         return displayed;
     }
 
-    /**
-     * Determines if the view is being displayed.
-     *
-     * @param displayed {@code true} if the view is being displayed
-     */
     @Override
     public void setDisplayed(boolean displayed)
     {
         this.displayed = displayed;
+    }
+
+    @Override
+    public boolean isReadonly()
+    {
+        return readonly;
+    }
+
+    @Override
+    public void setReadonly(boolean readonly)
+    {
+        this.readonly = readonly;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -142,7 +142,7 @@ public abstract class Field
         processor = config.getProcessor();
         label = config.getLabel();
         description = config.getDescription();
-        displayHidden = config.getDisplayHidden();
+        displayHidden = config.isDisplayHidden();
         tooltip = config.getTooltip();
         omitFromAuto = config.getOmitFromAuto();
         this.condition = config.getCondition();
@@ -201,7 +201,7 @@ public abstract class Field
      *
      * @return {@code true} if displaying hidden otherwise {@code false}
      */
-    public boolean getDisplayHidden()
+    public boolean isDisplayHidden()
     {
         return displayHidden;
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldConfig.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldConfig.java
@@ -56,7 +56,7 @@ public interface FieldConfig
      *
      * @return the 'displayHidden' attribute, or {@code null}
      */
-    boolean getDisplayHidden();
+    boolean isDisplayHidden();
 
     /**
      * Returns the packs that this field applies to.

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldFactory.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldFactory.java
@@ -24,6 +24,7 @@ package com.izforge.izpack.panels.userinput.field;
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.IzPackException;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.button.ButtonField;
 import com.izforge.izpack.panels.userinput.field.button.ButtonFieldReader;
 import com.izforge.izpack.panels.userinput.field.check.CheckField;
@@ -113,6 +114,7 @@ public class FieldFactory
         Field result;
         Type type;
         String value = config.getAttribute(element, "type");
+        RulesEngine rules = installData.getRules();
         try
         {
             type = Type.valueOf(value.toUpperCase());
@@ -127,7 +129,7 @@ public class FieldFactory
                 result = new ButtonField(new ButtonFieldReader(element, config, installData), installData);
                 break;
             case CHECK:
-                result = new CheckField(new CheckFieldReader(element, config), installData);
+                result = new CheckField(new CheckFieldReader(element, config, rules), installData);
                 break;
             case COMBO:
                 result = new ComboField(new SimpleChoiceReader(element, config, installData), installData);
@@ -136,40 +138,40 @@ public class FieldFactory
                 result = new CustomField(new CustomFieldReader(element, config, matcher, installData), installData);
                 break;
             case DIR:
-                result = new DirField(new DirFieldReader(element, config), installData);
+                result = new DirField(new DirFieldReader(element, config, rules), installData);
                 break;
             case DIVIDER:
-                result = new Divider(new DividerReader(element, config), installData);
+                result = new Divider(new DividerReader(element, config, rules), installData);
                 break;
             case FILE:
-                result = new FileField(new FileFieldReader(element, config), installData);
+                result = new FileField(new FileFieldReader(element, config, rules), installData);
                 break;
             case MULTIFILE:
-                result = new MultipleFileField(new MultipleFileFieldReader(element, config), installData);
+                result = new MultipleFileField(new MultipleFileFieldReader(element, config, rules), installData);
                 break;
             case PASSWORD:
-                result = new PasswordGroupField(new PasswordGroupFieldReader(element, config), installData);
+                result = new PasswordGroupField(new PasswordGroupFieldReader(element, config, rules), installData);
                 break;
             case RADIO:
                 result = new RadioField(new SimpleChoiceReader(element, config, installData), installData);
                 break;
             case RULE:
-                result = new RuleField(new RuleFieldReader(element, config), installData, config.getFactory());
+                result = new RuleField(new RuleFieldReader(element, config, rules), installData, config.getFactory());
                 break;
             case SEARCH:
-                result = new SearchField(new SearchFieldReader(element, config, matcher), installData);
+                result = new SearchField(new SearchFieldReader(element, config, rules, matcher), installData);
                 break;
             case SPACE:
-                result = new Spacer(new SimpleFieldReader(element, config), installData);
+                result = new Spacer(new SimpleFieldReader(element, config, rules), installData);
                 break;
             case STATICTEXT:
-                result = new StaticText(new StaticTextFieldReader(element, config), installData);
+                result = new StaticText(new StaticTextFieldReader(element, config, rules), installData);
                 break;
             case TEXT:
-                result = new TextField(new FieldReader(element, config), installData);
+                result = new TextField(new FieldReader(element, config, rules), installData);
                 break;
             case TITLE:
-                result = new TitleField(new TitleFieldReader(element, config), installData);
+                result = new TitleField(new TitleFieldReader(element, config, rules), installData);
                 break;
             default:
                 throw new IzPackException("Unsupported field type: " + value + " in " + config.getContext(element));

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldView.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldView.java
@@ -50,4 +50,18 @@ public interface FieldView
      */
     void setDisplayed(boolean displayed);
 
+    /**
+     * Determines if the view is read-only.
+     *
+     * @return {@code true} if the view is read-only
+     */
+    boolean isReadonly();
+
+    /**
+     * Set the view read-only or not.
+     *
+     * @param displayed {@code true} if the view is read-only
+     */
+    void setReadonly(boolean readonly);
+
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/SimpleChoiceReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/SimpleChoiceReader.java
@@ -32,7 +32,7 @@ public class SimpleChoiceReader extends FieldReader implements ChoiceFieldConfig
      */
     public SimpleChoiceReader(IXMLElement field, Config config, InstallData installData)
     {
-        super(field, config);
+        super(field, config, installData.getRules());
         this.installData = installData;
 
         for (IXMLElement choice : getSpec().getChildrenNamed("choice"))

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/SimpleFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/SimpleFieldReader.java
@@ -20,6 +20,7 @@
 package com.izforge.izpack.panels.userinput.field;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 
 
 /**
@@ -35,9 +36,9 @@ public class SimpleFieldReader extends FieldReader
      * @param field  the field
      * @param config the configuration
      */
-    public SimpleFieldReader(IXMLElement field, Config config)
+    public SimpleFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/button/ButtonFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/button/ButtonFieldReader.java
@@ -26,7 +26,7 @@ public class ButtonFieldReader extends SimpleFieldReader implements ButtonFieldC
      */
     public ButtonFieldReader(IXMLElement field, Config config, InstallData installData)
     {
-        super(field, config);
+        super(field, config, installData.getRules());
         this.installData = installData;
         this.messages = installData.getMessages();
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/check/CheckFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/check/CheckFieldReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.check;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 import com.izforge.izpack.panels.userinput.field.FieldReader;
 
@@ -40,9 +41,9 @@ public class CheckFieldReader extends FieldReader implements CheckFieldConfig
      * @param field  the field element
      * @param config the configuration
      */
-    public CheckFieldReader(IXMLElement field, Config config)
+    public CheckFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/custom/CustomFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/custom/CustomFieldReader.java
@@ -30,7 +30,7 @@ public class CustomFieldReader extends FieldReader implements CustomFieldConfig
      */
     public CustomFieldReader(IXMLElement field, Config config, PlatformModelMatcher matcher, InstallData installData)
     {
-        super(field, config);
+        super(field, config, installData.getRules());
         this.installData = installData;
         this.config = config;
         this.matcher = matcher;

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/divider/DividerReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/divider/DividerReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.divider;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Alignment;
 import com.izforge.izpack.panels.userinput.field.Config;
 import com.izforge.izpack.panels.userinput.field.SimpleFieldReader;
@@ -40,9 +41,9 @@ public class DividerReader extends SimpleFieldReader implements DividerConfig
      *
      * @param config the configuration
      */
-    public DividerReader(IXMLElement element, Config config)
+    public DividerReader(IXMLElement element, Config config, RulesEngine rules)
     {
-        super(element, config);
+        super(element, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/AbstractFileFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/AbstractFileFieldReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.file;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 import com.izforge.izpack.panels.userinput.field.FieldReader;
 
@@ -40,9 +41,9 @@ public abstract class AbstractFileFieldReader extends FieldReader implements Fil
      * @param field  the field element
      * @param config the configuration
      */
-    public AbstractFileFieldReader(IXMLElement field, Config config)
+    public AbstractFileFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/DirFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/DirFieldReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.file;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 
 
@@ -39,9 +40,9 @@ public class DirFieldReader extends AbstractFileFieldReader implements DirFieldC
      * @param field  the field element
      * @param config the configuration
      */
-    public DirFieldReader(IXMLElement field, Config config)
+    public DirFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/FileFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/FileFieldReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.file;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 
 /**
@@ -37,8 +38,8 @@ public class FileFieldReader extends AbstractFileFieldReader
      * @param field  the field element
      * @param config the configuration
      */
-    public FileFieldReader(IXMLElement field, Config config)
+    public FileFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/MultipleFileFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/MultipleFileFieldReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.file;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 
 
@@ -39,9 +40,9 @@ public class MultipleFileFieldReader extends AbstractFileFieldReader implements 
      * @param field  the field element
      * @param config the configuration
      */
-    public MultipleFileFieldReader(IXMLElement field, Config config)
+    public MultipleFileFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/password/PasswordGroupFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/password/PasswordGroupFieldReader.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 import com.izforge.izpack.panels.userinput.field.FieldReader;
 
@@ -43,9 +44,9 @@ public class PasswordGroupFieldReader extends FieldReader implements PasswordGro
      * @param field the field element
      * @param config the configuration
      */
-    public PasswordGroupFieldReader(IXMLElement field, Config config)
+    public PasswordGroupFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/rule/RuleFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/rule/RuleFieldReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.rule;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 import com.izforge.izpack.panels.userinput.field.FieldReader;
 
@@ -40,9 +41,9 @@ public class RuleFieldReader extends FieldReader implements RuleFieldConfig
      * @param field the field element
      * @param config the configuration
      */
-    public RuleFieldReader(IXMLElement field, Config config)
+    public RuleFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/search/SearchFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/search/SearchFieldReader.java
@@ -29,6 +29,7 @@ import java.util.logging.Logger;
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.binding.OsModel;
 import com.izforge.izpack.api.exception.IzPackException;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 import com.izforge.izpack.panels.userinput.field.FieldReader;
 import com.izforge.izpack.util.OsConstraintHelper;
@@ -74,9 +75,9 @@ public class SearchFieldReader extends FieldReader implements SearchFieldConfig
      * @param field  the field element
      * @param config the configuration
      */
-    public SearchFieldReader(IXMLElement field, Config config, PlatformModelMatcher matcher)
+    public SearchFieldReader(IXMLElement field, Config config, RulesEngine rules, PlatformModelMatcher matcher)
     {
-        super(field, config);
+        super(field, config, rules);
         this.matcher = matcher;
     }
 
@@ -162,7 +163,7 @@ public class SearchFieldReader extends FieldReader implements SearchFieldConfig
         for (IXMLElement element : spec.getChildrenNamed("choice"))
         {
             List<OsModel> models = OsConstraintHelper.getOsList(element);
-            
+
             if (matcher.matchesCurrentPlatform(models))
             {
                 String value = config.getString(element, "value", null);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/statictext/StaticTextFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/statictext/StaticTextFieldReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.statictext;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Config;
 import com.izforge.izpack.panels.userinput.field.SimpleFieldReader;
 
@@ -39,9 +40,9 @@ public class StaticTextFieldReader extends SimpleFieldReader
      * @param field  the field element
      * @param config the configuration
      */
-    public StaticTextFieldReader(IXMLElement field, Config config)
+    public StaticTextFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/title/TitleFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/title/TitleFieldReader.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.panels.userinput.field.title;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.panels.userinput.field.Alignment;
 import com.izforge.izpack.panels.userinput.field.Config;
 import com.izforge.izpack.panels.userinput.field.SimpleFieldReader;
@@ -40,9 +41,9 @@ public class TitleFieldReader extends SimpleFieldReader implements TitleFieldCon
      * @param field  the field element
      * @param config the configuration
      */
-    public TitleFieldReader(IXMLElement field, Config config)
+    public TitleFieldReader(IXMLElement field, Config config, RulesEngine rules)
     {
-        super(field, config);
+        super(field, config, rules);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/Component.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/Component.java
@@ -1,16 +1,16 @@
 /*
  * IzPack - Copyright 2001-2009 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2009 Dennis Reil
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -20,6 +20,9 @@
 package com.izforge.izpack.panels.userinput.gui;
 
 import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+import javax.swing.text.JTextComponent;
 
 /**
  * Field component.
@@ -47,6 +50,23 @@ public class Component
     public Object getConstraints()
     {
         return constraints;
+    }
+
+    public void setEnabled(boolean enabled)
+    {
+        if (component instanceof JLabel)
+        {
+            return;
+        }
+        if (component instanceof JTextComponent)
+        {
+            JTextComponent textComponent = ((JTextComponent)component);
+            if (!textComponent.isFocusable() || !textComponent.isEditable())
+            {
+                return;
+            }
+        }
+        component.setEnabled(enabled);
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/RuleInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/RuleInputField.java
@@ -193,6 +193,15 @@ public class RuleInputField extends JComponent implements KeyListener, FocusList
         }
     }
 
+    @Override
+    public void setEnabled(boolean enabled) {
+        for (JTextField jTextField : inputFields)
+        {
+            jTextField.setEnabled(enabled);
+        }
+        super.setEnabled(enabled);
+    };
+
     /*---------------------------------------------------------------------------*
      Implementation for KeyListener
      *---------------------------------------------------------------------------*/

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/field/TestFieldConfig.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/field/TestFieldConfig.java
@@ -92,7 +92,7 @@ public class TestFieldConfig implements FieldConfig
     }
 
     @Override
-    public boolean getDisplayHidden()
+    public boolean isDisplayHidden()
     {
         return false;
     }


### PR DESCRIPTION
This issue enhances the introduced read-only fields and panels from issue IZPACK-1120. The issue dealt exclusively for panels which are not displayed due to some not fulfilled condition and introduced the `displayHidden` attribute in the UserInputSpec.xml resource for panels and fields.

To make this more universal I'd infringe the rule to not introduce new features to 5.0 and put it to a more complete shape.

Imagine the following possibilities including those of IZPACK-1120:

**UserInputSpec.xml:**

**Introduced by IZPACK-1120:**

``` xml
<panel id="panel.dbsettings.review" displayHidden="true">
...
</panel>
<panel id="panel.dbsettings.review2" >
  <field ... displayHidden="true">
  </field>
...
</panel>
```

`displayHidden="true"` (default `"false"`) introduced displaying a panel or just dedicated user input fields to be displayed read-only although they have been disabled according to a condition on the panel (install.xml, UserInputSpec.xml) or on the field (UserInputSpec.xml) .

**New attributes:**

``` xml
<panel id="panel.dbsettings.review" displayHiddenCondition="SomeCondition">
...
</panel>
<panel id="panel.dbsettings.review2" >
  <field ... displayHiddenCondition="SomeCondition">
  </field>
...
</panel>
```

The `displayHiddenCondition` attribute enhances and replaces the `displayHidden` condition introduced by IZPACK-1120 and makes the related behavior dependent on another condition. Thus, the related panel or field gets displayed read-only only if a general condition on that panel or field disables it for displaying and the condition defined by `displayHiddenCondition` gets true.

``` xml
<panel id="panel.dbsettings.review" readonly="true">
...
</panel>
<panel id="panel.dbsettings.review2" >
  <field ... readonly="true">
  </field>
...
</panel>
```

The `readonly` attribute is completely new and reverses the logic - `readonly="true"` means to display a complete panel or field read-only in general in case it is not disabled by a general panel or field condition.

``` xml
<panel id="panel.dbsettings.review" readonlyCondition="SomeCondition">
...
</panel>
<panel id="panel.dbsettings.review2" >
  <field ... readonlyCondition="SomeCondition">
  </field>
...
</panel>
```

The new `readonlyCondition` attribute enhances and replaces the `readonly` condition and makes the related behavior dependent on another condition. Thus, the related panel or field gets displayed read-only only if it is not disabled by a general panel or field condition and the condition defined by `readonlyCondition` gets true.
