### PR TITLE
[IZPACK-1199] - post-fix

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -284,7 +284,11 @@ public class UserInputPanel extends IzPanel
             GUIField view = viewFactory.create(field, userInputModel, spec);
             view.setUpdateListener(listener);
             views.add(view);
-            variables.add(field.getVariable());
+            String var = field.getVariable();
+            if (var != null)
+            {
+                variables.add(var);
+            }
         }
         getMetadata().setAffectedVariableNames(variables);
         eventsActivated = true;


### PR DESCRIPTION
Just a post-fix for http://jira.codehaus.org/browse/IZPACK-1199: "Don't refresh a dynamic variable if it has been set by the user on a UserInputPanel - another post-fix for that issue (avoid "null" as blocked variable name)"

Avoid "null" variable names.