### PR TITLE
[IZPACK-1218] - Dynamic variables: escape="false" ignored for reading values from configuration files

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/ConfigFileValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/ConfigFileValue.java
@@ -149,6 +149,7 @@ public abstract class ConfigFileValue extends ValueImpl implements Serializable
     protected String resolve(InputStream in, VariableSubstitutor... substitutors)
             throws Exception
     {
+        Config config;
         String _key_ = key;
         for (VariableSubstitutor substitutor : substitutors)
         {
@@ -158,17 +159,21 @@ public abstract class ConfigFileValue extends ValueImpl implements Serializable
         switch (type)
         {
             case CONFIGFILE_TYPE_OPTIONS:
+                config = Config.getGlobal().clone();
+                config.setEscape(isEscape());
                 Options opts;
-                opts = new Options(in);
+                opts = new Options(in, config);
                 return opts.get(_key_);
             case CONFIGFILE_TYPE_INI:
+                config = Config.getGlobal().clone();
+                config.setEscape(isEscape());
                 Ini ini;
                 String _section_ = section;
                 for (VariableSubstitutor substitutor : substitutors)
                 {
                     _key_ = substitutor.substitute(_key_);
                 }
-                ini = new Ini(in);
+                ini = new Ini(in, config);
                 return ini.get(_section_, _key_);
             case CONFIGFILE_TYPE_XML:
                 return parseXPath(in, _key_, System.getProperty("line.separator"));

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DynamicVariableImplTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DynamicVariableImplTest.java
@@ -4,19 +4,29 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Properties;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import com.izforge.izpack.api.data.DynamicVariable;
 import com.izforge.izpack.api.data.ValueFilter;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.core.substitutor.VariableSubstitutorImpl;
+import com.izforge.izpack.core.variable.ConfigFileValue;
+import com.izforge.izpack.core.variable.PlainConfigFileValue;
 import com.izforge.izpack.core.variable.PlainValue;
 import com.izforge.izpack.core.variable.filters.LocationFilter;
+import com.izforge.izpack.core.variable.filters.RegularExpressionFilter;
 
 public class DynamicVariableImplTest
 {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void testSimple()
@@ -40,4 +50,63 @@ public class DynamicVariableImplTest
         }
     }
 
+    @Test
+    public void testBackSlashesWithRegex()
+    {
+        VariableSubstitutor subst = new VariableSubstitutorImpl(new Properties());
+        ValueFilter filter = new RegularExpressionFilter("[/\\\\]+", "/", null, Boolean.FALSE, Boolean.TRUE);
+
+        DynamicVariable dynvar = new DynamicVariableImpl();
+        dynvar.setValue(new PlainValue("C:\\Program Files\\Java\\jdk1.7.0_51\\bin\\java"));
+        dynvar.addFilter(filter);
+        try
+        {
+            assertEquals("C:/Program Files/Java/jdk1.7.0_51/bin/java",
+                         dynvar.evaluate(subst));
+        }
+        catch (Exception e)
+        {
+            fail(e.toString());
+        }
+    }
+
+    @Test
+    public void testBackSlashesWithRegexFromConfigFile()
+    {
+        InputStream in = getClass().getResourceAsStream("wrapper.conf");
+        byte[] buf = new byte[1024];
+        File configFile = null;
+
+        try
+        {
+            configFile = folder.newFile("_wrapper_.conf");
+            OutputStream out = new FileOutputStream(configFile);
+            int len;
+            while ((len = in.read(buf)) > 0) {
+                out.write(buf, 0, len);
+            }
+            out.close();
+        }
+        catch (Exception e)
+        {
+            fail(e.getMessage());
+        }
+
+        VariableSubstitutor subst = new VariableSubstitutorImpl(new Properties());
+        ValueFilter filter = new RegularExpressionFilter("[/\\\\]+", "/", null, Boolean.FALSE, Boolean.TRUE);
+
+        DynamicVariable dynvar = new DynamicVariableImpl();
+        dynvar.setValue(new PlainConfigFileValue(configFile.getPath(),
+                ConfigFileValue.CONFIGFILE_TYPE_OPTIONS, null, "wrapper.java.command", false));
+        dynvar.addFilter(filter);
+        try
+        {
+            assertEquals("C:/Program Files/Java/jdk1.7.0_51/bin/java",
+                         dynvar.evaluate(subst));
+        }
+        catch (Exception e)
+        {
+            fail(e.toString());
+        }
+    }
 }

--- a/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
@@ -35,11 +35,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.izforge.izpack.api.exception.IzPackException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLParser;
@@ -65,7 +65,6 @@ import com.izforge.izpack.core.rules.process.UserCondition;
 import com.izforge.izpack.core.rules.process.VariableCondition;
 import com.izforge.izpack.util.Platform;
 import com.izforge.izpack.util.Platforms;
-import org.junit.rules.ExpectedException;
 
 
 public class RulesEngineImplTest

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/data/wrapper.conf
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/data/wrapper.conf
@@ -1,0 +1,7 @@
+#encoding=UTF-8
+
+#********************************************************************
+# Wrapper Java Properties
+#********************************************************************
+# Java Application
+wrapper.java.command=C:\Program Files\Java\jdk1.7.0_51\bin\java

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Ini.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Ini.java
@@ -51,9 +51,21 @@ public class Ini extends BasicProfile implements Persistable, Configurable
         load(input);
     }
 
