### PR TITLE
Izpack 1182: Evaluation of dynamic variables, which depends on other ones

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -311,9 +311,9 @@ public class DefaultVariables implements Variables
     {
         logger.fine("Refreshing dynamic variables");
         Set<DynamicVariable> checkedVariables = new HashSet<DynamicVariable>();
-        boolean unchanged = false;
-        while (! unchanged) {
-            unchanged = true; 
+        boolean changed = true;
+        while (changed) {
+            changed = false; 
             Properties setVariables = new Properties();
             Set<String> unsetVariables = new HashSet<String>();
 
@@ -342,13 +342,13 @@ public class DefaultVariables implements Variables
                             }
                             if (newValue == null)
                             {
-                                unchanged &= (get(name) == null);
+                                changed |= (get(name) != null);
                                 // Mark unset if dynamic variable cannot be evaluated and failOnError set
                                 unsetVariables.add(name);
                             }
                             else
                             {
-                                unchanged &= newValue.equals(get(name));
+                                changed |= ! newValue.equals(get(name));
                                 setVariables.put(name, newValue);
                             }
                             checkedVariables.add(variable);

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -310,77 +310,87 @@ public class DefaultVariables implements Variables
     public synchronized void refresh()
     {
         logger.fine("Refreshing dynamic variables");
+        Set<DynamicVariable> checkedVariables = new HashSet<DynamicVariable>();
+        boolean unchanged = false;
+        while (! unchanged) {
+            unchanged = true; 
+            Properties setVariables = new Properties();
+            Set<String> unsetVariables = new HashSet<String>();
 
-        Properties setVariables = new Properties();
-        Set<String> unsetVariables = new HashSet<String>();
-
-        for (DynamicVariable variable : dynamicVariables)
-        {
-            String name = variable.getName();
-            if (!isBlockedVariableName(name))
+            for (DynamicVariable variable : dynamicVariables)
             {
-                String conditionId = variable.getConditionid();
-                if (conditionId == null || rules.isConditionTrue(conditionId))
+                String name = variable.getName();
+                if (!isBlockedVariableName(name))
                 {
-                    if (!(variable.isCheckonce() && variable.isChecked()))
+                    String conditionId = variable.getConditionid();
+                    if (conditionId == null || rules.isConditionTrue(conditionId))
                     {
-                        String newValue;
-                        try
+                        if (!(variable.isCheckonce() && variable.isChecked()))
                         {
-                            newValue = variable.evaluate(replacer);
-                        }
-                        catch (IzPackException exception)
-                        {
-                            throw exception;
-                        }
-                        catch (Exception exception)
-                        {
-                            throw new IzPackException("Failed to refresh dynamic variable (" + name + ")", exception);
-                        }
-                        if (newValue == null)
-                        {
-                            // Mark unset if dynamic variable cannot be evaluated and failOnError set
-                            unsetVariables.add(name);
+                            String newValue;
+                            try
+                            {
+                                newValue = variable.evaluate(replacer);
+                            }
+                            catch (IzPackException exception)
+                            {
+                                throw exception;
+                            }
+                            catch (Exception exception)
+                            {
+                                throw new IzPackException("Failed to refresh dynamic variable (" + name + ")", exception);
+                            }
+                            if (newValue == null)
+                            {
+                                unchanged &= (get(name) == null);
+                                // Mark unset if dynamic variable cannot be evaluated and failOnError set
+                                unsetVariables.add(name);
+                            }
+                            else
+                            {
+                                unchanged &= newValue.equals(get(name));
+                                setVariables.put(name, newValue);
+                            }
+                            checkedVariables.add(variable);
                         }
                         else
                         {
-                            setVariables.put(name, newValue);
+                            String oldvalue = properties.getProperty(name);
+                            if (oldvalue != null)
+                            {
+                                setVariables.put(name, oldvalue);
+                            }
                         }
-                        variable.setChecked();
                     }
                     else
                     {
-                        String oldvalue = properties.getProperty(name);
-                        if (oldvalue != null)
-                        {
-                            setVariables.put(name, oldvalue);
-                        }
+                        // Mark unset if condition is not true
+                        unsetVariables.add(name);
                     }
                 }
-                else
-                {
-                    // Mark unset if condition is not true
-                    unsetVariables.add(name);
+                else {
+                    logger.fine("Dynamic variable '" + name + "' blocked from changing due to user input");
                 }
             }
-            else {
-                logger.fine("Dynamic variable '" + name + "' blocked from changing due to user input");
-            }
-        }
 
-        for (String key : unsetVariables)
-        {
-            // Don't unset dynamic variable from one definition, which
-            // are set to a value from another one during this refresh
-            if (!setVariables.containsKey(key))
+            for (String key : unsetVariables)
             {
-                set(key, null);
+                // Don't unset dynamic variable from one definition, which
+                // are set to a value from another one during this refresh
+                if (!setVariables.containsKey(key))
+                {
+                    set(key, null);
+                }
+            }
+
+            for (String key : setVariables.stringPropertyNames())
+            {
+                set(key, setVariables.getProperty(key));
             }
         }
-
-        for (String key : setVariables.stringPropertyNames())
+        for (DynamicVariable variable : checkedVariables)
         {
-            set(key, setVariables.getProperty(key));
+            variable.setChecked();
         }
     }
 

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -342,13 +342,11 @@ public class DefaultVariables implements Variables
                             }
                             if (newValue == null)
                             {
-                                changed |= (get(name) != null);
                                 // Mark unset if dynamic variable cannot be evaluated and failOnError set
                                 unsetVariables.add(name);
                             }
                             else
                             {
-                                changed |= ! newValue.equals(get(name));
                                 setVariables.put(name, newValue);
                             }
                             checkedVariables.add(variable);
@@ -379,13 +377,23 @@ public class DefaultVariables implements Variables
                 // are set to a value from another one during this refresh
                 if (!setVariables.containsKey(key))
                 {
-                    set(key, null);
+                    if (get(key)!=null)
+                    {
+                        changed = true;
+                        set(key, null);
+                    }
                 }
             }
 
             for (String key : setVariables.stringPropertyNames())
             {
-                set(key, setVariables.getProperty(key));
+                String newValue = setVariables.getProperty(key);
+                String oldValue = get(key);
+                if (oldValue==null || ! oldValue.equals(newValue))
+                {
+                    changed = true;
+                    set(key,newValue);
+                }
             }
         }
         for (DynamicVariable variable : checkedVariables)

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -130,7 +130,7 @@ public class DynamicVariableImpl implements DynamicVariable
             return null;
         }
 
