### PR TITLE
[IZPACK-1222] Some text is hardcoded in english in console classes

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -332,6 +332,7 @@ file we looked for -->
     <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
     <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
 
     <!-- AutomatedInstaller Strings -->
     <str id="AutomatedInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -30,26 +30,57 @@
     <str id="TargetPanel.headline" txt="Ruta destino"/>
     <str id="TreePacksPanel.headline" txt="Seleccione los paquetes para la instalación"/>
     <str id="UserInputPanel.headline" txt="Datos del usuario"/>
+    <str id="UserPathPanel.headline" txt="Seleccione ruta de destino"/>
     <str id="InstallationTypePanel.headline" txt="Tipo de instalación"/>
 
-    <!-- General installer strings -->
-    <str id="installer.title" txt="IzPack - Instalación de "/>
-    <str id="installer.next" txt="Siguiente"/>
-    <str id="installer.prev" txt="Anterior"/>
-    <str id="installer.quit" txt="Salir"/>
-    <str id="installer.madewith" txt="(Hecho con IzPack - http://izpack.org/)"/>
-    <str id="installer.quit.title" txt="¿Confirma que desea salir?"/>
-    <str id="installer.quit.message" txt="¡Esto cancelará la instalación!"/>
-    <str id="installer.warning" txt="¡Atención!"/>
-    <str id="installer.yes" txt="Sí"/>
-    <str id="installer.no" txt="No"/>
-    <str id="installer.cancel" txt="Cancelar"/>
-    <str id="installer.error" txt="Error"/>
-    <str id="installer.help" txt="Ayuda"/>
-    <str id="installer.help.close" txt="Cerrar"/>
-    <str id="installer.step" txt="Paso"/>
-    <str id="installer.of" txt="de"/>
-    <str id="installer.Message" txt="Mensaje"/>
+    <!-- TreePacksPanel Strings -->
+    <str id="TreePacksPanel.confirm"
+         txt="Presione 0 para confirmar su selección."/>
+    <str id="TreePacksPanel.prompt"
+         txt="Por favor, seleccione los paquetes que desea instalar."/>
+    <str id="TreePacksPanel.no.packs"
+         txt="No ha seleccionado ningún paquete!\n¿Está seguro de que desea continuar?"/>
+    <str id="TreePacksPanel.space.required"
+         txt="Total espacio requerido:"/>
+    <str id="TreePacksPanel.invalid"
+         txt="El paquete seleccionado es inválido"/>
+    <str id="TreePacksPanel.dependent"
+         txt="Dependencias"/>
+    <str id="TreePacksPanel.children"
+         txt="Hijos"/>
+    <str id="TreePacksPanel.no.number"
+         txt="Por favor, introduzca un número de la selección anterior."/>
+    <str id="TreePacksPanel.required"
+         txt="Requerido"/>
+    <str id="TreePacksPanel.unselectable"
+         txt="No seleccionable"/>
+    <str id="TreePacksPanel.done"
+         txt="¡Hecho!"/>
+
+ 	<!-- General installer strings -->
+ 	<str id="installer.title" txt="IzPack - Instalación de " />
+ 	<str id="installer.next" txt="Siguiente" />
+ 	<str id="installer.prev" txt="Anterior" />
+ 	<str id="installer.quit" txt="Salir" />
+ 	<str id="installer.madewith" txt="(Hecho con IzPack - http://izpack.org/)" />
+ 	<str id="installer.reboot.ask.title" txt="Reinicio requerido" />
+ 	<str id="installer.reboot.ask.message" 
+ 		txt="Se requiere el reinicio del sistema para aplicar los cambios. Desea reiniciar ahora?" />
+ 	<str id="installer.reboot.notice.title" txt="Reinicio recomendado" />
+ 	<str id="installer.reboot.notice.message" txt="Se recommienda el reinicio del sistema para aplicar algunos cambios." />
+ 	<str id="installer.quit.title" txt="¿Confirma que desea salir?" />
+ 	<str id="installer.quit.message" txt="¡Esto cancelará la instalación!" />
+ 	<str id="installer.warning" txt="¡Atención!" />
+ 	<str id="installer.yes" txt="Sí" />
+ 	<str id="installer.no" txt="No" />
+ 	<str id="installer.cancel" txt="Cancelar" />
+ 	<str id="installer.error" txt="Error" />
+ 	<str id="installer.help" txt="Ayuda" />
+ 	<str id="installer.help.close" txt="Cerrar" />
+ 	<str id="installer.step" txt="Paso" />
+ 	<str id="installer.of" txt="de" />
+ 	<str id="installer.Message" txt="Mensaje" />
+ 	<str id="installer.uninstall.writefailed" txt="Falló almacenando la información para la desinstalación." />
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="¡Se eliminarán la(s) aplicacion(es) instalada(s)!"/>
@@ -57,59 +88,67 @@
     <str id="uninstaller.uninstall" txt="Desinstalar"/>
 
     <!-- The strings for the 'official' IzPack plugins -->
