### PR TITLE
[IZPACK-1212] UserInputPanel: Radio defaults apply just for the first radio field on one and the same panel

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Variables.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Variables.java
@@ -155,4 +155,11 @@ public interface Variables
      */
     void unregisterBlockedVariableNames(Set<String> names, Object blocker);
 
+    /**
+     * Whether a variable is currently blocked against being refreshed.
+     *
+     * @param name the variable name
+     */
+    boolean isBlockedVariableName(String name);
+
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -413,8 +413,8 @@ public class DefaultVariables implements Variables
         }
     }
 
-   @Override
-   public void unregisterBlockedVariableNames(Set<String> names, Object blocker)
+    @Override
+    public void unregisterBlockedVariableNames(Set<String> names, Object blocker)
     {
         if (names != null)
         {
@@ -429,7 +429,8 @@ public class DefaultVariables implements Variables
         }
     }
 
-    private boolean isBlockedVariableName(String name)
+    @Override
+    public boolean isBlockedVariableName(String name)
     {
         Deque<Object> blockerStack = blockedVariableNameStacks.get(name);
         return (blockerStack != null && !blockerStack.isEmpty());

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
@@ -85,7 +85,7 @@ public abstract class AbstractConsolePanel implements ConsolePanel
     {
         boolean result;
 
-        if (panel == null || panel.isValid())
+        if (panel == null || panel.isValid(false))
         {
             String prompt = installData.getMessages().get("ConsoleInstaller.continueQuitRedisplay");
             console.println();

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanels.java
@@ -84,7 +84,7 @@ public class ConsolePanels extends AbstractPanels<ConsolePanelView, ConsolePanel
                 {
                     break;
                 }
-            } while (!newPanel.isValid());
+            } while (!newPanel.isValid(false));
         }
 
         return result;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanelView.java
