### PR TITLE
Expired checker

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Info.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Info.java
@@ -21,7 +21,10 @@
 package com.izforge.izpack.api.data;
 
 import java.io.Serializable;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -142,6 +145,15 @@ public class Info implements Serializable
      */
     private Set<TempDir> tempdirs;
 
+    /**
+     * The date on which the installer expires, if not null
+     */
+    private Date expiresDate = null;
+    /**
+     * The format of the expiration date
+     */
+    public static final String EXPIRE_DATE_FORMAT = "yyyy-MM-dd";
+    
     public boolean isPrivilegedExecutionRequired()
     {
         return requirePrivilegedExecution;
@@ -193,7 +205,7 @@ public class Info implements Serializable
     }
 
     /**
-     * The constructor, deliberatly void.
+     * The constructor, deliberately void.
      */
     public Info()
     {
@@ -638,5 +650,21 @@ public class Info implements Serializable
     public Set<TempDir> getTempDirs()
     {
         return tempdirs;
+    }
+    
+    public Date getExpiresDate()
+    {
+        return expiresDate;
+    }
+    
+    public void setExpiresDate(Date value)
+    {
+        expiresDate = value;
+    }
+
+    public void setExpiresDate(String value) throws ParseException
+    {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(EXPIRE_DATE_FORMAT);
+        expiresDate = dateFormat.parse(value);
     }
 }

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -72,6 +72,7 @@ import com.izforge.izpack.api.data.DynamicInstallerRequirementValidator;
 import com.izforge.izpack.api.data.DynamicVariable;
 import com.izforge.izpack.api.data.GUIPrefs;
 import com.izforge.izpack.api.data.Info;
+import static com.izforge.izpack.api.data.Info.EXPIRE_DATE_FORMAT;
 import com.izforge.izpack.api.data.Info.TempDir;
 import com.izforge.izpack.api.data.InstallerRequirement;
 import com.izforge.izpack.api.data.LookAndFeels;
@@ -134,6 +135,7 @@ import com.izforge.izpack.util.OsConstraintHelper;
 import com.izforge.izpack.util.PlatformModelMatcher;
 import com.izforge.izpack.util.file.DirectoryScanner;
 import com.izforge.izpack.util.file.FileUtils;