+    <!-- HelloPanel strings -->
     <str id="HelloPanel.welcome1" txt="Bienvenido a la instalación de "/>
     <str id="HelloPanel.welcome2" txt=" !"/>
     <str id="HelloPanel.authors" txt="Autor(es) del programa: "/>
     <str id="HelloPanel.url" txt="Página del programa: "/>
 
-    <str id="PrinterSelectPanel.select_printer"
-         txt="Seleccione la impresora a usar para configuración inicial y pruebas."/>
-
-    <str id="CheckedHelloPanel.productAlreadyExist0"
-         txt="Este producto ya está instalado en este ordenador en el directorio  "/>
-    <str id="CheckedHelloPanel.productAlreadyExist1"
-         txt=" . ¿Está seguro de que desea instalar otra instancia del mismo?"/>
-    <str id="CheckedHelloPanel.infoOverUninstallKey" txt="La clave de desinstalación se llamará: "/>
-
+    <!-- LicensePanel strings -->
     <str id="LicencePanel.info" txt="Por favor, lea atentamente el acuerdo de licencia:"/>
     <str id="LicencePanel.agree" txt="Acepto los términos de este acuerdo de licencia"/>
     <str id="LicencePanel.notagree" txt="No acepto los términos de este acuerdo de licencia."/>
     <str id="LicencePanel.yes" txt="Sí"/>
     <str id="LicencePanel.no" txt="No"/>
 
-    <str id="InstallationTypePanel.info" txt="Por favor, seleccione el tipo de instalación:"/>
-    <str id="InstallationTypePanel.normal" txt="Nueva instalación"/>
-    <str id="InstallationTypePanel.modify" txt="Modificar la instalación"/>
+    <!-- PrinterSelect Panel -->
+    <str id="PrinterSelectPanel.select_printer" txt="Seleccione la impresora a usar para configuración inicial y pruebas."/>
 
+    <!-- InfoPanel strings -->
     <str id="InfoPanel.info" txt="Por favor, lea la siguiente información:"/>
 
-    <str id="PathInputPanel.required" txt="El directorio seleccionado debe existir"/>
-    <str id="PathInputPanel.required.forModificationInstallation" txt="El directorio seleccionado debe existir."/>
-    <str id="PathInputPanel.notValid" txt="El directorio seleccionado no contiene el producto requerido"/>
+    <!-- PathInputPanel strings -->
+    <str id="PathInputPanel.isfile"
+        txt="Ha seleccionado un fichero. Por favor, seleccione la ruta para un directorio nuevo o existente."/>
+    <str id="PathInputPanel.required" txt="El directorio seleccionado debe existir" />
+ 	<str id="PathInputPanel.required.forModificationInstallation" txt="El directorio seleccionado debe existir." />
+ 	<str id="PathInputPanel.notValid"
+ 		txt="El directorio seleccionado no contiene el producto requerido" />
+    
+    <!-- TargetPanel strings -->
+    <str id="TargetPanel.info" txt="Seleccione la ruta de instalación:" />
+ 	<str id="TargetPanel.browse" txt="Escoger ..." />
+ 	<str id="TargetPanel.warn"
+ 		txt="¡El directorio ya existe! ¿Confirma su deseo de realizar la instalación ahí y sobreescribir los posibles ficheros existentes?" />
+ 	<str id="TargetPanel.empty_target" txt="¡No ha especificado una ruta destino! ¿Desea hacerlo así?" />
+ 	<str id="TargetPanel.createdir" txt="Se creará el directorio destino:" />
+ 	<str id="TargetPanel.nodir"
+ 		txt="¡El fichero no es un directorio! Por favor, seleccione un directorio" />
+ 	<str id="TargetPanel.notwritable"
+ 		txt="¡El directorio no tiene permiso de escritura! Por favor, seleccione otro directorio" />
+ 	<str id="TargetPanel.incompatibleInstallation"
+ 		txt="Detectada instalación incompatible. Desinstale primero, o seleccione otro directorio para la instalación." />
+    <str id="TargetPanel.syntax.error"
+         txt="Directorio inválido. Por favor, seleccione un directorio válido para su sistema operativo."/>
+    
+    <!-- JDKPathPanel strings -->
+ 	<str id="JDKPathPanel.extendedIntro"
+ 		txt="La instalación instalada necesita un JDK cuya versión esté comprendida entre la ${JDKPathPanel.minVersion} y la ${JDKPathPanel.maxVersion}. Un entorno de ejecución de Java (JRE) no es suficiente." />
+ 	<str id="JDKPathPanel.intro"
+ 		txt="La aplicación necesita un JDK. Un entorno de ejecución de Java (JRE) no es suficiente." />
+ 	<str id="JDKPathPanel.info" txt="Seleccione el directorio del JDK:" />
+ 	<str id="JDKPathPanel.badVersion1" txt="El JDK seleccionado es una versión incorrecta (disponible: " />
+ 	<str id="JDKPathPanel.badVersion2" txt=" necesaria: " />
+ 	<str id="JDKPathPanel.badVersion3" txt=") ¿desea usar este JDK de todas formas?" />
+    <str id="JDKPathPanel.badVersion4" txt="¿Continuar de todos modos? [s/n] [n]"/>
+ 	<str id="JDKPathPanel.nonValidPathInReg"
+ 		txt="El registro de Windows contiene una ruta no válida para este JDK. ¿Desea usar este JDK de todas formas?" />
+ 	<str id="JDKPathPanel.jdkDownload"
+          txt="&lt;html&gt;&lt;p&gt;Este software requiere al menos la versión ${JDKPathPanel.minVersion} de Java Development Kit (JDK).&lt;p/&gt;
+          Si no está instalada, por favor vaya a &lt;a href='http://java.sun.com/javase/downloads/'&gt;http://java.sun.com/javase/downloads&lt;/a&gt;,
+          para descargar e instalarla.&lt;/html&gt;"/>
 
