### PR TITLE
[IZPACK-1194] "contains" condition does not work for checking plain <variable> values (post-fix)

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
@@ -124,10 +124,6 @@ public class ContainsCondition extends Condition {
     if (content == null)
       return false;
 
-    if (isRegEx && isByLine)
-    {
-        return matchesByLine(new StringReader(content));
-    }
     if (isRegEx)
     {
         if (isByLine)


### PR DESCRIPTION
This change is just a post-fix with clean-up, no functional bug, just code involved twice after the implementation originally introduced in https://github.com/izpack/izpack/pull/293.