@@ -96,30 +96,6 @@ public class IzPanelView extends AbstractPanelView<IzPanel>
     }
 
     /**
-     * Validates dynamic conditions.
-     * <br/>
-     * This implementation sets a busy cursor while evaluating conditions.
-     *
-     * @return {@code true} if there are no conditions, or conditions validate successfully
-     */
-    @Override
-    protected boolean validateDynamicConditions()
-    {
-        Component component = getView().getTopLevelAncestor();
-        Cursor current = component.getCursor();
-        Cursor wait = Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR);
-        try
-        {
-            component.setCursor(wait);
-            return super.validateDynamicConditions();
-        }
-        finally
-        {
-            component.setCursor(current);
-        }
-    }
-
-    /**
      * Evaluates the panel data validator.
      * <br/>
      * This implementation sets a busy cursor while evaluating conditions.

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
@@ -229,15 +229,30 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
     }
 
     /**
-     * Determines if the panel is valid.
+     * Determines if the panel is valid. Dynamic variables are automatically refreshed.
      *
      * @return {@code true} if the panel is valid
      */
     @Override
     public boolean isValid()
     {
+        return isValid(true);
+    }
+
+    /**
+     * Determines if the panel is valid.
+     *
+     * @param refreshVariables whether to refresh dynamic variables before validating
+     * @return {@code true} if the panel is valid
+     */
+    @Override
+    public boolean isValid(boolean refreshVariables)
+    {
         boolean result = false;
-        installData.getVariables().refresh();
+        if (refreshVariables)
+        {
+            installData.getVariables().refresh();
+        }
         executePreValidationActions();
 
         List<DynamicInstallerRequirementValidator> conditions = installData.getDynamicInstallerRequirements();
@@ -369,7 +384,6 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
         boolean result = true;
         try
         {
-            installData.refreshVariables();
             for (DynamicInstallerRequirementValidator validator : installData.getDynamicInstallerRequirements())
             {
                 if (!isValid(validator, installData))

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/PanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/PanelView.java
@@ -87,6 +87,23 @@ public interface PanelView<T>
     boolean isValid();
 
     /**
+     * Determines if the panel is valid.
+     * <p/>
+     * This:
+     * <ol>
+     * <li>Executes any pre-validation panel actions</li>
+     * <li>Validates any {@link DynamicInstallerRequirementValidator}s returned by
+     * {@link InstallData#getDynamicInstallerRequirements()}</li>
+     * <li>Validates any {@link DataValidator} associated with the panel</li>
+     * <li>Executes any post-validation panel actions</li>
+     * </ol>
+     *
+     * @param refreshVariables whether to refresh dynamic variables before validating
+     * @return {@code true} if the panel is valid, otherwise {@code false}
+     */
+    boolean isValid(boolean refreshVariables);
+
+    /**
      * Save the contents of the panel into install data.
      */
     void saveData();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -68,7 +68,7 @@ public class UserInputPanel extends IzPanel
 
     private boolean eventsActivated = false;
 
-    private Set<String> variables = new HashSet<String>();
+    private final Set<String> variables = new HashSet<String>();
     private List<GUIField> views = new ArrayList<GUIField>();
 
     private JPanel panel;
@@ -236,7 +236,7 @@ public class UserInputPanel extends IzPanel
     @Override
     public void createInstallationRecord(IXMLElement rootElement)
     {
-        new UserInputPanelAutomationHelper(variables, views).createInstallationRecord(installData, rootElement);
+        new UserInputPanelAutomationHelper(/*variables,*/ views).createInstallationRecord(installData, rootElement);
     }
 
     /**
@@ -259,9 +259,6 @@ public class UserInputPanel extends IzPanel
             // case we must skip the panel when it gets activated.
             return;
         }
-
-        // refresh variables specified in spec
-        updateVariables();
 
         // clear button mnemonics map
         ButtonFactory.clearPanelButtonMnemonics();
@@ -287,7 +284,9 @@ public class UserInputPanel extends IzPanel
             GUIField view = viewFactory.create(field, userInputModel, spec);
             view.setUpdateListener(listener);
             views.add(view);
+            variables.add(field.getVariable());
         }
+        getMetadata().setAffectedVariableNames(variables);
         eventsActivated = true;
     }
 
@@ -423,14 +422,8 @@ public class UserInputPanel extends IzPanel
      */
     private IXMLElement readSpec()
     {
-        userInputModel = new UserInputPanelSpec(getResources(), installData, factory, rules, matcher);
+        userInputModel = new UserInputPanelSpec(getResources(), installData, factory, /*rules,*/ matcher);
         return userInputModel.getPanelSpec(getMetadata());
-    }
-
-    protected void updateVariables()
-    {
-        variables = userInputModel.updateVariables(spec);
-        getMetadata().setAffectedVariableNames(variables);
     }
 
     /**
@@ -444,7 +437,6 @@ public class UserInputPanel extends IzPanel
         {
             this.eventsActivated = false;
             readInput(LoggingPrompt.INSTANCE, skipValidation); // read from the input fields, but don't display a prompt for errors
-            updateVariables();
             updateUIElements();
             buildUI();
             revalidate();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Logger;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
@@ -62,8 +61,6 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
 
     private static final String AUTO_ATTRIBUTE_VALUE = "value";
 
-    private Set<String> variables;
-
     private List<? extends AbstractFieldView> views;
 
     /**
@@ -79,9 +76,8 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
      * @param variables
      * @param views
      */
-    public UserInputPanelAutomationHelper(Set<String> variables, List<? extends AbstractFieldView> views)
+    public UserInputPanelAutomationHelper(List<? extends AbstractFieldView> views)
     {
-        this.variables = variables;
         this.views = views;
     }
 
@@ -95,7 +91,7 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
     public void createInstallationRecord(InstallData installData, IXMLElement rootElement)
     {
         HashSet<String> omitFromAutoSet = new HashSet<String>();
-        Map<String, String> entries = generateEntries(installData, variables, views, omitFromAutoSet);
+        Map<String, String> entries = generateEntries(installData, views, omitFromAutoSet);
         IXMLElement dataElement;
 
         for (String key : entries.keySet())
@@ -109,15 +105,11 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
     }
 
     private Map<String, String> generateEntries(InstallData installData,
-                                                Set<String> variables, List<? extends AbstractFieldView> views,
+                                                List<? extends AbstractFieldView> views,
                                                 HashSet<String> omitFromAutoSet)
     {
         Map<String, String> entries = new HashMap<String, String>();
 
-        for (String variable : variables)
-        {
-            entries.put(variable, installData.getVariable(variable));
-        }
         for (FieldView view : views)
         {
             String variable = view.getField().getVariable();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -351,6 +351,20 @@ public abstract class Field
     }
 
     /**
+     * Returns the forced value of the field.
+     *
+     * @return the forced value. May be {@code null}
+     */
+    private String getForcedValue()
+    {
+        if (initialValue != null)
+        {
+            return replaceVariables(initialValue);
+        }
+        return null;
+    }
+
+    /**
      * Returns the initial value to use for this field.
      * <p/>
      * The following non-null value is used from the following search order
@@ -365,9 +379,9 @@ public abstract class Field
     public String getInitialValue()
     {
         String result = null;
-        if (initialValue != null)
+        if (!installData.getVariables().isBlockedVariableName(variable))
         {
-            result = replaceVariables(initialValue);
+            result = getForcedValue();
         }
         if (result == null)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/combo/GUIComboField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/combo/GUIComboField.java
@@ -100,7 +100,7 @@ public class GUIComboField extends GUIField
 
         boolean result = false;
         ComboField field = (ComboField)getField();
-        String value = field.getValue();
+        String value = field.getInitialValue();
 
         if (value != null)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/GUIMultipleFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/GUIMultipleFileField.java
@@ -99,7 +99,7 @@ public class GUIMultipleFileField extends GUIField
     public boolean updateView()
     {
         boolean result = false;
-        String value = getField().getValue();
+        String value = getField().getInitialValue();
 
         if (value != null)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/password/GUIPasswordGroupField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/password/GUIPasswordGroupField.java
@@ -116,7 +116,7 @@ public class GUIPasswordGroupField extends GUIField
     public boolean updateView()
     {
         boolean result = false;
-        String value = getField().getValue();
+        String value = getField().getInitialValue();
 
         if (value != null)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
@@ -145,7 +145,7 @@ public class GUIRadioField extends GUIField implements ActionListener
 
         boolean result = false;
         RadioField field = getField();
-        String value = field.getValue();
+        String value = field.getInitialValue();
 
         if (value != null)
         {
@@ -230,7 +230,7 @@ public class GUIRadioField extends GUIField implements ActionListener
                 if (selected)
                 {
                     radioButton.setSelected(true);
-                }
+               }
             }
             else
             {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleField.java
@@ -21,13 +21,13 @@
 
 package com.izforge.izpack.panels.userinput.gui.rule;
 
+import javax.swing.JTextField;
+
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.panels.userinput.field.ValidationStatus;
 import com.izforge.izpack.panels.userinput.field.rule.RuleField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
-
-import javax.swing.*;
 
 
 /**
@@ -128,14 +128,13 @@ public class GUIRuleField extends GUIField
     @Override
     public boolean updateView()
     {
-        boolean result = false;
+        boolean changed = false;
         Field f = getField();
-        String value = f.getValue();
+        String value = f.getInitialValue();
 
         if (value != null)
         {
-            replaceValue(value);
-            result = true;
+            changed = replaceValue(value);
         }
         else
         {
@@ -143,16 +142,17 @@ public class GUIRuleField extends GUIField
             String defaultValue = f.getDefaultValue();
             if (defaultValue != null)
             {
-                replaceValue(defaultValue);
+                changed = replaceValue(defaultValue);
             }
         }
 
-        return result;
+        return changed;
     }
 
-    private void replaceValue(String value)
+    private boolean replaceValue(String value)
     {
         RuleField f = (RuleField) getField();
+        boolean changed = false;
         if (value != null)
         {
             ValidationStatus status = f.validateFormatted(value);
@@ -162,10 +162,17 @@ public class GUIRuleField extends GUIField
                 int id = 0;
                 for (JTextField input : component.getInputFields())
                 {
-                    input.setText(values[id]);
+                    String oldValue = input.getText();
+                    String newValue = values[id];
+                    if (!(oldValue == null ? newValue == null : oldValue.equals(newValue)))
+                    {
+                        input.setText(newValue);
+                        changed = true;
+                    }
                     id++;
                 }
             }
         }
+        return changed;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/RuleTextField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/RuleTextField.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2002 Elmar Grom
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,6 @@ import com.izforge.izpack.panels.userinput.field.rule.FieldSpec;
 /*---------------------------------------------------------------------------*/
 public class RuleTextField extends JTextField
 {
-
     private final FieldSpec spec;
 
     public RuleTextField(FieldSpec spec)
@@ -56,12 +55,14 @@ public class RuleTextField extends JTextField
         setDocument(rule);
     }
 
+    @Override
     protected Document createDefaultModel()
     {
         Rule rule = new Rule(spec);
         return (rule);
     }
 
+    @Override
     public int getColumns()
     {
         return spec.getColumns();
@@ -77,6 +78,7 @@ public class RuleTextField extends JTextField
         return spec.isUnlimitedLength();
     }
 
+    @Override
     public void setColumns(int columns)
     {
         super.setColumns(columns + 1);
@@ -102,6 +104,7 @@ public class RuleTextField extends JTextField
             this.spec = spec;
         }
 
+        @Override
         public void insertString(int offs, String str, AttributeSet a) throws BadLocationException
         {
             // --------------------------------------------------

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
@@ -108,7 +108,7 @@ public class GUITextField extends GUIField implements FocusListener, DocumentLis
     public boolean updateView()
     {
         boolean result = false;
-        String value = getField().getValue();
+        String value = getField().getInitialValue();
 
         if (value != null)
         {
@@ -131,10 +131,16 @@ public class GUITextField extends GUIField implements FocusListener, DocumentLis
 
     private void replaceValue(String value)
     {
-        text.getDocument().removeDocumentListener(this);
-        text.setText(replaceVariables(value));
-        text.getDocument().addDocumentListener(this);
-        setChanged(false);
+        boolean changed = false;
+        String oldValue = text.getText();
+        if (!(oldValue == null ? value == null : oldValue.equals(value)))
+        {
+            text.getDocument().removeDocumentListener(this);
+            text.setText(replaceVariables(value));
+            text.getDocument().addDocumentListener(this);
+            changed = true;
+        }
+        setChanged(changed);
     }
 
     public synchronized void setChanged(boolean changed)


### PR DESCRIPTION
Supposed there is the following installer defined:

**userInputSpec.xml:**
```xml
<izpack:userinput version="5.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:izpack="http://izpack.org/schema/userinput" xsi:schemaLocation="http://izpack.org/schema/userinput http://izpack.org/schema/5.0/izpack-userinput-5.0.xsd">

  <panel id="panel.test">
    <field type="title" txt="Test panel" id="text.test.title" />
    <field type="radio" variable="dbsystem">
      <spec txt="with set">
        <choice txt="MSSQL" value="mssql" id="text.dbsystem.mssql" />
    <choice txt="Oracle" value="oracle" id="text.dbsystem.oracle" set="true" />
    <choice txt="SAP Hana" value="hdb" id="text.dbsystem.hana" />
      </spec>
    </field>
    <field type="divider"/>
    <field type="radio" variable="dbsystem2">
      <spec txt="with default">
    <choice txt="MSSQL" value="mssql" id="text.dbsystem.mssql" />
    <choice txt="Oracle" value="oracle" id="text.dbsystem.oracle" default="true" />
    <choice txt="SAP Hana" value="hdb" id="text.dbsystem.hana" />
      </spec>
    </field>
    <field type="divider"/>
    <field type="radio" variable="dbsystem3">
      <spec txt="just relying on variable">
        <choice txt="MSSQL" value="mssql" id="text.dbsystem.mssql" />
        <choice txt="Oracle" value="oracle" id="text.dbsystem.oracle" />
        <choice txt="SAP Hana" value="hdb" id="text.dbsystem.hana" />
      </spec>
    </field>
  </panel>

</izpack:userinput>
```

**install.xml**
```xml
  ...
  <conditions>
    <condition type="exists" id="haveInstallPath">
      <variable>INSTALL_PATH</variable>
    </condition>
  </conditions>
  ....
  <dynamicvariables>
    <variable name="dbsystem" value="mssql" condition="!haveInstallPath"/>
    <variable name="dbsystem" value="hdb" condition="haveInstallPath"/>
    <variable name="dbsystem2" value="mssql" condition="!haveInstallPath"/>
    <variable name="dbsystem2" value="hdb" condition="haveInstallPath"/>
    <variable name="dbsystem3" value="mssql" condition="!haveInstallPath"/>
    <variable name="dbsystem3" value="hdb" condition="haveInstallPath"/>
  </dynamicvariables>
  ....
  <panels>
    <panel classname="TargetPanel" id="panel.target"/>
    <panel classname="UserInputPanel" id="panel.test"/>
    <panel classname="InstallPanel"/>
  </panels>
  ...
```

There are always working the defaults just for the first of the radio fields, not for the subsequent fields, regardless if the default should come from the variable value itself or from the set/default attributes of each choice.

This  pull request contains also post-fixes for serious problems regarding
[[IZPACK-1199] Don't refresh a dynamic variable if it has been set by the user on a UserInputPanel](http://jira.codehaus.org/browse/IZPACK-1199) - a post-fix for that issue regarding refreshing blocked dynamic variables after switching panels setting them explicitly.