+import java.text.ParseException;
 
 /**
  * A parser for the installer xml configuration. This parses a document conforming to the
@@ -1947,6 +1949,22 @@ public class CompilerConfig extends Thread
             info.setJdkRequired("yes".equals(jdkRequired.getContent()));
         }
 
+        // Does the installer expire?
+        IXMLElement expiresDate = root.getFirstChildNamed("expiresdate");
+        if (expiresDate != null)
+        {
+            try
+            {
+                info.setExpiresDate(expiresDate.getContent());
+            }
+            catch (ParseException e)
+            {
+                throw new CompilerException(
+                        "expiresdate must be in format '" + EXPIRE_DATE_FORMAT + "'",
+                        e);
+            }
+        }
+        
         // validate and insert (and require if -web kind) web dir
         IXMLElement webDirURL = root.getFirstChildNamed("webdir");
         if (webDirURL != null)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/InstallerContainer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/InstallerContainer.java
@@ -29,6 +29,7 @@ import com.izforge.izpack.installer.data.UninstallData;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.installer.event.InstallerListeners;
 import com.izforge.izpack.installer.event.ProgressNotifiersImpl;
+import com.izforge.izpack.installer.requirement.ExpiredChecker;
 import com.izforge.izpack.installer.requirement.InstallerRequirementChecker;
 import com.izforge.izpack.installer.requirement.JDKChecker;
 import com.izforge.izpack.installer.requirement.JavaVersionChecker;
@@ -97,6 +98,7 @@ public abstract class InstallerContainer extends AbstractContainer
         addComponent(JavaVersionChecker.class);
         addComponent(JDKChecker.class);
         addComponent(LangPackChecker.class);
+        addComponent(ExpiredChecker.class);
         addComponent(RequirementsChecker.class);
         addComponent(LockFileChecker.class);
         addComponent(MergeManagerImpl.class);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/requirement/ExpiredChecker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/requirement/ExpiredChecker.java
@@ -1,0 +1,141 @@
+/*
+ * IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
+ *
+ * http://izpack.org/
+ * http://izpack.codehaus.org/
+ *
+ * Copyright 2013 Bill Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.installer.requirement;
+
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.handler.Prompt;
+import com.izforge.izpack.api.installer.RequirementChecker;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+
+/**
+ * Verifies that the installer has not expired.
+ *
+ * @author Bill Root
+ */
+public class ExpiredChecker implements RequirementChecker
+{
+    /**
+     * The name of the variable holding the expiration date.
+     */
+    public static final String EXPIRE_DATE_VAR_NAME = "InstallerExpiresDate";
+
+    /**
+     * The installation data.
+     */
+    private final InstallData installData;
+
+    /**
+     * The prompt.
+     */
+    private final Prompt prompt;
+
+    /**
+     * Constructs a <tt>ExpiredChecker</tt>.
+     *
+     * @param installData the installation data
+     * @param prompt      the prompt
+     */
+    public ExpiredChecker(InstallData installData, Prompt prompt)
+    {
+        this.installData = installData;
+        this.prompt = prompt;
+    }
+
+    /**
+     * Determines whether the installer expires, and if so, whether it has.
+     *
+     * @return <tt>true</tt> if installer has NOT expired, otherwise <tt>false</tt>
+     */
+    @Override
+    public boolean check()
+    {
+      if (!expires())
+          return true;
+
+      try
+      {
+        if (expired())
+        {
+          showExpired();
+          return false;
+        }
+        else
+          return true;
+      }
+      catch (ParseException ex)
+      {
+        prompt.error(String.format(
+                "Could not parse %s.  Please correct the installer.",
+                EXPIRE_DATE_VAR_NAME));
+        // we return true so user can workaround installer problem
+        return true;
+      }
+      catch (Exception ex)
+      {
+        prompt.error(String.format(
+                "Could not check expiration date because: %s.  Please correct the installer.",
+                ex.toString(),
+                EXPIRE_DATE_VAR_NAME));
+        // we return true so user can workaround installer problem
+        return true;
+      }
+    }
+
+    private boolean expired() throws ParseException
+    {
+        String expirationDateStr = installData.getVariable(EXPIRE_DATE_VAR_NAME);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("YYYY-MM-DD");
+        Date expirationDate = dateFormat.parse(expirationDateStr);
+        return new Date().after(expirationDate);
+    }
+    
+    /**
+     * Determines whether the installer expires.
+     *
+     * @return <tt>true</tt> if installer expires, otherwise <tt>false</tt>
+     */
+    private boolean expires()
+    {
+        String expirationDateStr = installData.getVariable(EXPIRE_DATE_VAR_NAME);
+        return (expirationDateStr != null) && !expirationDateStr.isEmpty();
+    }
+    
+    /**
+     * Invoked when the installer has expired.
+     * <p/>
+     * This tells the user why we're canceling.
+     */
+    protected void showExpired()
+    {
+        String message = "This installer has expired.";
+        if (installData.getInfo().getAppURL() != null)
+        {
+            String urlText = installData.getInfo().getAppURL();
+            message += "\n\n" +
+                        "Please download a new one from " + urlText;
+        }
+        prompt.error(message);
+    }
+}

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/requirement/ExpiredChecker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/requirement/ExpiredChecker.java
@@ -23,8 +23,6 @@ package com.izforge.izpack.installer.requirement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.installer.RequirementChecker;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
@@ -34,16 +32,6 @@ import java.util.Date;
  */
 public class ExpiredChecker implements RequirementChecker
 {
-   /**
-     * The name of the variable holding the expiration date.
-     */
-    public static final String EXPIRE_DATE_VAR_NAME = "InstallerExpiresDate";
-
-    /**
-     * The format of the expiration date.
-     */
-    public static final String EXPIRE_DATE_FORMAT = "yyyy-MM-dd";
-
     /**
      * The installation data.
      */
@@ -89,32 +77,21 @@ public class ExpiredChecker implements RequirementChecker
             else
                 return true;
         } 
-        catch (ParseException ex)
-        {
-            prompt.error(String.format(
-                    "Could not parse %s.  Please correct the installer.",
-                    EXPIRE_DATE_VAR_NAME));
-            // we return true so user can workaround installer problem
-            return true;
-        } 
         catch (Exception ex)
         {
             prompt.error(String.format(
                     "Could not check expiration date because: %s.  Please correct the installer.",
-                    ex.toString(),
-                    EXPIRE_DATE_VAR_NAME));
+                    ex.toString()));
             // we return true so user can workaround installer problem
             return true;
         }
     }
 
     
