### PR TITLE
IZPACK-1207, IZPACK-1208 - panel enhancements

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/ConfigurationOption.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/ConfigurationOption.java
@@ -1,0 +1,62 @@
+package com.izforge.izpack.api.data;
+
+import java.io.Serializable;
+
+import com.izforge.izpack.api.rules.RulesEngine;
+
+public class ConfigurationOption implements Serializable
+{
+    private static final long serialVersionUID = 2616397619106736648L;
+
+    private final String value;
+
+    private final String conditionId;
+
+    private final String defaultValue;
+
+
+    public ConfigurationOption(String value, String conditionId, String defaultValue)
+    {
+        super();
+        this.value = value;
+        this.conditionId = conditionId;
+        this.defaultValue = defaultValue;
+    }
+
+    public ConfigurationOption(String value, String conditionId)
+    {
+        this(value, conditionId, null);
+    }
+
+    public ConfigurationOption(String value)
+    {
+        this(value, null);
+    }
+
+    /**
+     * Get the option's current value according to the optional condition
+     *
+     * @return the current value
+     */
+    public String getValue(RulesEngine rules)
+    {
+        final String result;
+        if (rules == null | conditionId == null || rules.isConditionTrue(conditionId))
+        {
+            result = value;
+        }
+        else
+        {
+            result = defaultValue;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "value='"+value+"'"
+                +(conditionId==null?"":"conditionId+"+conditionId+"'")
+                +(defaultValue==null?"":"defaultValue+"+defaultValue+"'");
+    }
+}

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import com.izforge.izpack.api.data.binding.Action;
 import com.izforge.izpack.api.data.binding.Help;
 import com.izforge.izpack.api.data.binding.OsModel;
+import com.izforge.izpack.api.rules.RulesEngine;
 
 /**
  * @author Jan Blok
@@ -135,7 +136,7 @@ public class Panel implements Serializable
     /**
      * Contains configuration values for a panel.
      */
-    private Map<String, String> configuration = null;
+    private Map<String, ConfigurationOption> configuration = null;
 
 
     public String getClassName()
@@ -383,26 +384,41 @@ public class Panel implements Serializable
         this.postValidationActions.add(action);
     }
 
-    public boolean hasConfiguration()
-    {
-        return this.configuration != null;
-    }
-
-    public void addConfiguration(String key, String value)
+    /**
+     * Add an optional configuration option additionally depending on the according configuration
+     * option condition (if defined)
+     *
+     * @param name Configuration option name
+     * @param the configuration option
+     */
+    public void addConfigurationOption(String name, ConfigurationOption option)
     {
         if (this.configuration == null)
         {
-            this.configuration = new HashMap<String, String>();
+            this.configuration = new HashMap<String, ConfigurationOption>();
         }
-        this.configuration.put(key, value);
+        this.configuration.put(name, option);
     }
 
-    public String getConfiguration(String key)
+    /**
+     * Get an optional configuration value additionally depending on the according configuration
+     * option condition (if defined)
+     *
+     * @param name Configuration option name
+     * @param rules Current RulesEngine instance
+     * @return the effective value or {@code null}
+     */
+    public String getConfigurationOptionValue(String name, RulesEngine rules)
     {
         String result = null;
+        ConfigurationOption option = null;
         if (this.configuration != null)
         {
-            result = this.configuration.get(key);
+            option = this.configuration.get(name);
+        }
+        if (option != null)
+        {
+            result = option.getValue(rules);
         }
         return result;
     }

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -67,6 +67,7 @@ import com.izforge.izpack.api.adaptator.IXMLWriter;
 import com.izforge.izpack.api.adaptator.impl.XMLParser;
 import com.izforge.izpack.api.adaptator.impl.XMLWriter;
 import com.izforge.izpack.api.data.Blockable;
+import com.izforge.izpack.api.data.ConfigurationOption;
 import com.izforge.izpack.api.data.DynamicInstallerRequirementValidator;
 import com.izforge.izpack.api.data.DynamicVariable;
 import com.izforge.izpack.api.data.GUIPrefs;
@@ -1580,13 +1581,29 @@ public class CompilerConfig extends Thread
             if (configurationElement != null)
             {
                 logger.fine("Found a configuration for panel " + panel.getPanelId());
-                List<IXMLElement> params = configurationElement.getChildrenNamed("param");
+                List<IXMLElement> params = configurationElement.getChildren();
                 for (IXMLElement param : params)
                 {
-                    String name = xmlCompilerHelper.requireAttribute(param, "name");
-                    String value = xmlCompilerHelper.requireAttribute(param, "value");
-                    logger.fine("Adding configuration property " + name + " with value " + value);
-                    panel.addConfiguration(name, value);
+                    String elementName = param.getName();
+                    String name = elementName;
+                    final String value;
+                    final ConfigurationOption option;
+                    if (elementName.equals("param"))
+                    {
+                        // TODO after 5.0: Compatibility: Nested <param name="..." value="..." /> (remove in future?)
+                        name = xmlCompilerHelper.requireAttribute(param, "name");
+                        value = xmlCompilerHelper.requireAttribute(param, "value");
+                        option = new ConfigurationOption(value);
+                    }
+                    else
+                    {
+                        value = xmlCompilerHelper.requireContent(param);
+                        option = new ConfigurationOption(value,
+                                param.getAttribute("condition"),
+                                param.getAttribute("defaultValue"));
+                    }
+                    logger.fine("-> Adding configuration option " + name + " (" + option + ")");
+                    panel.addConfigurationOption(name, option);
                 }
             }
 