-    <str id="TargetPanel.info" txt="Seleccione la ruta de instalación:"/>
-    <str id="TargetPanel.browse" txt="Escoger ..."/>
-    <str id="TargetPanel.warn"
-         txt="¡El directorio ya existe! ¿Confirma su deseo de realizar la instalación ahí y sobreescribir los posibles ficheros existentes?"/>
-    <str id="TargetPanel.empty_target"
-         txt="¡No ha especificado una ruta destino! ¿Desea hacerlo así?"/>
-    <str id="TargetPanel.createdir" txt="Se creará el directorio destino:"/>
-    <str id="TargetPanel.nodir"
-         txt="¡El fichero no es un directorio! Por favor, seleccione un directorio"/>
-    <str id="TargetPanel.notwritable"
-         txt="¡El directorio no tiene permiso de escritura! Por favor, seleccione otro directorio"/>
-
-    <str id="JDKPathPanel.extendedIntro"
-         txt="La instalación instalada necesita un JDK cuya versión esté comprendida entre la ${JDKPathPanel.minVersion} y la ${JDKPathPanel.maxVersion}. Un entorno de ejecución de Java (JRE) no es suficiente."/>
-    <str id="JDKPathPanel.intro"
-         txt="La aplicación necesita un JDK. Un entorno de ejecución de Java (JRE) no es suficiente."/>
-    <str id="JDKPathPanel.info" txt="Seleccione el directorio del JDK:"/>
-    <str id="JDKPathPanel.badVersion1" txt="El JDK seleccionado es una versión incorrecta (disponible: "/>
-    <str id="JDKPathPanel.badVersion2" txt=" necesaria: "/>
-    <str id="JDKPathPanel.badVersion3" txt=") ¿desea usar este JDK de todas formas?"/>
-    <str id="JDKPathPanel.nonValidPathInReg"
-         txt="El registro de Windows contiene una ruta no válida para este JDK. ¿Desea usar este JDK de todas formas?"/>
-
+    <!-- PacksPanel strings -->
     <str id="PacksPanel.info" txt="Seleccione los paquetes que desea instalar:"/>
     <str id="PacksPanel.tip" txt="Nota: los paquetes en gris son obligatorios."/>
     <str id="PacksPanel.space" txt="Espacio total necesario: "/>
@@ -119,11 +158,11 @@
          txt="El paquete seleccionado necesita los siguientes paquetes para ser instalado"/>
     <str id="PacksPanel.dependencies" txt="Dependencias: "/>
     <str id="PacksPanel.excludes" txt="Exclusiones: "/>