-    private boolean expired() throws ParseException
+    private boolean expired()
     {
-        String expirationDateStr = installData.getVariable(EXPIRE_DATE_VAR_NAME);
-        SimpleDateFormat dateFormat = new SimpleDateFormat(EXPIRE_DATE_FORMAT);
-        Date expirationDate = dateFormat.parse(expirationDateStr);
-        return new Date().after(expirationDate);
+        Date expiresDate = installData.getInfo().getExpiresDate();
+        return new Date().after(expiresDate);
     }
 
     
@@ -125,17 +102,7 @@ public class ExpiredChecker implements RequirementChecker
      */
     private boolean expires()
     {
-        String expirationDateStr;
-        try
-        {
-            expirationDateStr = installData.getVariable(EXPIRE_DATE_VAR_NAME);
-        } 
-        catch (NullPointerException e)
-        {
-            // getVariable throws NPE if installData.variables is null
-            return false;
-        }
-        return (expirationDateStr != null) && !expirationDateStr.isEmpty();
+        return installData.getInfo().getExpiresDate() != null;
     }
 
     

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/requirement/RequirementsChecker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/requirement/RequirementsChecker.java
@@ -58,6 +58,11 @@ public class RequirementsChecker implements RequirementChecker
     private final LockFileChecker lockChecker;
 
     /**
+     * The expired installer checker.
+     */
+    private final ExpiredChecker expiredChecker;
+    
+    /**
      * The installer requirement checker.
      */
     private final InstallerRequirementChecker installerRequirementChecker;
@@ -70,10 +75,12 @@ public class RequirementsChecker implements RequirementChecker
      * @param versionChecker              the java version checker
      * @param jdkChecker                  the JDK checker
      * @param lockChecker                 the lock file checker
+     * @param expiredChecker              the expiration checker
      * @param installerRequirementChecker the installer requirement checker
      */
     public RequirementsChecker(Variables variables, LangPackChecker langChecker, JavaVersionChecker versionChecker,
                                JDKChecker jdkChecker, LockFileChecker lockChecker,
+                               ExpiredChecker expiredChecker,
                                InstallerRequirementChecker installerRequirementChecker)
     {
         this.variables = variables;
@@ -81,6 +88,7 @@ public class RequirementsChecker implements RequirementChecker
         this.jdkChecker = jdkChecker;
         this.lockChecker = lockChecker;
         this.langChecker = langChecker;
+        this.expiredChecker = expiredChecker;
         this.installerRequirementChecker = installerRequirementChecker;
     }
 
@@ -94,6 +102,7 @@ public class RequirementsChecker implements RequirementChecker
     {
         variables.refresh();
         return langChecker.check() && versionChecker.check() && jdkChecker.check() && lockChecker.check() &&
+                expiredChecker.check() && 
                 installerRequirementChecker.check();
     }
 }

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/AbstractRequirementCheckerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/AbstractRequirementCheckerTest.java
@@ -31,6 +31,7 @@ import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.installer.RequirementChecker;
 import com.izforge.izpack.api.resource.Locales;
+import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.core.handler.ConsolePrompt;
 import com.izforge.izpack.installer.data.InstallData;
 import com.izforge.izpack.test.util.TestConsole;