--- a/izpack-dist/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-dist/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -32,7 +32,7 @@
     <!--                                                                                                        -->
     <xs:element name="installation">
         <xs:complexType>
-            <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
                 <xs:element name="properties" type="propertiesType" minOccurs="0"/>
                 <xs:element name="info" type="infoType" minOccurs="1"/>
                 <xs:element name="variables" type="variablesType" minOccurs="0"/>
@@ -49,7 +49,7 @@
                 <xs:element name="panels" type="panelsType" minOccurs="1"/>
                 <xs:element name="packs" type="packsType" minOccurs="1"/>
                 <xs:element name="natives" type="nativesType" minOccurs="0"/>
-            </xs:sequence>
+            </xs:choice>
             <xs:attribute name="version" type="xs:string" fixed="5.0"/>
         </xs:complexType>
     </xs:element>
@@ -98,11 +98,11 @@
         </xs:sequence>
     </xs:complexType>
 
-	<xs:complexType name="tempDirType">
-		<xs:attribute type="xs:string" name="variablename" use="optional" />
-		<xs:attribute type="xs:string" name="prefix" use="optional" />
-		<xs:attribute type="xs:string" name="suffix" use="optional" />
-	</xs:complexType>
+  <xs:complexType name="tempDirType">
+    <xs:attribute type="xs:string" name="variablename" use="optional" />
+    <xs:attribute type="xs:string" name="prefix" use="optional" />
+    <xs:attribute type="xs:string" name="suffix" use="optional" />
+  </xs:complexType>
 
     <xs:complexType name="runPrivilegedType">
         <xs:attribute type="xs:string" name="condition" use="optional"/>
@@ -329,18 +329,25 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:attributeGroup name="panelConfigurationOptionGroup">
+      <xs:attribute name="condition" type="xs:string" use="optional" />
+    </xs:attributeGroup>
+
     <xs:complexType name="panelType">
         <xs:sequence>
             <xs:element name="configuration" minOccurs="0">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="param" type="nameValueType" minOccurs="0" maxOccurs="unbounded"/>
+                        <!-- <xs:element name="param" type="nameValueType" minOccurs="0" maxOccurs="unbounded"/> -->
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
                     </xs:sequence>
+                    <xs:attributeGroup ref="panelConfigurationOptionGroup"/>
                 </xs:complexType>
             </xs:element>
             <xs:element name="validator" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:attribute type="xs:string" name="classname" use="required"/>
+                    <xs:attribute type="xs:string" name="condition" use="optional"/>
                 </xs:complexType>
             </xs:element>
             <xs:element name="actions" minOccurs="0">
@@ -454,6 +461,7 @@
         <xs:attribute name="targetdir" type="xs:string" use="optional" default="${INSTALL_PATH}"/>
         <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
         <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
+        <xs:attribute name="condition" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="fileSetTypePack">
@@ -533,6 +541,7 @@
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="keep" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="condition" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="updateCheckType">

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputPanel.java
@@ -49,6 +49,21 @@ public class PathInputPanel extends IzPanel implements ActionListener
     private static final transient Logger logger = Logger.getLogger(PathInputPanel.class.getName());
 
     /**
+     * ShowCreateDirectoryMessage configuration option<br>
+     * If 'ShowCreateDirectoryMessage' configuration option set 'false' then don't show
+     * then don't show "directory will be created" dialog
+     */
+    private static final String SHOWCREATEDIRECTORYMESSAGE = "ShowCreateDirectoryMessage";
+
+    /**
+     * ShowExistingDirectoryWarning configuration option<br>
+     * If 'ShowExistingDirectoryWarning' configuration option set 'false' then don't show
+     * "The directory already exists! Are you sure you want to install here and possibly overwrite existing files?"
+     * warning dialog
+     */
+    private static final String SHOWEXISTINGDIRECTORYWARNING = "ShowExistingDirectoryWarning";
+
+    /**
      * Flag whether the choosen path must exist or not
      */
     protected boolean mustExist = false;