-    <str id="ImgPacksPanel.dependencyList" txt="Dependencias y/ó exclusiones"/>
     <str id="PacksPanel.notEnoughSpace"
          txt="El espacio en disco necesario para la instalación excede el espacio disponible."/>
     <str id="PacksPanel.notAscertainable" txt="No determinable"/>
 
+    <!-- InstallPanel strings -->
     <str id="InstallPanel.info" txt="Pulse el botón ¡Instalar! para comenzar el proceso de instalación"/>
     <str id="InstallPanel.install" txt="¡Instalar!"/>
     <str id="InstallPanel.tip" txt="Progreso de la instalación:"/>
@@ -133,30 +172,41 @@
     <str id="InstallPanel.overwrite.title" txt="El fichero ya existe"/>
     <str id="InstallPanel.overwrite.question" txt="El fichero siguiente ya existe. ¿Desea sobreescribirlo?"/>
 
-    <str id="FinishPanel.success" txt="La instalación ha finalizado con éxito."/>
-    <str id="FinishPanel.done" txt="Hecho"/>
-    <str id="FinishPanel.fail" txt="¡La instalación ha fallado!"/>
-    <str id="FinishPanel.uninst.info" txt="Se ha creado un programa de desinstalación en:"/>
-    <str id="FinishPanel.auto" txt="Generar un guión para reproducir esta misma instalación"/>
-    <str id="FinishPanel.auto.tip"
-         txt="Use este guión para repetir automáticamente la misma instalación en otras máquinas."/>
+    <!-- InstallationGroupPanel strings -->
+    <str id="InstallationGroupPanel.colNameSelected" txt="Seleccionada"/>
+    <str id="InstallationGroupPanel.colNameInstallType" txt="Tipo de instalación"/>
+    <str id="InstallationGroupPanel.colNameSize" txt="Tamaño"/>
 
+    <!-- InstallationTypePanel strings -->
+    <str id="InstallationTypePanel.info" txt="Por favor, seleccione el tipo de instalación:"/>
+    <str id="InstallationTypePanel.normal" txt="Nueva instalación"/>
+    <str id="InstallationTypePanel.modify" txt="Modificar la instalación"/>
+
+    <!-- FinishPanel strings -->
+ 	<str id="FinishPanel.success" txt="La instalación ha finalizado con éxito." />
+ 	<str id="FinishPanel.done" txt="Hecho" />
+ 	<str id="FinishPanel.fail" txt="¡La instalación ha fallado!" />
+ 	<str id="FinishPanel.uninst.info" txt="Se ha creado un programa de desinstalación en:" />
+ 	<str id="FinishPanel.auto" txt="Generar un guión para reproducir esta misma instalación" />
+ 	<str id="FinishPanel.auto.tip"
+ 		txt="Use este guión para repetir automáticamente la misma instalación en otras máquinas." />
+ 	<str id="FinishPanel.auto.dialog.filterdesc" txt="Archivos XML"/>	
+
+    <!-- ImgPacksPanel strings -->
+ 	<str id="ImgPacksPanel.dependencyList" txt="Dependencias y/ó exclusiones" />
     <str id="ImgPacksPanel.packs" txt="Paquetes disponibles:"/>
     <str id="ImgPacksPanel.snap" txt="Captura de pantalla asociada:"/>
     <str id="ImgPacksPanel.checkbox" txt=" Instalar este paquete"/>
 
-    <str id="ShortcutPanel.headline" txt="Configuración de accesos directos"/>
+    <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.regular.list" txt="Seleccione un grupo de programas para los accesos directos:"/>
     <str id="ShortcutPanel.regular.default" txt="Por defecto"/>
     <str id="ShortcutPanel.regular.desktop" txt="Crear accesos directos adicionales en el escritorio"/>
-    <str id="ShortcutPanel.regular.StartMenu:Start-Menu" txt="Start-Menu"/>
-    <str id="ShortcutPanel.regular.StartMenu:K-Menu" txt="XDG-Menu"/>
-    <!-- "StartMenu" is a placeholder will be replaced at runtime -->
+    <str id="ShortcutPanel.regular.startup" txt="Lanzar en el inicio"/>
     <str id="ShortcutPanel.regular.create" txt="Crear accesos directos en el menú Inicio"/>
     <str id="ShortcutPanel.regular.userIntro" txt="Crear acceso directo para:"/>
     <str id="ShortcutPanel.regular.currentUser" txt="Usuario actual"/>
     <str id="ShortcutPanel.regular.allUsers" txt="Todos los usuarios"/>
