### PR TITLE
IZPACK-1226: ConfigurationInstallerListener does not remove entries as configured

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
@@ -285,7 +285,7 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
     {
         for (int i = 0; i < ((Options) configurable).length(key); i++)
         {
-            if (lookupValue == null)
+            if (lookupValue != null)
             {
                 String origValue = getValueFromOptionMap((OptionMap) configurable, key, i);
 


### PR DESCRIPTION
Deleting key/value-entries from a properties-file does go the wrong way. See [IZPACK-1226](http://jira.codehaus.org/browse/IZPACK-1226).