### PR TITLE
IZPACK-1231 - AntActionsInstallerListener: Improve error handling and messageboxes

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/exception/IzPackException.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/exception/IzPackException.java
@@ -19,6 +19,9 @@
 
 package com.izforge.izpack.api.exception;
 
+import com.izforge.izpack.api.handler.Prompt;
+import com.izforge.izpack.api.handler.Prompt.Type;
+
 /**
  * Izpack specific exception
  *
@@ -26,6 +29,8 @@ package com.izforge.izpack.api.exception;
  */
 public class IzPackException extends RuntimeException
 {
+    Prompt.Type promptType = Type.ERROR;
+
     public IzPackException(String message)
     {
         super(message);    //To change body of overridden methods use File | Settings | File Templates.
@@ -39,5 +44,28 @@ public class IzPackException extends RuntimeException
     public IzPackException(String message, Throwable cause)
     {
         super(message, cause);
+    }
+
+    public IzPackException(String message, Prompt.Type promptType)
+    {
+        super(message);    //To change body of overridden methods use File | Settings | File Templates.
+        this.promptType = promptType;
+    }
+
+    public IzPackException(Throwable cause, Prompt.Type promptType)
+    {
+        super(cause);
+        this.promptType = promptType;
+    }
+
+    public IzPackException(String message, Throwable cause, Prompt.Type promptType)
+    {
+        super(message, cause);
+        this.promptType = promptType;
+    }
+
+    public Prompt.Type getPromptType()
+    {
+        return promptType;
     }
 }

--- a/izpack-api/src/main/java/com/izforge/izpack/api/handler/Prompt.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/handler/Prompt.java
@@ -55,6 +55,13 @@ public interface Prompt
     /**
      * Displays a message.
      *
+     * @param throwable the throwable for displaying details
+     */
+    void message(Throwable throwable);
+
+    /**
+     * Displays a message.
+     *
      * @param type    the type of the message
      * @param message the message to display
      */
@@ -68,6 +75,23 @@ public interface Prompt
      * @param message the message to display
      */
     void message(Type type, String title, String message);
+
+    /**
+     * Displays a message.
+     *
+     * @param type    the type of the message
+     * @param title   the message title. If {@code null}, the title will be determined from the type
+     * @param message the message to display
+     * @param throwable the throwable for displaying details
+     */
+    void message(Type type, String title, String message, Throwable throwable);
+
+    /**
+     * Displays a warning message.
+     *
+     * @param throwable the throwable for displaying details
+     */
+    void warn(Throwable throwable);
 
     /**
      * Displays a warning message.
@@ -94,10 +118,34 @@ public interface Prompt
     /**
      * Displays an error message.
      *
+     * @param throwable the throwable for displaying details
+     */
+    void error(Throwable throwable);
+
+    /**
+     * Displays an error message.
+     *
+     * @param message the message to display
+     * @param throwable the throwable for displaying details
+     */
+    void error(String message, Throwable throwable);
+
+    /**
+     * Displays an error message.
+     *
      * @param title   the message title. May be {@code null}
      * @param message the message display
      */
     void error(String title, String message);
+
+    /**
+     * Displays an error message.
+     *
+     * @param title   the message title. May be {@code null}
+     * @param message the message display
+     * @param throwable the throwable for displaying details
+     */
+    void error(String title, String message, Throwable throwable);
 
     /**
      * Displays a confirmation message.

--- a/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
@@ -92,17 +92,52 @@ public class ConsolePrompt extends AbstractPrompt
         no = messages.get("ConsolePrompt.no");
     }
 
-    /**
-     * Displays a message.
-     *
-     * @param type    the type of the message
-     * @param title   the message title. If {@code null}, the title will be determined from the type
-     * @param message the message to display
-     */
     @Override
-    public void message(Type type, String title, String message)
+    public void message(Type type, String title, String message, Throwable throwable)
     {
+        if (title != null)
+        {
+            console.println(title + ":");
+        }
         console.println(message);
+        if (throwable != null)
+        {
+            console.println(getDetails(throwable));
+        }
+    }
+
+    private static String getDetails(Throwable throwable)
+    {
+        StringBuffer b = new StringBuffer();
+        int lengthOfLastTrace = 1; // initial value
+        // Start with the specified throwable and loop through the chain of
+        // causality for the throwable.
+        while (throwable != null)
+        {
+            // Output Exception name and message, and begin a list
+            b.append(throwable.getClass().getName() + ": " + throwable.getMessage());
+            // Get the stack trace and output each frame.
+            // Be careful not to repeat stack frames that were already reported
+            // for the exception that this one caused.
+            StackTraceElement[] stack = throwable.getStackTrace();
+            for (int i = stack.length - lengthOfLastTrace; i >= 0; i--)
+            {
+                b.append("- in " + stack[i].getClassName() + "." + stack[i].getMethodName()
+                        + "() at " + stack[i].getFileName() + ":"
+                        + stack[i].getLineNumber() + "\n");
+            }
+            // See if there is a cause for this exception
+            throwable = throwable.getCause();
+            if (throwable != null)
+            {
+                // If so, output a header
+                b.append("Caused by: ");
+                // And remember how many frames to skip in the stack trace
+                // of the cause exception
+                lengthOfLastTrace = stack.length;
+            }
+        }
+        return b.toString();
     }
 
     /**

--- a/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
@@ -70,6 +70,7 @@ public class ActionBase implements Serializable
     public static final String ANTCALL_VERBOSE_ATTR = "verbose";
     public static final String ANTCALL_LOGLEVEL_ATTR = "loglevel";
     public static final String ANTCALL_LOGFILE_ATTR = "logfile";
+    public static final String ANTCALL_SEVERITY_ATTR = "severity";
     public static final String LOGFILE_APPEND = "logfile_append";
     public static final String ANTCALL_DIR_ATTR = "dir";
     public static final String ANTCALL_BUILDFILE_ATTR = "buildfile";

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntActionInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntActionInstallerListener.java
@@ -124,7 +124,7 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
      * @throws IzPackException for any error
      */
     @Override
-    public void beforePacks(List<Pack> packs)
+    public void beforePacks(List<Pack> packs) throws InstallerException
     {
         try
         {
@@ -195,7 +195,7 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
      * @throws IzPackException for any error
      */
     @Override
-    public void beforePack(Pack pack, int i)
+    public void beforePack(Pack pack, int i) throws InstallerException
     {
         performAllActions(pack.getName(), ActionBase.BEFOREPACK, null);
     }
@@ -208,7 +208,7 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
      * @throws IzPackException for any error
      */
     @Override
-    public void afterPack(Pack pack, int i)
+    public void afterPack(Pack pack, int i) throws InstallerException
     {
         performAllActions(pack.getName(), ActionBase.AFTERPACK, null);
     }
@@ -221,7 +221,7 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
      * @throws IzPackException for any error
      */
     @Override
-    public void afterPacks(List<Pack> packs, ProgressListener listener)
+    public void afterPacks(List<Pack> packs, ProgressListener listener) throws InstallerException
     {
         if (notifyProgress())
         {
@@ -310,9 +310,9 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
                     act.performInstallAction();
                 }
             }
-            catch (Exception e)
+            catch (IzPackException e)
             {
-                throw new InstallerException(e);
+                act.throwBuildException(e);
             }
             if (!act.getUninstallTargets().isEmpty())
             {
@@ -364,6 +364,19 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
             }
             act.setLogLevel(logLevel);
         }
+
+        String severityAttrValue = el.getAttribute(ActionBase.ANTCALL_SEVERITY_ATTR);
+        AntSeverity severity = AntSeverity.fromName(severityAttrValue);
+        if (severity == null)
+        {
+            if (severityAttrValue != null)
+            {
+                throw new InstallerException("Bad value for attribute " + ActionBase.ANTCALL_SEVERITY_ATTR);
+            }
+            severity = AntSeverity.ERROR;
+        }
+        act.setSeverity(severity.getLevel());
+
         buildDir = el.getAttribute(ActionBase.ANTCALL_DIR_ATTR);
         if (buildDir != null)
         {

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntActionUninstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntActionUninstallerListener.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import com.izforge.izpack.api.event.AbstractUninstallerListener;
 import com.izforge.izpack.api.event.ProgressListener;
+import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.util.IoHelper;
 
@@ -163,11 +164,18 @@ public class AntActionUninstallerListener extends AbstractUninstallerListener
      * @throws IzPackException for any error
      */
     @Override
-    public void beforeDelete(List<File> files)
+    public void beforeDelete(List<File> files) throws InstallerException
     {
         for (AntAction act : befDel)
         {
-            act.performUninstallAction();
+            try
+            {
+                act.performUninstallAction();
+            }
+            catch (IzPackException e)
+            {
+                act.throwBuildException(e);
+            }
         }
     }
 
@@ -179,11 +187,18 @@ public class AntActionUninstallerListener extends AbstractUninstallerListener
      * @throws IzPackException for any error
      */
     @Override
-    public void afterDelete(List<File> files, ProgressListener listener)
+    public void afterDelete(List<File> files, ProgressListener listener) throws InstallerException
     {
         for (AntAction act : antActions)
         {
-            act.performUninstallAction();
+            try
+            {
+                act.performUninstallAction();
+            }
+            catch (IzPackException e)
+            {
+                act.throwBuildException(e);
+            }
         }
     }
 

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntSeverity.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntSeverity.java
@@ -1,0 +1,69 @@
+package com.izforge.izpack.event;
+
+/*
+ * IzPack - Copyright 2001-2013 Julien Ponge, All Rights Reserved.
+ *
+ * http://izpack.org/
+ * http://izpack.codehaus.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.izforge.izpack.api.handler.Prompt;
+
+public enum AntSeverity
+{
+    ERROR("error", Prompt.Type.ERROR),
+    WARNING("warning", Prompt.Type.WARNING),
+    INFO("info", Prompt.Type.INFORMATION);
+
+    private final String name;
+    private final Prompt.Type level;
+
+    AntSeverity(String name, Prompt.Type level) {
+        this.name = name;
+        this.level = level;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Prompt.Type getLevel() {
+        return level;
+    }
+
+    private final static Map<String, AntSeverity> reversed;
+    static {
+        reversed = new HashMap<String, AntSeverity>();
+        for (AntSeverity l: values()) {
+            reversed.put(l.getName(), l);
+        }
+    }
+
+    public static AntSeverity fromName(String name) {
+        return fromName(name, null);
+    }
+
+    public static AntSeverity fromName(String name, AntSeverity defaultLevel) {
+        AntSeverity level = reversed.get(name);
+        if (level == null)
+        {
+            return defaultLevel;
+        }
+        return level;
+    }
+}

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/event/InstallerListeners.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/event/InstallerListeners.java
@@ -31,6 +31,7 @@ import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.data.PackFile;
 import com.izforge.izpack.api.event.InstallerListener;
 import com.izforge.izpack.api.event.ProgressListener;
+import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.core.handler.ProgressHandler;
@@ -156,9 +157,9 @@ public class InstallerListeners
      *
      * @param packs    the packs to install
      * @param listener the progress listener
-     * @throws IzPackException if a listener throws an exception
+     * @throws InstallerException if a listener throws an exception
      */
-    public void beforePacks(List<Pack> packs, ProgressListener listener)
+    public void beforePacks(List<Pack> packs, ProgressListener listener) throws InstallerException
     {
         for (InstallerListener l : listeners)
         {
@@ -176,9 +177,9 @@ public class InstallerListeners
      * @param pack     the pack
      * @param i        the pack number
      * @param listener the progress listener
-     * @throws IzPackException if a listener throws an exception
+     * @throws InstallerException if a listener throws an exception
      */
-    public void beforePack(Pack pack, int i, ProgressListener listener)
+    public void beforePack(Pack pack, int i, ProgressListener listener) throws InstallerException
     {
         for (InstallerListener l : listeners)
         {
@@ -206,9 +207,9 @@ public class InstallerListeners
      * @param dir      the directory
      * @param packFile corresponding pack file
      * @param pack     the pack that {@code packFile} comes from
-     * @throws IzPackException if a listener throws an exception
+     * @throws InstallerException if a listener throws an exception
      */
-    public void beforeDir(File dir, PackFile packFile, Pack pack)
+    public void beforeDir(File dir, PackFile packFile, Pack pack) throws InstallerException
     {
         for (InstallerListener l : fileListeners)
         {
@@ -222,9 +223,9 @@ public class InstallerListeners
      * @param dir      the directory
      * @param packFile corresponding pack file
      * @param pack     the pack that {@code packFile} comes from
-     * @throws IzPackException if a listener throws an exception
+     * @throws InstallerException if a listener throws an exception
      */
-    public void afterDir(File dir, PackFile packFile, Pack pack)
+    public void afterDir(File dir, PackFile packFile, Pack pack) throws InstallerException
     {
         for (InstallerListener l : fileListeners)
         {
@@ -240,9 +241,9 @@ public class InstallerListeners
      * @param file     the file
      * @param packFile corresponding pack file
      * @param pack     the pack that {@code packFile} comes from
-     * @throws IzPackException if a listener throws an exception
+     * @throws InstallerException if a listener throws an exception
      */
-    public void beforeFile(File file, PackFile packFile, Pack pack)
+    public void beforeFile(File file, PackFile packFile, Pack pack) throws InstallerException
     {
         for (InstallerListener l : fileListeners)
         {
@@ -258,9 +259,9 @@ public class InstallerListeners
      * @param file     the file
      * @param packFile corresponding pack file
      * @param pack     the pack that {@code packFile} comes from
-     * @throws IzPackException if a listener throws an exception
+     * @throws InstallerException if a listener throws an exception
      */
-    public void afterFile(File file, PackFile packFile, Pack pack)
+    public void afterFile(File file, PackFile packFile, Pack pack) throws InstallerException
     {
         for (InstallerListener l : fileListeners)
         {
@@ -274,9 +275,9 @@ public class InstallerListeners
      * @param pack     current pack object
      * @param i        current pack number
      * @param listener the progress listener
-     * @throws IzPackException if a listener throws an exception
+     * @throws InstallerException if a listener throws an exception
      */
-    public void afterPack(Pack pack, int i, ProgressListener listener)
+    public void afterPack(Pack pack, int i, ProgressListener listener) throws InstallerException
     {
         for (InstallerListener l : listeners)
         {
@@ -293,9 +294,9 @@ public class InstallerListeners
      *
      * @param packs    the installed packs
      * @param listener the progress listener
-     * @throws IzPackException if a listener throws an exception
+     * @throws InstallerException if a listener throws an exception
      */
-    public void afterPacks(List<Pack> packs, ProgressListener listener)
+    public void afterPacks(List<Pack> packs, ProgressListener listener) throws InstallerException
     {
         for (InstallerListener l : listeners)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/DelegatingPrompt.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/DelegatingPrompt.java
@@ -57,71 +57,72 @@ public class DelegatingPrompt implements Prompt
         this.prompt = prompt;
     }
 
-    /**
-     * Displays a message.
-     *
-     * @param type    the type of the message
-     * @param message the message to display
-     */
+    @Override
+    public void message(Throwable throwable)
+    {
+        prompt.message(throwable);
+    }
+
     @Override
     public void message(Type type, String message)
     {
         prompt.message(type, message);
     }
 
-    /**
-     * Displays a message.
-     *
-     * @param type    the type of the message
-     * @param title   the message title. If {@code null}, the title will be determined from the type
-     * @param message the message to display
-     */
     @Override
     public void message(Type type, String title, String message)
     {
         prompt.message(type, title, message);
     }
 
-    /**
-     * Displays a warning message.
-     *
-     * @param message the message to display
-     */
+    @Override
+    public void message(Type type, String title, String message, Throwable throwable)
+    {
+        prompt.message(type, title, message, throwable);
+    }
+
+    @Override
+    public void error(Throwable throwable)
+    {
+        prompt.message(null, null, null, throwable);
+    }
+
+    @Override
+    public void error(String message, Throwable throwable)
+    {
+        prompt.message(null, null, message, throwable);
+    }
+
+    @Override
+    public void error(String title, String message, Throwable throwable)
+    {
+        prompt.message(null, title, message, throwable);
+    }
+
+    @Override
+    public void warn(Throwable throwable)
+    {
+        prompt.warn(throwable);
+    }
+
     @Override
     public void warn(String message)
     {
         prompt.warn(message);
     }
 
-    /**
-     * Displays a warning message.
-     *
-     * @param title   the message title. May be {@code null}
-     * @param message the message to display
-     */
     @Override
     public void warn(String title, String message)
     {
         prompt.warn(title, message);
     }
 
-    /**
-     * Displays an error message.
-     *
-     * @param message the message to display
-     */
     @Override
     public void error(String message)
     {
         prompt.error(message);
     }
 
-    /**
-     * Displays an error message.
-     *
-     * @param title   the message title. May be {@code null}
-     * @param message the message display
-     */
     @Override
     public void error(String title, String message)
     {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/LoggingPrompt.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/LoggingPrompt.java
@@ -44,15 +44,8 @@ public class LoggingPrompt extends AbstractPrompt
      */
     public static final Prompt INSTANCE = new LoggingPrompt();
 
-    /**
-     * Displays a message.
-     *
-     * @param type    the type of the message
-     * @param title   the message title. If {@code null}, the title will be determined from the type
-     * @param message the message to display
-     */
     @Override
-    public void message(Type type, String title, String message)
+    public void message(Type type, String title, String message, Throwable throwable)
     {
         Level level;
         switch (type)
@@ -66,7 +59,13 @@ public class LoggingPrompt extends AbstractPrompt
             default:
                 level = Level.INFO;
         }
-        logger.log(level, message);
+        logger.log(level, message, throwable);
+    }
+
+    @Override
+    public void message(Type type, String title, String message)
+    {
+        message(type, title, message, null);
     }
 
     /**

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/process/ProcessConsolePanelTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/process/ProcessConsolePanelTest.java
@@ -134,8 +134,8 @@ public class ProcessConsolePanelTest
         ProcessConsolePanel panel = new ProcessConsolePanel(rules, resources, prompt, matcher, null);
         assertFalse(panel.run(installData, console));
 
-        assertEquals(3, console.getOutput().size());
-        assertTrue(console.getOutput().get(2).equals(
+        assertEquals(4, console.getOutput().size());
+        assertTrue(console.getOutput().get(3).equals(
                 "Invocation Problem calling : com.izforge.izpack.panels.process.Executable, Executable exception"));
 
         // verify Executable was run the expected no. of times, with the expected arguments

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.9.2</version>
+                <version>1.9.4</version>
             </dependency>
             <dependency>
                 <groupId>bsf</groupId>


### PR DESCRIPTION
This pull request implements https://jira.codehaus.org/browse/IZPACK-1231:

If there occur Ant build failures in AntActionInstallerListener they are handled poorly at the moment. In each case, the installation fails with a messagebox containing the complete error trace not very useful for people just using an installer.
The error handling should be enhanced to the following possibilities:
- Hide the Ant stacktrace from the user or open it optionally
- Ant build stacktraces can be still seen in the AntAction log file.
- Introduce info, warning and error level

Also increased Ant dependency to version 1.9.4.

The enhanced API of messageboxes is can be used also in other custom listeners or elsewhere.
Stack traces and the severity can be packed into an IzPackException.

The documentation is also affected.