### PR TITLE
Tweak for [IZPACK-1202] NPE in AndCondition due to a bad condition definition

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -21,6 +21,17 @@
 
 package com.izforge.izpack.core.rules;
 
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.XMLException;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
@@ -38,15 +49,18 @@ import com.izforge.izpack.core.rules.logic.AndCondition;
 import com.izforge.izpack.core.rules.logic.NotCondition;
 import com.izforge.izpack.core.rules.logic.OrCondition;
 import com.izforge.izpack.core.rules.logic.XorCondition;
-import com.izforge.izpack.core.rules.process.*;
+import com.izforge.izpack.core.rules.process.CompareNumericsCondition;
+import com.izforge.izpack.core.rules.process.CompareVersionsCondition;
+import com.izforge.izpack.core.rules.process.ContainsCondition;
+import com.izforge.izpack.core.rules.process.EmptyCondition;
+import com.izforge.izpack.core.rules.process.ExistsCondition;
+import com.izforge.izpack.core.rules.process.JavaCondition;
+import com.izforge.izpack.core.rules.process.PackSelectionCondition;
+import com.izforge.izpack.core.rules.process.RefCondition;
+import com.izforge.izpack.core.rules.process.UserCondition;
+import com.izforge.izpack.core.rules.process.VariableCondition;
 import com.izforge.izpack.util.Platform;
 import com.izforge.izpack.util.Platforms;
-
-import java.io.OutputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
-import java.util.logging.Logger;
 
 
 /**

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/AndCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/AndCondition.java
@@ -52,7 +52,9 @@ public class AndCondition extends ConditionWithMultipleOperands
         }
         for (IXMLElement element : xmlcondition.getChildren())
         {
-            if (!RefCondition.isValidRefCondition(element)){
+            String type = element.getAttribute("type");
+            if (type == null || (type.equals("ref") && !RefCondition.isValidRefCondition(element)))
+            {
                 throw new Exception("Incorrect element specified in condition \"" + getId() + "\"");
             }
             nestedConditions.add(rules.createCondition(element));

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/NotCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/NotCondition.java
@@ -51,9 +51,14 @@ public class NotCondition extends ConditionReference
         {
             throw new Exception("Missing nested element in condition \"" + getId() + "\"");
         }
-        else if (xmlcondition.getChildrenCount() != 1 || !RefCondition.isValidRefCondition(xmlcondition.getChildAtIndex(0)))
+        else
         {
-            throw new Exception("Condition \"" + getId() + "\" needs exactly one condition of type \"ref\" as operand");
+            String type = xmlcondition.getAttribute("type");
+            if (xmlcondition.getChildrenCount() != 1 ||
+               (type == null || (type.equals("ref") && !RefCondition.isValidRefCondition(xmlcondition.getChildAtIndex(0)))))
+            {
+                throw new Exception("Condition \"" + getId() + "\" needs exactly one condition of type \"ref\" as operand");
+            }
         }
 
         RefCondition refCondition = new RefCondition(rules);

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/OrCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/OrCondition.java
@@ -50,7 +50,9 @@ public class OrCondition extends ConditionWithMultipleOperands
         }
         for (IXMLElement element : xmlcondition.getChildren())
         {
-            if (!RefCondition.isValidRefCondition(element)){
+            String type = element.getAttribute("type");
+            if (type == null || (type.equals("ref") && !RefCondition.isValidRefCondition(element)))
+            {
                 throw new Exception("Incorrect element specified in condition \"" + getId() + "\"");
             }
             nestedConditions.add(rules.createCondition(element));

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/XorCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/XorCondition.java
@@ -47,8 +47,9 @@ public class XorCondition extends OrCondition
             throw new Exception("Not more than two operands allowed in XOR condition \"" + getId() + "\"");
         }
 
-        for (IXMLElement condition : xmlcondition.getChildren()){
-            if (!RefCondition.isValidRefCondition(condition))
+        for (IXMLElement element : xmlcondition.getChildren()){
+            String type = element.getAttribute("type");
+            if (type == null || (type.equals("ref") && !RefCondition.isValidRefCondition(element)))
             {
                 throw new Exception("Incorrect element specified in condition \"" + getId() + "\"");
             }

--- a/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
@@ -529,6 +529,7 @@ public class RulesEngineImplTest
         assertTrue(rules.getCondition("packselection1") instanceof PackSelectionCondition);
         assertTrue(rules.getCondition("ref1") instanceof RefCondition);
         assertTrue(rules.getCondition("user1") instanceof UserCondition);
+        assertTrue(rules.getCondition("linuxInstallOrUpdate") instanceof AndCondition);
     }
 
     /**
@@ -540,7 +541,8 @@ public class RulesEngineImplTest
         RulesEngine rules = createRulesEngine(new AutomatedInstallData(new DefaultVariables(), Platforms.UNIX));
         IXMLParser parser = new XMLParser();
         IXMLElement conditions = parser.parse(getClass().getResourceAsStream("poorly_defined_not_condition.xml"));
-        exception.expectMessage("Condition \"poorlydefinednot\" needs exactly one condition of type \"ref\" as operand");
+        exception.expectMessage("Missing attribute \"refid\" in condition");
+
         rules.analyzeXml(conditions);
         rules.getCondition("poorlydefinednot");
     }
@@ -633,7 +635,6 @@ public class RulesEngineImplTest
         assertFalse(rules2.isConditionTrue("izpack.windowsinstall"));
         assertTrue(rules2.isConditionTrue("izpack.macinstall.osx"));
     }
-
 
     /**
      * Verifies that when conditions are deserialized, any built-in conditions are replaced with those held by the

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/rules/conditions.xml
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/rules/conditions.xml
@@ -58,4 +58,18 @@
         <requiredusername>foo</requiredusername>
     </condition>
 
+    <condition type="exists" id="Update">
+        <file>${INSTALL_PATH}/some_path</file>
+    </condition>
+    <condition type="not" id="Install">
+        <condition type="ref" refid="Update" />
+    </condition>
+    <condition type="and" id="linuxInstallOrUpdate">
+      <condition type="ref" refid="izpack.linuxinstall" />
+      <condition type="or" id="installOrUpdate">
+        <condition type="ref" refid="Install" />
+        <condition type="ref" refid="Update" />
+      </condition>
+    </condition>
+
 </izpack:conditions>


### PR DESCRIPTION
I have to tweak the original solution from pull request #301 a bit.
Actually there is also a possibility to have nested logical conditions, like this:
```xml
    <condition type="exists" id="Update">
        <file>${INSTALL_PATH}/some_path</file>
    </condition>
    <condition type="not" id="Install">
        <condition type="ref" refid="Update" />
    </condition>
    <condition type="and" id="linuxInstallOrUpdate">
      <condition type="ref" refid="izpack.linuxinstall" />
      <condition type="or" id="installOrUpdate">
        <condition type="ref" refid="Install" />
        <condition type="ref" refid="Update" />
      </condition>
    </condition>
```
which isn't covered neither in unit tests not in the documentation.