-        if (checkonce && currentValue != null)
+        if (checkonce && checked)
         {
             return filterValue(currentValue, substitutors);
         }

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -254,12 +254,8 @@ public class DefaultVariablesTest
         rules.readConditionMap(conditions);
         ((DefaultVariables) variables).setRules(rules);
 
-        DynamicVariable variable1 = createDynamic("unset1", "a", "cond1+cond2");
-        variable1.setCheckonce(true);
-        variables.add(variable1);
-        DynamicVariable variable2 = createDynamic("unset1", "b", "cond1+!cond2");
-        variable2.setCheckonce(true);
-        variables.add(variable2);
+        variables.add(createDynamicCheckonce("unset1", "a", "cond1+cond2"));
+        variables.add(createDynamicCheckonce("unset1", "b", "cond1+!cond2"));
 
         // !cond1+!cond2
         variables.refresh();
@@ -311,9 +307,7 @@ public class DefaultVariablesTest
        variables.add(createDynamic("depVar2", "${depVar3}"));
        variables.set("depVar3", "depValue");
 
-       DynamicVariable checkonceVar = createDynamic("checkonceVar", "${depVar1}");
-       checkonceVar.setCheckonce(true);
-       variables.add(checkonceVar);
+       variables.add(createDynamicCheckonce("checkonceVar", "${depVar1}"));
 
        variables.refresh();
        assertEquals("check dependent variable","depValue", variables.get("depVar1"));
@@ -323,6 +317,33 @@ public class DefaultVariablesTest
        variables.refresh();
        assertEquals("recheck dependent variable","newValue", variables.get("depVar1")); // should be changed
        assertEquals("recheck variable with checkonce=true","depValue", variables.get("checkonceVar")); // should not change any more
+   }
+
+   /**
+    * Creates a dynamic variable with Checkonce set.
+    *
+    * @param name        the variable name
+    * @param value       the variable value
+    * @return a new variable
+    */
+   private DynamicVariable createDynamicCheckonce(String name, String value)
+   {
+       return createDynamicCheckonce(name, value, null);
+   }
+
+   /**
+    * Creates a dynamic variable with a condition and Checkonce set.
+    *
+    * @param name        the variable name
+    * @param value       the variable value
+    * @param conditionId the condition identifier. May be {@code null}
+    * @return a new variable
+    */
+   private DynamicVariable createDynamicCheckonce(String name, String value, String conditionId)
+   {
+       DynamicVariable var = createDynamic(name, value, conditionId);
+       var.setCheckonce(true);
+       return var;
    }
 
     /**

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -313,5 +313,47 @@ public class DefaultVariablesTest
         result.setConditionid(conditionId);
         return result;
     }
+    
+    /**
+      * Tests dynamic variables with a deeper dependency
+      * @see https://jira.codehaus.org/browse/IZPACK-1182
+      */
+     @Test
+    public void testDependentDynamicVariables()
+    {
+         variables.add(createDynamic("depVar1", "${depVar2}"));
+         variables.add(createDynamic("depVar2", "${depVar3}"));
+         variables.set("depVar3", "depValue");
+
+         assertNull(variables.get("depVar1")); // not created till variables refreshed
+         variables.refresh();
+         assertEquals("check dependent variable","depValue", variables.get("depVar1"));
+    }
+
+    /**
+     * Tests dynamic variables with a deeper dependency and checkonce==true
+     * @see https://jira.codehaus.org/browse/IZPACK-1182
+     */
+    @Test
+    public void testDependentDynamicVariablesWithCheckOnce()
+    {
+        variables.add(createDynamic("depVar1", "${depVar2}"));
+        variables.add(createDynamic("depVar2", "${depVar3}"));
+        variables.set("depVar3", "depValue");
+
+        DynamicVariable checkonceVar = createDynamic("checkonceVar", "${depVar1}");
+        checkonceVar.setCheckonce(true);
+        variables.add(checkonceVar);
+
+        variables.refresh();
+        assertEquals("check dependent variable","depValue", variables.get("depVar1"));
+        assertEquals("check variable with checkonce=true","depValue", variables.get("checkonceVar"));
+
+        variables.set("depVar3", "newValue");
+        variables.refresh();
+        assertEquals("recheck dependent variable","newValue", variables.get("depVar1")); // should be changed
+        assertEquals("recheck variable with checkonce=true","depValue", variables.get("checkonceVar")); // should not change any more
+    }
+    
 }
 


### PR DESCRIPTION
With this fix the dynamic variables, which depend on other ones, are computated correct on the first refresh() already. The Issue is olved with this pull request.