### PR TITLE
[4.3] eclipse settings fix and DTD fix

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,29 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="src" path="src/lib">
-        <attributes>
-        </attributes>
-    </classpathentry>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-        <attributes>
-        </attributes>
-    </classpathentry>
-    <classpathentry kind="lib" path="lib/jakarta-regexp-1.3.jar">
-        <attributes>
-        </attributes>
-    </classpathentry>
-    <classpathentry kind="lib" path="lib/ant.jar">
-        <attributes>
-        </attributes>
-    </classpathentry>
-    <classpathentry kind="src" path="src/tests">
-        <attributes>
-        </attributes>
-    </classpathentry>
-    <classpathentry sourcepath="ECLIPSE_HOME/plugins/org.eclipse.jdt.source_3.0.0/src/org.junit_3.8.1/junitsrc.zip"
-                    kind="var" path="JUNIT_HOME/junit.jar">
-        <attributes>
-        </attributes>
-    </classpathentry>
-    <classpathentry kind="output" path="eclipse-bin"/>
+	<classpathentry kind="src" path="src/lib"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="lib/jakarta-regexp-1.3.jar"/>
+	<classpathentry kind="lib" path="lib/ant.jar"/>
+	<classpathentry kind="lib" path="lib/bsf.jar"/>
+	<classpathentry kind="src" path="src/tests"/>
+	<classpathentry kind="var" path="JUNIT_HOME/junit.jar" sourcepath="ECLIPSE_HOME/plugins/org.eclipse.jdt.source_3.0.0/src/org.junit_3.8.1/junitsrc.zip"/>
+	<classpathentry kind="output" path="eclipse-bin"/>
 </classpath>

--- a/src/dtd/installation.dtd
+++ b/src/dtd/installation.dtd
@@ -143,6 +143,7 @@ $Id$
         <!ATTLIST pack excludeGroup CDATA #IMPLIED>
         <!ATTLIST pack uninstall (yes|no) "yes">
         <!ATTLIST pack parent CDATA #IMPLIED>
+        <!ATTLIST pack hidden (true|false) "false">
         <!ELEMENT description (#PCDATA)>
         <!ELEMENT file (os*, additionaldata*)>
             <!ATTLIST file src CDATA #REQUIRED>


### PR DESCRIPTION
eclipse needs BSF classes for compilation, it is not included in the current eclipse project setup.

Added the hidden attribute to the pack definition so that a hidden pack does not cause validation errors.