### PR TITLE
Post-fix for IZPACK-1231: Remove showing stacktraces on the command line

### DIFF
--- a/izpack-gui/src/main/java/com/izforge/izpack/gui/GUIPrompt.java
+++ b/izpack-gui/src/main/java/com/izforge/izpack/gui/GUIPrompt.java
@@ -237,7 +237,6 @@ public class GUIPrompt extends AbstractPrompt
             final String submissionURL,
             final Throwable throwable)
     {
-        new Exception().printStackTrace();
         final List<Object> buttons = new ArrayList<Object>();
         String throwMessage = null;
         final JButton detailsButton = new JButton("Show Details");;


### PR DESCRIPTION
Post-fix for IZPACK-1231: Remove showing stacktraces on the command line before opening error messageboxes, for instance on validation failures