### PR TITLE
Avoid NullPointerException in ConfigurationInstallerListener, if patchFile hasn't been defined in the descriptor

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleOptionFileTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleOptionFileTask.java
@@ -124,11 +124,14 @@ public class SingleOptionFileTask extends ConfigFileTask
             throw new Exception(ioe);
         }
 
-        if (cleanup && oldFile.exists())
+        if (oldFile != null)
         {
-            if (!oldFile.delete())
+            if (cleanup && oldFile.exists())
             {
-                logger.warning("File " + oldFile + " could not be cleant up");
+                if (!oldFile.delete())
+                {
+                    logger.warning("File " + oldFile + " could not be cleant up");
+                }
             }
         }
     }


### PR DESCRIPTION
Just a quick fix for this inconvenience:

```
Feb 27, 2015 6:39:22 PM SEVERE: java.lang.NullPointerException
com.izforge.izpack.api.exception.InstallerException: java.lang.NullPointerException
        at com.izforge.izpack.event.ConfigurationInstallerListener.performAllActions(ConfigurationInstallerListener.java:357)
        at com.izforge.izpack.event.ConfigurationInstallerListener.afterPack(ConfigurationInstallerListener.java:261)
        at com.izforge.izpack.installer.event.InstallerListeners.afterPack(InstallerListeners.java:287)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:412)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:251)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.run(UnpackerBase.java:233)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
        at com.izforge.izpack.util.config.SingleOptionFileTask.writeConfigurable(SingleOptionFileTask.java:127)
        at com.izforge.izpack.util.config.SingleConfigurableTask.execute(SingleConfigurableTask.java:217)
        at com.izforge.izpack.event.ConfigurationActionTask.execute(ConfigurationActionTask.java:71)
        at com.izforge.izpack.event.ConfigurationAction.performInstallAction(ConfigurationAction.java:59)
        at com.izforge.izpack.event.ConfigurationInstallerListener.performAllActions(ConfigurationInstallerListener.java:353)
        ... 6 more
```