@@ -64,7 +65,7 @@ public abstract class AbstractRequirementCheckerTest
      */
     public AbstractRequirementCheckerTest()
     {
-        installData = new InstallData(null, Platforms.FEDORA_LINUX);
+        installData = new InstallData(new DefaultVariables(), Platforms.FEDORA_LINUX);
         Info info = new Info();
         installData.setInfo(info);
 

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/ExpiredCheckerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/ExpiredCheckerTest.java
@@ -21,6 +21,8 @@
 
 package com.izforge.izpack.installer.requirement;
 
+import com.izforge.izpack.api.data.Info;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import static junit.framework.Assert.assertNotNull;
@@ -37,69 +39,111 @@ import org.junit.Test;
  */
 public class ExpiredCheckerTest extends AbstractRequirementCheckerTest
 {
-  /**
-   * CONSTANTS
-   */
-  private final long DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
-  private final long YEAR_MILLISECONDS = 365 * DAY_MILLISECONDS;
 
-  
-  /**
-   * DATA
-   */
-  ExpiredChecker checker = new ExpiredChecker(installData, prompt);
-  SimpleDateFormat dateFormat = new SimpleDateFormat(ExpiredChecker.EXPIRE_DATE_FORMAT);
-  
-  
-  /**
-   * METHODS
-   */
-  
-  /**
-   * Tests the {@link ExpiredChecker} when the installer has NOT expired.
-   */
-  @Test
-  public void testNotExpired()
-  {
-    assertNotNull("This class requires variables", installData.getVariables());
-    
-    // no expiration date set
-    assertTrue(checker.check());
+    /**
+     * CONSTANTS
+     */
+    private final long DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
+    private final long YEAR_MILLISECONDS = 365 * DAY_MILLISECONDS;
 
-    // expires tomorrow
-    String tomorrow = dateFormat.format(new Date(new Date().getTime() + DAY_MILLISECONDS));
-    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, tomorrow);
-    assertTrue(checker.check());
     
-    // expires a year from now
-    String nextYear = dateFormat.format(new Date(new Date().getTime() + YEAR_MILLISECONDS));
-    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, nextYear);
-    assertTrue(checker.check());
-  }
+    /**
+     * DATA
+     */
+    ExpiredChecker checker = new ExpiredChecker(installData, prompt);
+    SimpleDateFormat dateFormat = new SimpleDateFormat(Info.EXPIRE_DATE_FORMAT);
 
-  
-  /**
-   * Tests the {@link ExpiredChecker} when the installer has expired.
-   */
-  @Test
-  public void testExpired()
-  {
-    assertNotNull("This class requires variables", installData.getVariables());
     
-    // expires today
-    String today = dateFormat.format(new Date());
-    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, today);
-    assertFalse(checker.check());
+    /**
+     * METHODS
+     */
     
-    // expired yesterday
-    String yesterday = dateFormat.format(new Date(new Date().getTime() - DAY_MILLISECONDS));
-    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, yesterday);
-    assertFalse(checker.check());
-    
-    // expired a year ago
-    String lastYear = dateFormat.format(new Date(new Date().getTime() - YEAR_MILLISECONDS));
-    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, lastYear);
-    assertFalse(checker.check());
-  }
+    /**
+     * Tests the {@link ExpiredChecker} when the installer has NOT expired.
+     */
+    @Test
+    public void testNotExpired()
+    {
+        // no expiration date set
+        installData.getInfo().setExpiresDate((Date) null);
+        assertTrue(checker.check());
+
+        // bad date format
+        try
+        {
+            installData.getInfo().setExpiresDate("01/01/2001");
+        } 
+        catch (ParseException ex)
+        {
+            assertNotNull(ex);
+        }
+
+        // expires tomorrow
+        String tomorrow = dateFormat.format(new Date(new Date().getTime() + DAY_MILLISECONDS));
+        try
+        {
+            installData.getInfo().setExpiresDate(tomorrow);
+        } 
+        catch (ParseException ex)
+        {
+            assertTrue(false);
+        }
+        assertTrue(checker.check());
+
+        // expires a year from now
+        String nextYear = dateFormat.format(new Date(new Date().getTime() + YEAR_MILLISECONDS));
+        try
+        {
+            installData.getInfo().setExpiresDate(nextYear);
+        }
+        catch (ParseException ex)
+        {
+            assertTrue(false);
+        }
+        assertTrue(checker.check());
+    }
+
+    /**
+     * Tests the {@link ExpiredChecker} when the installer has expired.
+     */
+    @Test
+    public void testExpired()
+    {
+        // expires today
+        String today = dateFormat.format(new Date());
+        try
+        {
+            installData.getInfo().setExpiresDate(today);
+        }
+        catch (ParseException ex)
+        {
+            assertTrue(false);
+        }
+        assertFalse(checker.check());
+
+        // expired yesterday
+        String yesterday = dateFormat.format(new Date(new Date().getTime() - DAY_MILLISECONDS));
+        try
+        {
+            installData.getInfo().setExpiresDate(yesterday);
+        }
+        catch (ParseException ex)
+        {
+            assertTrue(false);
+        }
+        assertFalse(checker.check());
+
+        // expired a year ago
+        String lastYear = dateFormat.format(new Date(new Date().getTime() - YEAR_MILLISECONDS));
+        try
+        {
+            installData.getInfo().setExpiresDate(lastYear);
+        }
+        catch (ParseException ex)
+        {
+            assertTrue(false);
+        }
+        assertFalse(checker.check());
+    }
 
 }

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/ExpiredCheckerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/ExpiredCheckerTest.java
@@ -1,0 +1,105 @@
+/*
+ * IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
+ *
+ * http://izpack.org/
+ * http://izpack.codehaus.org/
+ *
+ * Copyright 2015 Bill Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.installer.requirement;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+
+/**
+ * Tests the {@link ExpiredChecker} class.
+ *
+ * @author Bill Root
+ */
+public class ExpiredCheckerTest extends AbstractRequirementCheckerTest
+{
+  /**
+   * CONSTANTS
+   */
+  private final long DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
+  private final long YEAR_MILLISECONDS = 365 * DAY_MILLISECONDS;
+
+  
+  /**
+   * DATA
+   */
+  ExpiredChecker checker = new ExpiredChecker(installData, prompt);
+  SimpleDateFormat dateFormat = new SimpleDateFormat(ExpiredChecker.EXPIRE_DATE_FORMAT);
+  
+  
+  /**
+   * METHODS
+   */
+  
+  /**
+   * Tests the {@link ExpiredChecker} when the installer has NOT expired.
+   */
+  @Test
+  public void testNotExpired()
+  {
+    assertNotNull("This class requires variables", installData.getVariables());
+    
+    // no expiration date set
+    assertTrue(checker.check());
+
+    // expires tomorrow
+    String tomorrow = dateFormat.format(new Date(new Date().getTime() + DAY_MILLISECONDS));
+    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, tomorrow);
+    assertTrue(checker.check());
+    
+    // expires a year from now
+    String nextYear = dateFormat.format(new Date(new Date().getTime() + YEAR_MILLISECONDS));
+    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, nextYear);
+    assertTrue(checker.check());
+  }
+
+  
+  /**
+   * Tests the {@link ExpiredChecker} when the installer has expired.
+   */
+  @Test
+  public void testExpired()
+  {
+    assertNotNull("This class requires variables", installData.getVariables());
+    
+    // expires today
+    String today = dateFormat.format(new Date());
+    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, today);
+    assertFalse(checker.check());
+    
+    // expired yesterday
+    String yesterday = dateFormat.format(new Date(new Date().getTime() - DAY_MILLISECONDS));
+    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, yesterday);
+    assertFalse(checker.check());
+    
+    // expired a year ago
+    String lastYear = dateFormat.format(new Date(new Date().getTime() - YEAR_MILLISECONDS));
+    installData.setVariable(ExpiredChecker.EXPIRE_DATE_VAR_NAME, lastYear);
+    assertFalse(checker.check());
+  }
+
+}

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/RequirementsCheckerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/RequirementsCheckerTest.java
@@ -50,6 +50,7 @@ public class RequirementsCheckerTest
                                                              mock(JavaVersionChecker.class, true),
                                                              mock(JDKChecker.class, true),
                                                              mock(LockFileChecker.class, true),
