### PR TITLE
Load default directory from resources if there is no variable specified and relaunch with same arguments for privilege escalation

### DIFF
--- a/src/lib/com/izforge/izpack/installer/Installer.java
+++ b/src/lib/com/izforge/izpack/installer/Installer.java
@@ -39,6 +39,9 @@ public class Installer {
 
 	public static final int INSTALLER_GUI = 0, INSTALLER_AUTO = 1, INSTALLER_CONSOLE = 2;
 	public static final int CONSOLE_INSTALL = 0, CONSOLE_GEN_TEMPLATE = 1, CONSOLE_FROM_TEMPLATE = 2;
+	
+	private static String[] args;
+	private static int type;
 
     /*
 	 * The main method (program entry point).
@@ -49,6 +52,9 @@ public class Installer {
 		Debug.log(" - Logger initialized at '" + new Date(System.currentTimeMillis()) + "'.");
 
 		Debug.log(" - commandline args: " + StringTool.stringArrayToSpaceSeparatedString(args));
+		
+		// Save the arguments in case need to re-launch because of privilege escalation.
+		Installer.args = args;
 
 		// OS X tweakings
 		if (System.getProperty("mrj.version") != null) {
@@ -60,7 +66,7 @@ public class Installer {
 		try {
 		    Iterator<String> args_it = Arrays.asList(args).iterator();
 		    
-		    int type = INSTALLER_GUI;
+		    type = INSTALLER_GUI;
 		    int consoleAction = CONSOLE_INSTALL;
 		    String path = null, langcode = null;
 		    
@@ -131,5 +137,13 @@ public class Installer {
 			e.printStackTrace();
 			System.exit(1);
 		}
+	}
+	
+	public static String[] getArgs() {
+	    return args;
+	}
+	
+	public static boolean isGUI() {
+	    return type == INSTALLER_GUI;
 	}
 }

--- a/src/lib/com/izforge/izpack/installer/PrivilegedRunner.java
+++ b/src/lib/com/izforge/izpack/installer/PrivilegedRunner.java
@@ -25,7 +25,6 @@ import com.izforge.izpack.util.OsVersion;
 
 import java.io.*;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -174,6 +173,12 @@ public class PrivilegedRunner
             elevator.add(installer);
         }
 
+        // Add command line arguments
+        String[] args = Installer.getArgs();
+        for (String arg : args) {
+            elevator.add(arg);
+        }
+        
         return elevator;
     }
 
@@ -256,7 +261,8 @@ public class PrivilegedRunner
     {
         if (OsVersion.IS_WINDOWS)
         {
-            return "javaw.exe";
+            // if not GUI, use java.exe
+            return Installer.isGUI() ? "javaw.exe" : "java.exe";
         }
         else
         {

--- a/src/lib/com/izforge/izpack/panels/TargetPanel.java
+++ b/src/lib/com/izforge/izpack/panels/TargetPanel.java
@@ -47,6 +47,8 @@ public class TargetPanel extends PathInputPanel
     public TargetPanel(InstallerFrame parent, InstallData idata)
     {
         super(parent, idata);
+        // load and save default directory from resource
+        super.loadDefaultInstallDir(parent, idata);
     }
 
     /**
@@ -56,6 +58,10 @@ public class TargetPanel extends PathInputPanel
     {
         // load the default directory info (if present)
         String path = TargetPanelConsoleHelper.loadDefaultInstallDirFromVariables(idata.getVariables());
+        // If no default directory in variables, load from resource
+        if (path==null) {
+            path = defaultInstallDir;
+        }
         if(path!=null)
     {
             setDefaultInstallDir(path);


### PR DESCRIPTION
1. The current version of 4.3 broke the ability to specify default install directories using the TargetDir.os.xxx resource files as described in http://izpack.org/documentation/panels.html#targetpanel.

This fixes the problem by reading in and using the resource files if no TargetDir.os.xxx variable is specifically specified.

2. In addition, in the current version if there is a privilege escalation under Windows, any command line arguments specified are lost when the application is relaunched with a higher privilege.  This was fixed as was calling the correct java executable: javaw.exe for GUI and java.exe for command line.  

I'm not sure why it's showing that the entire TargetPanel.java file changed as there were only 4 lines added.