### PR TITLE
Izpack 94

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Panel.java
@@ -138,7 +138,24 @@ public class Panel implements Serializable
      */
     private Map<String, ConfigurationOption> configuration = null;
 
-
+    /**
+     * Whether we confirm quit from this panel.
+     * 
+     * This is set from the "allowClose" attribute in the panel specification:
+     * - not specified      = DYNAMIC
+     * - allowClose="true"  = SILENT
+     * - allowClose="false" = CONFIRM
+     * 
+     * See CompilerConfig.addPanels for special handling to simplify usage while  
+     * maintaining backward compatibility.
+     */
+    public enum ConfirmQuitType {
+        DYNAMIC,  //confirm quit until files are copied; "classic" behavior
+        CONFIRM,  //always confirm quit
+        SILENT};  //never confirm quit
+    private ConfirmQuitType confirmQuitType = ConfirmQuitType.DYNAMIC;
+    
+    
     public String getClassName()
     {
         return this.className;
@@ -501,6 +518,24 @@ public class Panel implements Serializable
         affectedVariableNames = names;
     }
 
+    /**
+     * Gets the behavior when quit is pressed on this panel.
+     * @return 
+     */
+    public ConfirmQuitType getConfirmQuitType()
+    {
+      return confirmQuitType;
+    }
+
+    /**
+     * Sets the behavior when quit is pressed on this panel.
+     * @param value 
+     */
+    public void setConfirmQuitType(ConfirmQuitType value)
+    {
+      confirmQuitType = value;
+    }
+    
     @Override
     public String toString()
     {

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1522,7 +1522,7 @@ public class CompilerConfig extends Thread
     }
 
     /**
-     * Parse panels and their paramters, locate the panels resources and add to the Packager.
+     * Parse panels and their parameters, locate the panels resources and add to the Packager.
      *
      * @param data The XML data.
      * @throws CompilerException Description of the Exception
@@ -1540,7 +1540,7 @@ public class CompilerConfig extends Thread
         }
 
         // We process each panel markup
-        // We need a panel counter to build unique panel dependet resource names
+        // We need a panel counter to build unique panel dependent resource names
         int panelCounter = 0;
         for (IXMLElement panelElement : panels)
         {
@@ -1562,6 +1562,25 @@ public class CompilerConfig extends Thread
             String condition = panelElement.getAttribute("condition");
             panel.setCondition(condition);
 
+            String allowCloseStr = panelElement.getAttribute("allowClose");
+            if (allowCloseStr != null)
+            {
+              boolean allowClose = Boolean.parseBoolean(allowCloseStr);
+              if (allowClose)
+                panel.setConfirmQuitType(Panel.ConfirmQuitType.SILENT);
+              else
+                panel.setConfirmQuitType(Panel.ConfirmQuitType.CONFIRM);
+              // Make all previous panels CONFIRM if they're currently DYNAMIC.
+              // This simplifies usage while maintaining backward compatibility
+              // (user only has to specify allowClose="true" on last panel for
+              //  probably the most common desired behavior).
+              // Note: the new panel is not in the list yet (so we don't have to
+              //       manually exclude it)
+              List<Panel> previousPanels = packager.getPanelList();
+              for (Panel previousPanel: previousPanels)
+                if (previousPanel.getConfirmQuitType() == Panel.ConfirmQuitType.DYNAMIC)
+                  previousPanel.setConfirmQuitType(Panel.ConfirmQuitType.CONFIRM);
+            }
             // note - all jars must be added to the classpath prior to invoking this
             Class<IzPanel> type = classLoader.loadClass(className, IzPanel.class);
             if (type.equals(UserInputPanel.class))

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/IPackager.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/IPackager.java
@@ -167,8 +167,15 @@ public interface IPackager
     public abstract List<DynamicInstallerRequirementValidator> getDynamicInstallerRequirements();
 
     /**
-     * Add a panel, where order is important. Only one copy of the class files needd are inserted in
+     * Add a panel, where order is important. Only one copy of the class files needed are inserted in
      * the installer. The panel class is automatically searched in the classpath.
      */
     void addPanel(Panel panel);
+    
+    /**
+     * Returns the list of panels.
+     * 
+     * @return the panels
+     */
+    public List<Panel> getPanelList();
 }

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -286,6 +286,12 @@ public abstract class PackagerBase implements IPackager
     }
 
     @Override
+    public List<Panel> getPanelList()
+    {
+        return panelList;
+    }
+    
+    @Override
     public Properties getVariables()
     {
         return properties;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -93,6 +93,7 @@ import com.izforge.izpack.util.Housekeeper;
  * @author Julien Ponge created October 27, 2002
  * @author Fabrice Mirabile added fix for alert window on cross button, July 06 2005
  * @author Dennis Reil, added RulesEngine November 10 2006, several changes in January 2007
+ * @author Bill Root added per-panel quit confirmation control, Feb 2015
  */
 public class InstallerFrame extends JFrame implements InstallerBase, InstallerView
 {
@@ -678,7 +679,14 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
     void quit()
     {
         // FIXME !!! Reboot handling
-        if (installdata.isCanClose() || (!navigator.isNextEnabled() && !navigator.isPreviousEnabled()))
+
+        boolean confirmQuit;
+        Panel panel = panels.getPanel();
+        if (panel.getConfirmQuitType() == Panel.ConfirmQuitType.DYNAMIC)
+            confirmQuit = !(installdata.isCanClose() || (!navigator.isNextEnabled() && !navigator.isPreviousEnabled()));
+        else
+            confirmQuit = (panel.getConfirmQuitType() == Panel.ConfirmQuitType.CONFIRM);
+        if (!confirmQuit)
         {
             if (!writeUninstallData())
             {


### PR DESCRIPTION
This change lets izpack users specify the panel(s) on which Quit should be confirmed.  This fixes a problem for some end users where izpack installers could exit without confirmation because the user pressed the Quit button accidentally or otherwise.

See http://jira.codehaus.org/browse/IZPACK-94 for more info.