-
     <str id="ShortcutPanel.alternate.apology"
          txt="Lo sentimos, IzPack no puede crear accesos directos en este sistema operativo. Para crearlos, por favor consulte el manual de su sistema operativo."/>
     <str id="ShortcutPanel.alternate.targetsLabel"
@@ -164,7 +214,6 @@
     <str id="ShortcutPanel.alternate.textFileExplanation"
          txt="Puede guardar información detallada sobre los ficheros ejecutables de la aplicación en un fichero de texto para referencia posterior."/>
     <str id="ShortcutPanel.alternate.saveButton" txt="Guardar fichero de texto"/>
-
     <str id="ShortcutPanel.textFile.header"
          txt="Información de accesos directos\n===============================\n\nEl siguiente es un listado de toda la información relevante sobre los accesos\ndirectos deseados. Esta información puede ayudar en su creación manual.\n"/>
     <str id="ShortcutPanel.textFile.name" txt="Acceso directo        : "/>
@@ -175,27 +224,55 @@
     <str id="ShortcutPanel.textFile.iconName" txt="Fichero del ícono     : "/>
     <str id="ShortcutPanel.textFile.iconIndex" txt="Indice del ícono      : "/>
     <str id="ShortcutPanel.textFile.work" txt="Directorio de trabajo : "/>
-
     <str id="ShortcutPanel.location.desktop" txt="Escritorio"/>
     <str id="ShortcutPanel.location.applications" txt="Menú de aplicaciones"/>
     <str id="ShortcutPanel.location.startMenu" txt="Menú de inicio"/>
     <str id="ShortcutPanel.location.startup" txt="Grupo de inicio"/>
+    <str id="ShortcutPanel.regular.StartMenu:Start-Menu" txt="Start-Menu"/>
+    <str id="ShortcutPanel.regular.StartMenu:K-Menu" txt="XDG-Menu"/>
+    <str id="ShortcutPanel.group.error" txt="Grupo de programa inválido. Por favor, introduzca una cadena de caracteres alfanúmerico."/>
 
-    <str id="UserInputPanel.error.caption" txt="Problema de datos de entrada"/>
-    <str id="UserInputPanel.search.autodetect" txt="Autodetectar"/>
+    <!-- UserInputPanel strings -->
+ 	<str id="UserInputPanel.error.caption" txt="Problema de datos de entrada" />
+ 	<str id="UserInputPanel.dir.nodirectory.message" txt="Debe seleccionar un directorio válido."/>
+    <str id="UserInputPanel.dir.nodirectory.caption" txt="No hay directorio seleccionado"/>
+    <str id="UserInputPanel.dir.notdirectory.message"
+         txt="El directorio que ha seleccionado no existe o no es válido."/>
+    <str id="UserInputPanel.dir.notdirectory.caption" txt="Directorio Incorrecto"/>
+    <str id="UserInputPanel.file.nofile.message" txt="Debe seleccionar un archivo válido."/>
+    <str id="UserInputPanel.file.nofile.caption" txt="No hay archivos seleccionados"/>
+    <str id="UserInputPanel.file.notfile.message"
+         txt="El archivo que ha seleccionado no existe o no es válido."/>
+    <str id="UserInputPanel.file.notfile.caption" txt="Archivo Incorrecto"/>
+ 	<!-- more descriptive error message would be cool, like specifying what 
+ 		file we looked for -->
+ 	<str id="UserInputPanel.search.autodetect" txt="Autodetectar" />
+ 	<str id="UserInputPanel.search.autodetect.failed.message" txt="La autodetección ha fallado." />
+ 	<str id="UserInputPanel.search.autodetect.failed.caption" txt="La autodetección ha fallado." />
+ 	<str id="UserInputPanel.search.autodetect.tooltip"
+ 		txt="Compruebe el fichero o directorio en las rutas mostradas arriba." />
+ 	<str id="UserInputPanel.search.location" txt="Introduzca la ruta de {0}." />
+ 	<str id="UserInputPanel.search.location.checkedfile" txt="Se ha comprobado la existencia de {0}." />
+ 	<str id="UserInputPanel.search.browse" txt="Buscar..." />
+ 	<str id="UserInputPanel.search.delete" txt="Eliminar..."/>
+ 	<str id="UserInputPanel.search.wrongselection.message"
+ 		txt="El fichero o directorio elegido no existe o no es apropiado." />
+ 	<str id="UserInputPanel.search.wrongselection.caption" txt="Selección no válida." />
 
