### PR TITLE
[IZPACK-1240] Message boxes after validation failures cannot be closed using ENTER, but just by ESC, SPACE or clicking on the Close button

### DIFF
--- a/izpack-gui/src/main/java/com/izforge/izpack/gui/GUIPrompt.java
+++ b/izpack-gui/src/main/java/com/izforge/izpack/gui/GUIPrompt.java
@@ -53,7 +53,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 import com.izforge.izpack.api.handler.AbstractPrompt;
-import com.izforge.izpack.api.handler.Prompt.Type;
 
 
 /**
@@ -344,6 +343,7 @@ public class GUIPrompt extends AbstractPrompt
                 }
             });
         }
+
         // Display the dialog modally. This method will return only when the
         // user clicks the "Exit" button of the JOptionPane.
         dialog.setVisible(true);
@@ -548,6 +548,7 @@ public class GUIPrompt extends AbstractPrompt
     {
         public static void main(String[] args)
         {
+            UIManager.put("Button.defaultButtonFollowsFocus", Boolean.TRUE);
             String url = (args.length > 0) ? args[0] : null;
             try
             {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
@@ -96,6 +96,8 @@ public class GUIInstallDataProvider extends AbstractInstallDataProvider
         {
             guiInstallData.buttonsHColor = UIManager.getColor("Button.background");
         }
+        // ENTER always presses button in focus
+        UIManager.put("Button.defaultButtonFollowsFocus", Boolean.TRUE);
         return guiInstallData;
     }
 


### PR DESCRIPTION
This PR fixes https://jira.codehaus.org/browse/IZPACK-1240:

On Unix, when validating user inputs, in case of validation errors or warnings the installer opens a messagebox with a focused 'Close' button, but pressing ENTER doesn't close it, just ESC, SPACE or clicking it directly close these messageboxes.

This is specific to the Look and Feel. Activate/override the "Button.defaultButtonFollowsFocus" setting in general for all L&F.