+    public Ini(Reader input, Config config) throws IOException, InvalidFileFormatException
+    {
+        this(config);
+        load(input);
+    }
+
     public Ini(InputStream input) throws IOException, InvalidFileFormatException
     {
         this();
+        load(input);
+    }
+
+    public Ini(InputStream input, Config config) throws IOException, InvalidFileFormatException
+    {
+        this(config);
         load(input);
     }
 
@@ -63,9 +75,22 @@ public class Ini extends BasicProfile implements Persistable, Configurable
         load(input);
     }
 
+    public Ini(URL input, Config config) throws IOException, InvalidFileFormatException
+    {
+        this(config);
+        load(input);
+    }
+
     public Ini(File input) throws IOException, InvalidFileFormatException
     {
         this();
+        _file = input;
+        load();
+    }
+
+    public Ini(File input, Config config) throws IOException, InvalidFileFormatException
+    {
+        this(config);
         _file = input;
         load();
     }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Options.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/Options.java
@@ -55,9 +55,21 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
         load(input);
     }
 
+    public Options(Reader input, Config config) throws IOException, InvalidFileFormatException
+    {
+        this(config);
+        load(input);
+    }
+
     public Options(InputStream input) throws IOException, InvalidFileFormatException
     {
         this();
+        load(input);
+    }
+
+    public Options(InputStream input, Config config) throws IOException, InvalidFileFormatException
+    {
+        this(config);
         load(input);
     }
 
@@ -67,9 +79,22 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
         load(input);
     }
 
+    public Options(URL input, Config config) throws IOException, InvalidFileFormatException
+    {
+        this(config);
+        load(input);
+    }
+
     public Options(File input) throws IOException, InvalidFileFormatException
     {
         this();
+        _file = input;
+        load();
+    }
+
+    public Options(File input, Config config) throws IOException, InvalidFileFormatException
+    {
+        this(config);
         _file = input;
         load();
     }


### PR DESCRIPTION
Assuming the following configuration file wrapper.conf:
```
wrapper.java.command=C:\Program Files\Java\jdk1.7.0_51\bin\java
```
and the following dynamic variable definition:
```xml
<variable name="java.cmd" type="options" escape="false" ignorefailure="true" file="${INSTALL_PATH}/bin/wrapper.conf" key="wrapper.java.command">
  <filters>
    <regex regexp="[/\\]+" replace="/" global="true" />
  </filters>
</variable>
```

After refreshing. the variable {{java.cmd}} should have been evaluated to `C:/Program Files/Java/jdk1.7.0_51/bin/java`.
Actually It contains `C:Program FilesJavajdk1.7.0_51/bin/java`.

This happens just for reading values from files, plain values with backslashes and `escape="false"` work as expected.

There is also a small cleanup for some other unit tests.