-    <!-- more descriptive error message would be cool, like specifying what file we looked for -->
-    <str id="UserInputPanel.search.autodetect.failed.message" txt="La autodetección ha fallado."/>
-    <str id="UserInputPanel.search.autodetect.failed.caption" txt="La autodetección ha fallado."/>
-    <str id="UserInputPanel.search.autodetect.tooltip"
-         txt="Compruebe el fichero o directorio en las rutas mostradas arriba."/>
-    <str id="UserInputPanel.search.location" txt="Introduzca la ruta de {0}."/>
-    <str id="UserInputPanel.search.location.checkedfile" txt="Se ha comprobado la existencia de {0}."/>
-    <str id="UserInputPanel.search.browse" txt="Buscar..."/>
-    <str id="UserInputPanel.search.wrongselection.message"
-         txt="El fichero o directorio elegido no existe o no es apropiado."/>
-    <str id="UserInputPanel.search.wrongselection.caption" txt="Selección no válida."/>
+    <!-- UserPathPanel strings -->
+    <str id="UserPathPanel.required" txt="El directorio seleccionado debe existir."/>
+    <str id="UserPathPanel.info" txt="Seleccione la ubicación: "/>
+    <str id="UserPathPanel.browse" txt="Buscar"/>
+    <str id="UserPathPanel.exists_warn"
+         txt="El directorio ya existe! Esta seguro de instalar aquí y posiblemente sobreescribir los archivos existentes?"/>
+    <str id="UserPathPanel.empty_target"
+         txt="No ha especificado una ubicación destino! Esto es correcto?"/>
+    <str id="UserPathPanel.createdir" txt="El directorio destino será creado: "/>
+    <str id="UserPathPanel.nodir" txt="Esta dirección no es un directorio! Por favor seleccione un directorio!"/>
+    <str id="UserPathPanel.notwritable"
+         txt="En este directorio no se puede escribir! por favor seleccione otro directorio!"/>
 
+    <!-- CompilePanel strings -->
     <str id="CompilePanel.heading" txt="Compilación"/>
     <str id="CompilePanel.tip" txt="Progreso de la compilación:"/>
     <str id="CompilePanel.browse" txt="Buscar..."/>
@@ -217,25 +294,49 @@
     <str id="CompilePanel.choose_compiler" txt="Compilador a usar:"/>
     <str id="CompilePanel.additional_arguments" txt="Argumentos adicionales de compilación:"/>
 
+    <!-- ProcessPanel strings -->
     <str id="ProcessPanel.heading" txt="Procesando"/>
 
-    <!-- Strings for the summary of panels - START -->
-    <str id="SummaryPanel.info"
-         txt="La configuración de la instalación ha terminado. Se muestra a continuación un resumen de la misma. Pulse &quot;Siguiente&quot; para comenzar la instalación: "/>
-    <str id="TargetPanel.summaryCaption" txt="Ruta de la instalación"/>
-    <str id="JDKPathPanel.summaryCaption" txt="Ruta del JDK"/>
-    <str id="PacksPanel.summaryCaption" txt="Paquetes de la instalación seleccionados"/>
-    <str id="ImgPacksPanel.summaryCaption" txt="Paquetes de la instalación seleccionados"/>
-    <str id="TreePacksPanel.summaryCaption" txt="Paquetes de la instalación seleccionados"/>
-    <!-- Strings for the summary of panels - END -->
+    <!-- SummaryPanel strings -->
+ 	<str id="SummaryPanel.info"
+ 		txt="La configuración de la instalación ha terminado. Se muestra a continuación un resumen de la misma. Pulse &quot;Siguiente&quot; para comenzar la instalación: " />
+ 	<str id="TargetPanel.summaryCaption" txt="Ruta de la instalación" />
+ 	<str id="JDKPathPanel.summaryCaption" txt="Ruta del JDK" />
+	<str id="InstallationGroupPanel.summaryCaption" txt="Opciones de Instalación Seleccionadas"/>
+ 	<str id="PacksPanel.summaryCaption" txt="Paquetes de la instalación seleccionados" />
+ 	<str id="ImgPacksPanel.summaryCaption" txt="Paquetes de la instalación seleccionados" />
+ 	<str id="TreePacksPanel.summaryCaption" txt="Paquetes de la instalación seleccionados" />
+ 	<str id="UserPathPanel.summaryCaption" txt="Ubicación seleccionada"/>
+    <str id="DefaultTargetPanel.summaryCaption" txt="Directorio de Instalación"/>
 
     <!-- Strings for the Registry -->
     <str id="functionFailed.RegOpenKeyEx" txt="No se pudo abrir la clave {0}\\{1} del registro."/>
 