@@ -343,9 +358,9 @@ public class PathInputPanel extends IzPanel implements ActionListener
     protected boolean checkCreateDirectory(File dir)
     {
         boolean result = true;
-        //if 'ShowCreateDirectoryMessage' variable set to 'false'
+        // if 'ShowCreateDirectoryMessage' configuration option set 'false' then don't show
         // then don't show "directory will be created" dialog:
-        String show = installData.getVariable("ShowCreateDirectoryMessage");
+        String show = getMetadata().getConfigurationOptionValue(SHOWCREATEDIRECTORYMESSAGE, installData.getRules());
         if (show == null || Boolean.getBoolean(show))
         {
             result = emitNotificationFeedback(getI18nStringForClass("createdir", "TargetPanel") + "\n" + dir);
@@ -361,9 +376,17 @@ public class PathInputPanel extends IzPanel implements ActionListener
      */
     protected boolean checkOverwrite(File dir)
     {
-        return askWarningQuestion(getString("installer.warning"), warnMsg,
-                           AbstractUIHandler.CHOICES_YES_NO, AbstractUIHandler.ANSWER_YES)
-                == AbstractUIHandler.ANSWER_YES;
+        boolean result = true;
+        // if 'ShowExistingDirectoryWarning' configuration option set 'false' then don't show
+        // "The directory already exists! Are you sure you want to install here and possibly overwrite existing files?"
+        // warning dialog:
+        String show = getMetadata().getConfigurationOptionValue(SHOWEXISTINGDIRECTORYWARNING, installData.getRules());
+        if (show == null || Boolean.getBoolean(show))
+        {
+            result = askWarningQuestion(getString("installer.warning"), warnMsg,
+                    AbstractUIHandler.CHOICES_YES_NO, AbstractUIHandler.ANSWER_YES) == AbstractUIHandler.ANSWER_YES;
+        }
+        return result;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathInputPanel.java
@@ -103,7 +103,7 @@ public class UserPathInputPanel extends IzPanel implements ActionListener
         _variableName = getString(targetPanel + ".variableName");
 
         String mustExist;
-        if ((mustExist = panel.getConfiguration("mustExist")) != null) {
+        if ((mustExist = panel.getConfigurationOptionValue("mustExist", installData.getRules())) != null) {
             this._mustExist = Boolean.parseBoolean(mustExist);
         }
 

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/InstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/InstallationTest.java
@@ -74,7 +74,7 @@ public class InstallationTest
     @InstallFile("samples/helloAndFinish.xml")
     public void testHelloAndFinishPanels() throws Exception
     {
-    	Image image = icons.get("JFrameIcon").getImage();
+        Image image = icons.get("JFrameIcon").getImage();
         assertThat(image, IsNull.<Object>notNullValue());
 
         languageDialog.initLangPack();
@@ -107,8 +107,8 @@ public class InstallationTest
         installerController.buildInstallation();
 
         HelloPanel helloPanel = (HelloPanel) installerContainer.getComponent("hellopanel");
-        assertThat(helloPanel.getMetadata().getConfiguration("config1"), Is.is("value1"));
-        assertThat(helloPanel.getMetadata().getConfiguration("config2"), Is.is("value2"));
+        assertThat(helloPanel.getMetadata().getConfigurationOptionValue("config1", installData.getRules()), Is.is("value1"));
+        assertThat(helloPanel.getMetadata().getConfigurationOptionValue("config2", installData.getRules()), Is.is("value2"));
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses a couple of issues partly depending on on each other at once:
- https://jira.codehaus.org/browse/IZPACK-1207
  Make TargetPanel.warn ("The directory already exists! Are you sure you want to install here and possibly overwrite existing files?") message optional
- https://jira.codehaus.org/browse/IZPACK-1208
  Enhance panel configuration options (syntax, add conditions)
- XSD fixes for recent implementations

**IZPACK-1207**
On TargetPanel, there is a message {{TargetPanel.warn}} ("The directory already exists! Are you sure you want to install here and possibly overwrite existing files?") shown uncondtionally.

This might be inconvenient if you want to provide an update installer, which counts with existing files in the target directory.

An option would be needed for being able to deactivate this warning and continue wit the installation.

Note:
There is already a optional {{ShowCreateDirectoryMessage}} boolean IzPack variable used for controlling a similar warning whether the target directory should be created if it doesn't exist. This approach might be enough for now.

**IZPACK-1208**
In future, it should be possible to define panel {{configuration}} entries using the element name as the option name directly, similar to Maven.

Additionally there should be used optional conditions which must evaluate true before the given value applies.

The old syntax {{<param name="..." value="..." />}} will be preserved for compatibility reasons to not break older environments, but I will recommend to use the newer one.

Example:

``` xml
<panel classname="TargetPanel" id="panel.target">
  <configuration>
    <!-- Don't show warning if target directory already exists -->
    <param name="ShowExistingDirectoryWarning" value="false" />
  </configuration>
</panel>
```

should be written now:

``` xml
<panel classname="TargetPanel" id="panel.target">
  <configuration>
    <!-- Don't show warning if target directory already exists -->
    <ShowExistingDirectoryWarning>false</ShowExistingDirectoryWarning>
  </configuration>
</panel>
```

which can be enhanced by a condition:

``` xml
<panel classname="TargetPanel" id="panel.target">
  <configuration>
    <!-- Don't show warning if target directory already exists -->
    <ShowExistingDirectoryWarning condition="isUninstaller|isUpdate">false</ShowExistingDirectoryWarning>
  </configuration>
</panel>
```

**XSD fixes**
There are several installation descriptor schema fixes I found for recent implementations
