### PR TITLE
[IZPACK-1238] UserInputPanel: input fields not focused automatically onpanel activation

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/Component.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/Component.java
@@ -21,6 +21,8 @@ package com.izforge.izpack.panels.userinput.gui;
 
 import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextPane;
 import javax.swing.text.JTextComponent;
 
 /**
@@ -34,6 +36,8 @@ public class Component
     private final JComponent component;
 
     private final Object constraints;
+
+    private boolean enabled = true;
 
     public Component(JComponent component, Object constraints)
     {
@@ -53,8 +57,9 @@ public class Component
 
     public void setEnabled(boolean enabled)
     {
-        if (component instanceof JLabel)
+        if (component instanceof JLabel || component instanceof JPanel || component instanceof JTextPane)
         {
+            enabled = false;
             return;
         }
         if (component instanceof JTextComponent)
@@ -62,10 +67,16 @@ public class Component
             JTextComponent textComponent = ((JTextComponent)component);
             if (!textComponent.isFocusable() || !textComponent.isEditable())
             {
+                enabled = false;
                 return;
             }
         }
-        component.setEnabled(enabled);
+        enabled = true;
+        component.setEnabled(true);
     }
 
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
@@ -114,6 +114,13 @@ public abstract class GUIField extends AbstractFieldView
     }
 
     /**
+     * Return a {@link JComponent} of this field which is the primary candidate to gain focus.
+     *
+     * @return the primary {@link JComponent} to gain focus
+     */
+    public abstract JComponent getFirstFocusableComponent();
+
+    /**
      * Registers a listener to be notified of field updates.
      *
      * @param listener the listener to notify

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/button/GUIButtonField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/button/GUIButtonField.java
@@ -7,6 +7,7 @@ import com.izforge.izpack.panels.userinput.field.button.ButtonField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
 import javax.swing.*;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.List;
@@ -50,5 +51,11 @@ public class GUIButtonField extends GUIField implements ActionListener
         {
             prompt.message(Prompt.Type.INFORMATION, successMsg);
         }
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return button;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/check/GUICheckField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/check/GUICheckField.java
@@ -21,14 +21,16 @@
 
 package com.izforge.izpack.panels.userinput.gui.check;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
 import com.izforge.izpack.panels.userinput.field.check.CheckField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
-
-import javax.swing.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 
 /**
@@ -106,5 +108,11 @@ public class GUICheckField extends GUIField
             field.setValue(field.getFalseValue());
         }
         return true;
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return checkbox;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/combo/GUIComboField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/combo/GUIComboField.java
@@ -21,15 +21,16 @@
 
 package com.izforge.izpack.panels.userinput.gui.combo;
 
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.panels.userinput.field.Choice;
 import com.izforge.izpack.panels.userinput.field.combo.ComboField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
-
-import javax.swing.*;
-
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 
 
 /**
@@ -159,4 +160,10 @@ public class GUIComboField extends GUIField
             index++;
         }
      }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return combo;
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/GUICustomField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/GUICustomField.java
@@ -13,6 +13,8 @@ import com.izforge.izpack.panels.userinput.gui.GUIField;
 
 import java.util.List;
 
+import javax.swing.JComponent;
+
 /**
  * JPanel that contains the possible rows of fields defined by the user,
  * along with control buttons to add and remove rows.
@@ -53,5 +55,11 @@ public class GUICustomField extends GUIField implements CustomFieldType
     public boolean updateField(Prompt prompt)
     {
         return customInputField.updateField(prompt);
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return customInputField;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/divider/GUIDivider.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/divider/GUIDivider.java
@@ -27,6 +27,7 @@ import com.izforge.izpack.panels.userinput.field.divider.Divider;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
 import javax.swing.*;
+
 import java.awt.*;
 
 /**
@@ -61,6 +62,12 @@ public class GUIDivider extends GUIField
         constraints.stretch = true;
         addComponent(panel, constraints);
         addTooltip();
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return null;
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/AbstractGUIFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/AbstractGUIFileField.java
@@ -23,6 +23,8 @@ package com.izforge.izpack.panels.userinput.gui.file;
 
 import java.io.File;
 
+import javax.swing.JComponent;
+
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
 import com.izforge.izpack.panels.userinput.field.Field;
@@ -126,6 +128,12 @@ public abstract class AbstractGUIFileField extends GUIField
         {
             addComponent(inputField, new TwoColumnConstraints(TwoColumnConstraints.BOTH));
         }
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return this.fileInput;
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/GUIMultipleFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/GUIMultipleFileField.java
@@ -21,6 +21,8 @@
 
 package com.izforge.izpack.panels.userinput.gui.file;
 
+import javax.swing.JComponent;
+
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
 import com.izforge.izpack.installer.data.GUIInstallData;
@@ -150,6 +152,12 @@ public class GUIMultipleFileField extends GUIField
                 fileInput.addFile(file);
             }
         }
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return fileInput;
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/password/GUIPasswordGroupField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/password/GUIPasswordGroupField.java
@@ -152,5 +152,10 @@ public class GUIPasswordGroupField extends GUIField
         return result;
     }
 
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return passwords.get(0);
+    }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
@@ -21,18 +21,22 @@
 
 package com.izforge.izpack.panels.userinput.gui.radio;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.ButtonGroup;
+import javax.swing.JComponent;
+import javax.swing.JRadioButton;
+
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.gui.TwoColumnConstraints;
 import com.izforge.izpack.panels.userinput.field.Choice;
 import com.izforge.izpack.panels.userinput.field.radio.RadioField;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
-
-import javax.swing.*;
-
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**
@@ -79,6 +83,21 @@ public class GUIRadioField extends GUIField implements ActionListener
             ++id;
             button.setText(choice.getValue());
             button.addActionListener(this);
+
+            button.addItemListener(new ItemListener() {
+
+                @Override
+                public void itemStateChanged(ItemEvent e)
+                {
+                    if (e.getStateChange() == ItemEvent.SELECTED)
+                    {
+                        // Fire a change action if the arrow keys are used to select a radiobutton.
+                        // This is important for condition-driven dynamic changes on the UserInputPanel,
+                        // otherwise they happen just on mouse clicks.
+                        ((JRadioButton) e.getSource()).doClick();
+                    }
+                }
+            });
 
             buttonGroup.add(button);
             boolean selected = field.getSelectedIndex() == buttonGroup.getButtonCount() - 1;
@@ -238,5 +257,26 @@ public class GUIRadioField extends GUIField implements ActionListener
             }
             index++;
         }
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        // Return first selected radiobutton
+        for (RadioChoiceView radioChoiceView : choices)
+        {
+            JRadioButton radioButton = radioChoiceView.getButton();
+            if (radioButton.isSelected())
+            {
+                return radioButton;
+            }
+        }
+        // No choice selected
+        if (choices.size() > 0)
+        {
+            return choices.get(0).getButton();
+        }
+        // No radiobutton at all
+        return null;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleField.java
@@ -21,6 +21,9 @@
 
 package com.izforge.izpack.panels.userinput.gui.rule;
 
+import java.util.List;
+
+import javax.swing.JComponent;
 import javax.swing.JTextField;
 
 import com.izforge.izpack.api.handler.Prompt;
@@ -174,5 +177,16 @@ public class GUIRuleField extends GUIField
             }
         }
         return changed;
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        List<JTextField> inputFields = component.getInputFields();
+        if (!inputFields.isEmpty())
+        {
+            return component.getInputFields().get(0);
+        }
+        return null;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/search/GUISearchField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/search/GUISearchField.java
@@ -131,4 +131,10 @@ public class GUISearchField extends GUIField
         getField().setValue(searchInputField.getResult());
         return true;
     }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return getComponents().get(0).getComponent();
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/space/GUISpacer.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/space/GUISpacer.java
@@ -52,4 +52,9 @@ public class GUISpacer extends GUIField
         addTooltip();
     }
 
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return null;
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/statictext/GUIStaticText.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/statictext/GUIStaticText.java
@@ -21,6 +21,8 @@
 
 package com.izforge.izpack.panels.userinput.gui.statictext;
 
+import javax.swing.JComponent;
+
 import com.izforge.izpack.panels.userinput.field.statictext.StaticText;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
 
@@ -42,5 +44,11 @@ public class GUIStaticText extends GUIField
         super(field);
         addText(getField().getLabel());
         addTooltip();
+    }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return null;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
@@ -190,4 +190,10 @@ public class GUITextField extends GUIField implements FocusListener, DocumentLis
     {
         setChanged(true);
     }
+
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return text;
+    }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/title/GUITitleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/title/GUITitleField.java
@@ -129,4 +129,10 @@ public class GUITitleField extends GUIField
         return result;
     }
 
+    @Override
+    public JComponent getFirstFocusableComponent()
+    {
+        return null;
+    }
+
 }


### PR DESCRIPTION
This pull request solves https://jira.codehaus.org/browse/IZPACK-1238:

On opening a user input panel during a Swing-based installation, there is not automatically focused the first valid input field. Instead, the user must navigate or click on it to do any input.