-    <!-- Add your own panels specific strings here if you need or use a custom
-         langpack with the same syntax referred as resoure CustomLangpack.xml_[ISO3]"
-    -->
+    <!-- CheckedHelloPanel strings -->
+    <str id="CheckedHelloPanel.productAlreadyExist0"
+         txt="Este producto ya está instalado en este ordenador en el directorio  "/>
+    <str id="CheckedHelloPanel.productAlreadyExist1" txt=" . ¿Está seguro de que desea instalar otra instancia del mismo?"/>
+    <str id="CheckedHelloPanel.infoOverUninstallKey" txt="La clave de desinstalación se llamará: "/>
 
+ 	<!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Escriba O para OK, C para Cancelar: "/>
+    <str id="ConsolePrompt.yesNo" txt="Escriba S para Si, N para No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Escriba S para Si, N para No, o C para Cancelar: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="S"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Presione 1 para continuar, 2 para salir, 3 para volver a mostrar"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Presione 1 para aceptar, 2 para rechazar, 3 para volver a mostrar"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Presione 1 para volver a mostrar, 2 para salir"/>
+    <str id="ConsoleInstaller.permissionError" txt="Se requieren permisos administrativos. Por favor, arranque de nuevo el instalador con permisos administrativos."/>
+
+    <!-- AutomatedInstaller Strings -->
+    <str id="AutomatedInstaller.permissionError" txt="Se requieren permisos administrativos. Por favor, arranque de nuevo el instalador con permisos administrativos."/>
+
+    <!-- Next Media Strings -->
     <str id="nextmedia.title" txt="Siguiente medio para la instalación"/>
     <str id="nextmedia.msg" txt="Seleccione el siguiente medio para la instalación."/>
     <str id="nextmedia.browsebtn" txt="Buscar"/>
@@ -244,17 +345,17 @@
     <str id="nextmedia.choosertitle" txt="Seleccionar el medio de la instalación"/>
     <str id="nextmedia.filedesc" txt="Paquetes de instalación (.pak*)"/>
 
-    <!-- Strings for the loggin/reporting system (Messenger) -->
-
     <!-- This string defines the time stamp format in the installation report.
          The format details are documented in java.text.SimpleDateFormat -->
     <str id="log.timeStamp" txt="MM-dd-yyyy [HH:mm:ss]  zzzz"/>
 
-    <!-- Strings for various purposes in the logging/reporting system  -->
+    <!-- Strings for various purposes in the logging/reporting system -->
     <str id="log.reportHeading" txt="                           Informe de instalación de IzPack"/>
     <str id="log.installFailed" txt="¡¡¡ATENCIÓN!!! ¡La instalación no ha terminado correctamente!"/>
-    <str id="log.partialInstall" txt="¡¡¡ATENCIÓN!!! ¡La instalación puede no haber terminado con éxito!"/>
-    <str id="log.messageCount" txt="Este informe contiene {0} mensaje(s) general(es), {1} aviso(s) y {2} error(es)"/>
+    <str id="log.partialInstall" 
+    	txt="¡¡¡ATENCIÓN!!! ¡La instalación puede no haber terminado con éxito!"/>
+    <str id="log.messageCount" 
+    	txt="Este informe contiene {0} mensaje(s) general(es), {1} aviso(s) y {2} error(es)"/>
     <str id="log.application" txt="Informe de instalación para : {0} Versión {1}"/>
     <str id="log.timePrefix" txt="Hora de instalación            : {0}"/>
     <str id="log.pathPrefix" txt="Directorio de instalación      : {0}"/>
@@ -278,14 +379,11 @@
     <!-- Strings for individual messages in the logging/reporting system.
          Numbers for each category (message/warning/error) start at 0  -->
     <str id="log.message_" txt=""/>
-
     <str id="log.warning_" txt=""/>
-
     <str id="log.error_0" txt="No es posible escribir ''{0}''"/>
-
-    <str id="InstallationGroupPanel.colNameSelected" txt="Seleccionada"/>
-    <str id="InstallationGroupPanel.colNameInstallType" txt="Tipo de instalación"/>
-    <str id="InstallationGroupPanel.colNameSize" txt="Tamaño"/>
-
     <str id="debug.changevariable" txt="Modificar valor"/>
