### PR TITLE
[IZPACK-1238] UserInputPanel: input fields not focused automatically on panel activation - post-fix

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/AbstractGUIFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/AbstractGUIFileField.java
@@ -133,7 +133,7 @@ public abstract class AbstractGUIFileField extends GUIField
     @Override
     public JComponent getFirstFocusableComponent()
     {
-        return this.fileInput;
+        return this.fileInput.filetxt;
     }
 
 }


### PR DESCRIPTION
File/dir input fields still didn't receive the initial focus correctly.
This small change fixes this problem for them.