+                                                             mock(ExpiredChecker.class, true),
                                                              mock(InstallerRequirementChecker.class, true));
         assertTrue(checker.check());
     }
@@ -63,16 +64,17 @@ public class RequirementsCheckerTest
     public void testCheckFailure()
     {
         Variables variables = Mockito.mock(Variables.class);
-        for (int i = 0; i < 5; ++i)
+        for (int i = 0; i < 6; ++i)
         {
             LangPackChecker langChecker = mock(LangPackChecker.class, (i != 0));
             JavaVersionChecker javaChecker = mock(JavaVersionChecker.class, (i != 1));
             JDKChecker jdkChecker = mock(JDKChecker.class, (i != 2));
             LockFileChecker lockChecker = mock(LockFileChecker.class, (i != 3));
-            InstallerRequirementChecker requirementChecker = mock(InstallerRequirementChecker.class, (i != 4));
+            ExpiredChecker expiredChecker = mock(ExpiredChecker.class, (i != 4));
+            InstallerRequirementChecker requirementChecker = mock(InstallerRequirementChecker.class, (i != 5));
 
             RequirementsChecker checker2 = new RequirementsChecker(variables, langChecker, javaChecker, jdkChecker,
-                                                                   lockChecker, requirementChecker);
+                                                                   lockChecker, expiredChecker, requirementChecker);
             assertFalse(checker2.check());
         }
     }


### PR DESCRIPTION
This checker lets installers automatically expire on a date specified by variable "InstallerExpiresDate" in the installer XML file.  The date must be in the format "yyyy-MM-dd".  If "InstallerExpiresDate" is not defined, the installer does not expire.