### PR TITLE
Izpack 1215: Terminate loop

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Variables.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Variables.java
@@ -25,7 +25,7 @@ package com.izforge.izpack.api.data;
 import java.util.Properties;
 import java.util.Set;
 
-import com.izforge.izpack.api.exception.IzPackException;
+import com.izforge.izpack.api.exception.InstallerException;
 
 /**
  * A collection of variables.
@@ -128,9 +128,9 @@ public interface Variables
     /**
      * Refreshes dynamic variables.
      *
-     * @throws IzPackException if variables cannot be refreshed
+     * @throws InstallerException if variables cannot be refreshed
      */
-    void refresh();
+    void refresh() throws InstallerException;
 
     /**
      * Exposes the variables as properties.

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -35,6 +35,7 @@ import java.util.logging.Logger;
 
 import com.izforge.izpack.api.data.DynamicVariable;
 import com.izforge.izpack.api.data.Variables;
+import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
@@ -304,16 +305,25 @@ public class DefaultVariables implements Variables
     /**
      * Refreshes dynamic variables.
      *
-     * @throws IzPackException if variables cannot be refreshed
+     * @throws InstallerException if variables cannot be refreshed
      */
     @Override
-    public synchronized void refresh()
+    public synchronized void refresh() throws InstallerException
     {
         logger.fine("Refreshing dynamic variables");
         Set<DynamicVariable> checkedVariables = new HashSet<DynamicVariable>();
+        int maxCount = dynamicVariables.size()+1;
+        int count=maxCount;
         boolean changed = true;
         while (changed) {
-            changed = false; 
+            changed = false;
+            count--;		// decrement number of remaining loops
+            if (count<0) {
+            	throw new InstallerException(
+            		String.format("Refresh of dynamic variables seem to produce a loop. "
+            				     +"Stopped after %1s iterations. "
+            				     +"(Maybe a cyclic dependency of variables?)", maxCount));
+            }
             Properties setVariables = new Properties();
             Set<String> unsetVariables = new HashSet<String>();
 

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -401,6 +401,25 @@ public class DefaultVariablesTest
    }
 
    /**
+    * Tests dynamic variables with cyclic reference
+    * <dynamicvariables>
+    *   <variable name="a" value="${b}" />
+    *   <variable name="b" value="${a}" />
+    * </dynamicvariables>
+    * 
+    * This example is not useful, but should not create a loop
+    * @see http://jira.codehaus.org/browse/IZPACK-1215
+    */
+   @Test
+   public void testCyclicReference()
+   {
+       variables.add(createDynamic("a", "${b}"));
+       variables.add(createDynamic("b", "${a}"));
+
+       variables.refresh();
+   }
+   
+   /**
     * Creates a dynamic variable with Checkonce set.
     *
     * @param name        the variable name

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -422,7 +422,25 @@ public class DefaultVariablesTest
        } catch (InstallerException e) {
     	   catched=true;
        }
-       assertTrue("cyclic dependency must throw a exception", catched);
+       assertTrue("cyclic dependency must throw an exception", catched);
+   }
+   
+   /**
+    * Test loop detection with no dynamic variables at all
+    * Ensure, that no exception is thrown 
+    * 
+    * @see http://jira.codehaus.org/browse/IZPACK-1215
+    */
+   @Test
+   public void testNoDynamicVariables()
+   {
+       boolean catched=false;
+       try {
+    	   variables.refresh();
+       } catch (InstallerException e) {
+    	   catched=true;
+       }
+       assertFalse("empty <dynamicVariables> must not throw an exception", catched);
    }
    
    /**

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -21,8 +21,7 @@
 
 package com.izforge.izpack.core.data;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +31,7 @@ import org.junit.Test;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.DynamicVariable;
 import com.izforge.izpack.api.data.Variables;
+import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.core.container.DefaultContainer;
 import com.izforge.izpack.core.rules.ConditionContainer;
@@ -416,7 +416,13 @@ public class DefaultVariablesTest
        variables.add(createDynamic("a", "${b}"));
        variables.add(createDynamic("b", "${a}"));
 
-       variables.refresh();
+       boolean catched=false;
+       try {
+    	   variables.refresh();
+       } catch (InstallerException e) {
+    	   catched=true;
+       }
+       assertTrue("cyclic dependency must throw a exception", catched);
    }
    
    /**


### PR DESCRIPTION
This fix does end the loop which is generated by a definition like
{code:xml}
  <dynamicvariables>
    <variable name="a" value="${b}" />
    <variable name="b" value="${a}" />
  </dynamicvariables>
{code}