+
+ 	<str id="data.validation.error.title" txt="Validación fallida"/>
+    <str id="data.validation.warning.title" txt="Validación fallida - continuando instalación"/>
+    
 </izpack:langpack>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -332,6 +332,7 @@
     <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Presione 1 para aceptar, 2 para rechazar, 3 para volver a mostrar"/>
     <str id="ConsoleInstaller.redisplayQuit" txt="Presione 1 para volver a mostrar, 2 para salir"/>
     <str id="ConsoleInstaller.permissionError" txt="Se requieren permisos administrativos. Por favor, arranque de nuevo el instalador con permisos administrativos."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Introduzca selección: "/>
 
     <!-- AutomatedInstaller Strings -->
     <str id="AutomatedInstaller.permissionError" txt="Se requieren permisos administrativos. Por favor, arranque de nuevo el instalador con permisos administrativos."/>

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetConsolePanel.java
@@ -100,7 +100,7 @@ public class TargetConsolePanel extends AbstractConsolePanel implements ConsoleP
             defaultPath = "";
         }
 
-        String path = console.promptLocation("Select target path [" + defaultPath + "] ", defaultPath, null);
+        String path = console.promptLocation(installData.getMessages().get("TargetPanel.info")+ " [" + defaultPath + "] ", defaultPath, null);
         if (path != null)
         {
             path = installData.getVariables().replace(path);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleChoiceField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleChoiceField.java
@@ -82,7 +82,7 @@ public abstract class ConsoleChoiceField<T extends Choice> extends ConsoleField
             List<Choice> choices = field.getChoices();
             listChoices(choices, field.getSelectedIndex());
 
-            int selected = getConsole().prompt("input selection: ", 0, choices.size() - 1, field.getSelectedIndex(), -1);
+            int selected = getConsole().prompt(getMessage("ConsoleInstaller.inputSelection"), 0, choices.size() - 1, field.getSelectedIndex(), -1);
             if (selected == -1)
             {
                 return false;

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/combo/ConsoleComboFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/combo/ConsoleComboFieldTest.java
@@ -28,22 +28,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.api.handler.Prompt;
-import com.izforge.izpack.api.resource.Messages;
-import com.izforge.izpack.api.rules.RulesEngine;
-import com.izforge.izpack.core.container.DefaultContainer;
-import com.izforge.izpack.core.data.DefaultVariables;
-import com.izforge.izpack.core.handler.ConsolePrompt;
-import com.izforge.izpack.core.rules.ConditionContainer;
-import com.izforge.izpack.core.rules.RulesEngineImpl;
+import com.izforge.izpack.panels.userinput.console.AbstractConsoleFieldTest;
 import com.izforge.izpack.panels.userinput.field.Choice;
 import com.izforge.izpack.panels.userinput.field.choice.TestChoiceFieldConfig;
 import com.izforge.izpack.panels.userinput.field.combo.ComboField;
-import com.izforge.izpack.test.util.TestConsole;
-import com.izforge.izpack.util.Platforms;
 
 
 /**
@@ -51,23 +40,8 @@ import com.izforge.izpack.util.Platforms;
  *
  * @author Tim Anderson
  */
-public class ConsoleComboFieldTest
+public class ConsoleComboFieldTest extends AbstractConsoleFieldTest
 {
-
-    /**
-     * The install data.
-     */
-    private final AutomatedInstallData installData;
-
-    /**
-     * The console.
-     */
-    private final TestConsole console;
-
-    /**
-     * The prompt.
-     */
-    private final Prompt prompt;
 
     /**
      * The choices.
@@ -79,13 +53,8 @@ public class ConsoleComboFieldTest
      */
     public ConsoleComboFieldTest()
     {
-        installData = new AutomatedInstallData(new DefaultVariables(), Platforms.HP_UX);
-        RulesEngine rules = new RulesEngineImpl(new ConditionContainer(new DefaultContainer()),
-                                                installData.getPlatform());
-        console = new TestConsole();
-        prompt = new ConsolePrompt(console, Mockito.mock(Messages.class));
-        installData.setRules(rules);
-
+    	super();
+    	
         choices = Arrays.asList(new Choice("A", "A String"), new Choice("B", "B String"), new Choice("C", "C String"));
     }
 


### PR DESCRIPTION
Add the localization support for some text hardcoded in the code (console classes).
1.
class "TargetConsolePanel" 
method "public boolean run(InstallData installData, Console console)"
text: "Select target path ["
2. 
class "ConsoleChoiceField"
method "public boolean More ...display()"
text: "input selection: "

The test has been changed too in order to load the messages.

This pull request in about the jira issue IZPACK-1222
http://jira.codehaus.org/browse/IZPACK-1222

This pull request depends on the previous pull request (for avoiding conflicts in spa.xml and eng.xml)
https://github.com/izpack/izpack/pull/331 
for the jira issue: http://jira.codehaus.org/browse/IZPACK-1092
