### PR TITLE
Fix for IZPACK-1191 (1190 and 1189 also)

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -466,6 +466,9 @@ public class CompilerConfig extends Thread
             {
                 String lafName = prefs.lookAndFeelMapping.get(s);
                 LookAndFeels feels = LookAndFeels.lookup(lafName);
+                if (feels == null){
+                    assertionHelper.parseError(guiPrefsElement, "Unrecognized Look and Feel: " + lafName);
+                }
                 List<Mergeable> mergeableList = Collections.emptyList();
                 switch (feels)
                 {


### PR DESCRIPTION
Explicit check for null here since the lookup will return null if lafName doesn't exist, which causes NPE in the switch(feels) statment.

This also fixes 1190 and 1189 simultaneously, since both metal and aqua LAFs don't exist in the LookAndFeels class, so they're just a more specific case of 1190.