### PR TITLE
[IZPACK-1211] UserInputPanel: Missing variable resolution in attribute <field><spec text="..."/><field> including the according translations

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -309,6 +309,7 @@ public class UserInputPanel extends IzPanel
             {
                 view.setDisplayed(false);
             }
+            updated |= view.translateStaticText();
             updated |= view.updateView();
         }
         if (updated)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -345,7 +345,7 @@ public abstract class Field
     {
         if (defaultValue != null)
         {
-            return installData.getVariables().replace(defaultValue);
+            return replaceVariables(defaultValue);
         }
         return null;
     }
@@ -367,7 +367,7 @@ public abstract class Field
         String result = null;
         if (initialValue != null)
         {
-            result = installData.getVariables().replace(initialValue);
+            result = replaceVariables(initialValue);
         }
         if (result == null)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
@@ -167,19 +167,34 @@ public abstract class GUIField extends AbstractFieldView
     }
 
     /**
-     * Refresh JLabel texts to replace variables
+     * Refresh not editable texts to replace variables
+     *
+     * @return whether the text changed
      */
-    protected void refreshStaticText()
+    public final boolean translateStaticText()
     {
+        boolean updated = false;
         for (Component c : components)
         {
             JComponent jc = c.getComponent();
             if (jc instanceof JTextPane)
             {
                 JTextPane pane = (JTextPane)jc;
-                pane.setText(replaceVariables(pane.getText()));
+                String oldText = pane.getText();
+                String newText = replaceVariables(pane.getText());
+                updated |= oldText.equals(newText);
+                pane.setText(newText);
+            }
+            else if (jc instanceof JLabel)
+            {
+                JLabel label = (JLabel)jc;
+                String oldText = label.getText();
+                String newText = replaceVariables(label.getText());
+                updated |= oldText.equals(newText);
+                label.setText(newText);
             }
         }
+        return updated;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/statictext/GUIStaticText.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/statictext/GUIStaticText.java
@@ -43,11 +43,4 @@ public class GUIStaticText extends GUIField
         addText(getField().getLabel());
         addTooltip();
     }
-
-    @Override
-    public boolean updateView()
-    {
-        refreshStaticText();
-        return false;
-    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/title/GUITitleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/title/GUITitleField.java
@@ -107,20 +107,6 @@ public class GUITitleField extends GUIField
         addTooltip();
     }
 
-    @Override
-    public boolean updateView()
-    {
-        String value = getField().getLabel();
-
-        if (value != null)
-        {
-            // Set value here for getting current variable values replaced
-            label.setText(replaceVariables(value));
-        }
-
-        return false;
-    }
-
     /**
      * Maps an {@code Alignment} to the {@link TwoColumnConstraints} constants.
      *


### PR DESCRIPTION
This is a fix for issue https://jira.codehaus.org/browse/IZPACK-1211:
*UserInputPanel: Missing variable resolution in attribute <field><spec text="..."/><field> including the according translations*



Provided there is a panel specification in userInputSpec.xml like this:

```xml
<panel id="panel.test">
    <field type="title" txt="Test panel" id="text.test.title" />
    <field type="staticText" align="left" txt="${INSTALL_PATH}${FILE_SEPARATOR}${application.folder}" />
    <field type="text" variable="targetsettings.target">
    <spec txt="Target directory: ${INSTALL_PATH}${FILE_SEPARATOR}" id="text.targetsettings.target" size="20" set="${application.folder}" />
         <validator class="com.izforge.izpack.panels.userinput.validator.NotEmptyValidator" txt="Target directory path is mandatory!" id="text.targetsettings.target.error" />
    </field>
</panel>
```

and a <panel> section in install.xml like this

```xml
<panels>
    <panel classname="TargetPanel" id="panel.target"/>
    <panel classname="UserInputPanel" id="panel.test"/>
    ...
</panels>
```

there doesn't happen any variable resolution for the txt="Target directory: ${INSTALL_PATH}${FILE_SEPARATOR}" attribute value including its translations although the according variables are set.

Should be translated here to make variable replacement consistent everywhere.
