### PR TITLE
Enable InstallationGroupPanel logic in installation schema

### DIFF
--- a/izpack-dist/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-dist/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -408,6 +408,7 @@
         <xs:attribute name="preselected" type="types:yesNoTrueFalseType" use="optional"/>
         <xs:attribute name="loose" type="xs:boolean" use="optional"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
+        <xs:attribute name="installGroups" type="xs:string" use="optional"/>
     </xs:complexType>
 
 


### PR DESCRIPTION
The current installation schema does not allow the "installGroups' attribute, which is required for the InstallationGroupPanel.

This fix will add the optional attribute so that an IzPack 5 configuration file that uses the InstallationGroupPanel can be successfully validated.