### PR TITLE
IZPACK-1210: IzPack cannot build with JDK 8

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
@@ -332,11 +332,11 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
         }
         else if (configurable instanceof Ini)
         {
-            ((Ini) configurable).remove(section, key);
+            ((Ini) configurable).removeOptionFromSection(section, key);
         }
         else if (configurable instanceof Reg)
         {
-            ((Reg) configurable).remove(section, key);
+            ((Reg) configurable).removeOptionFromSection(section, key);
         }
         else
         {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/BasicProfile.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/BasicProfile.java
@@ -156,7 +156,7 @@ public class BasicProfile extends CommonMultiMap<String, Profile.Section> implem
         return remove((Object) section.getName());
     }
 
-    @Override public String remove(Object sectionName, Object optionName)
+    @Override public String removeOptionFromSection(Object sectionName, Object optionName)
     {
         Section sec = get(sectionName);
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Profile.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Profile.java
@@ -56,7 +56,7 @@ public interface Profile extends MultiMap<String, Profile.Section>, CommentedMap
 
     Section remove(Profile.Section section);
 
-    String remove(Object sectionName, Object optionName);
+    String removeOptionFromSection(Object sectionName, Object optionName);
 
     interface Section extends OptionMap
     {


### PR DESCRIPTION
This is an initial solution to the JDK 8 buildability issue. Renaming this method avoids collision with the method found in documentation here:
http://docs.oracle.com/javase/8/docs/api/java/util/Map.html#remove-java.lang.Object-java.lang.Object-