### PR TITLE
Post-fix for [IZPACK-1182] Evaluation of dynamic variables, which depends on another one, fails

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -320,12 +320,12 @@ public class DefaultVariables implements Variables
         boolean changed = true;
         while (changed) {
             changed = false;
-            count--;		// decrement number of remaining loops
+            count--;        // decrement number of remaining loops
             if (count<0) {
-            	throw new InstallerException(
-            		String.format("Refresh of dynamic variables seem to produce a loop. "
-            				     +"Stopped after %1s iterations. "
-            				     +"(Maybe a cyclic dependency of variables?)", maxCount));
+                throw new InstallerException(
+                    String.format("Refresh of dynamic variables seem to produce a loop. "
+                                +"Stopped after %1s iterations. "
+                                +"(Maybe a cyclic dependency of variables?)", maxCount));
             }
             Properties setVariables = new Properties();
             Set<String> unsetVariables = new HashSet<String>();
@@ -362,7 +362,7 @@ public class DefaultVariables implements Variables
                             {
                                 setVariables.put(name, newValue);
                             }
-                            if (newValue==null || ! newValue.contains("$"))
+                            if (!(newValue == null || newValue.contains("$")))
                             {
                                 variable.setChecked();
                             } else {


### PR DESCRIPTION
This is a post-fix regarding https://jira.codehaus.org/browse/IZPACK-1182:

Where possible, force resolving of dynamic variables independently of the order they are defined in.