### PR TITLE
[IZPACK-1242] Dynamic variable definitions with the same name and conditionid overwritten, although applying different filters for each of them

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1992,7 +1992,7 @@ public class CompilerConfig extends Thread
                         e);
             }
         }
-        
+
         // validate and insert (and require if -web kind) web dir
         IXMLElement webDirURL = root.getFirstChildNamed("webdir");
         if (webDirURL != null)
@@ -2538,7 +2538,7 @@ public class CompilerConfig extends Thread
     private void addDynamicVariable(IXMLElement varXml, int index, String name, DynamicVariable dynamicVariable)
     {
         Map<String, List<DynamicVariable>> dynamicvariables = packager.getDynamicVariables();
-        List<DynamicVariable> dynamicValues = new ArrayList<DynamicVariable>();
+        List<DynamicVariable> dynamicValues;
 
         if (dynamicvariables.containsKey(name))
         {
@@ -2546,12 +2546,13 @@ public class CompilerConfig extends Thread
         }
         else
         {
+            dynamicValues = new ArrayList<DynamicVariable>();
             dynamicvariables.put(name, dynamicValues);
         }
 
         if (dynamicValues.remove(dynamicVariable))
         {
-            assertionHelper.parseWarn(varXml, "Variable '" + name + "' will be overwritten");
+            assertionHelper.parseWarn(varXml, "Variable definition '" + dynamicVariable.toString() + "' will be overwritten");
         }
         if (index < 0)
         {
@@ -3165,7 +3166,7 @@ public class CompilerConfig extends Thread
         try
         {
             if (dir_attr != null)
-            {   
+            {
                 File dir = FileUtil.getAbsoluteFile(dir_attr, compilerData.getBasedir());
                 // if the path does not exist, maybe it contains variables
                 if (! dir.exists()) {

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -312,6 +312,8 @@ public class DefaultVariables implements Variables
     {
         logger.fine("Refreshing dynamic variables");
         Set<DynamicVariable> checkedVariables = new HashSet<DynamicVariable>();
+        Properties setVariables = new Properties();
+        Set<String> unsetVariables = new HashSet<String>();
         // for dependent dynamic variables a size of dynamicVariables.size()+1 would be enough
         // in case of conditions, which depend on dynamic variables also, we need more iterations
         // to be on the safe side, we take 10*dynamicVariables.size()+1
@@ -327,9 +329,6 @@ public class DefaultVariables implements Variables
                                 +"Stopped after %1s iterations. "
                                 +"(Maybe a cyclic dependency of variables?)", maxCount));
             }
-            Properties setVariables = new Properties();
-            Set<String> unsetVariables = new HashSet<String>();
-
             for (DynamicVariable variable : dynamicVariables)
             {
                 String name = variable.getName();

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -256,27 +256,49 @@ public class DynamicVariableImpl implements DynamicVariable
             return false;
         }
         DynamicVariable compareObj = (DynamicVariable) obj;
-        return (name.equals(compareObj.getName())
-                && (   (conditionid == null && compareObj.getConditionid() == null)
-                    || (conditionid != null && conditionid.equals(compareObj.getConditionid()))
-                   ));
+        if (!name.equals(compareObj.getName())) { return false; }
+        if (!((conditionid == null && compareObj.getConditionid() == null)
+                || (conditionid != null && conditionid.equals(compareObj.getConditionid())))) { return false; }
+        if (checkonce != compareObj.isCheckonce()) { return false; }
+        if (!((value == null && compareObj.getValue() == null)
+                || (value != null && value.equals(compareObj.getValue())))) { return false; }
+        List<ValueFilter> compareFilters = compareObj.getFilters();
+        if (filters != null && compareFilters != null)
+        {
+            if (!(filters.containsAll(compareFilters) && compareFilters.containsAll(filters)))
+            {
+                return false;
+            }
+        }
+        else if ((filters != null && compareFilters == null) || (filters == null && compareFilters != null)) {
+            return false;
+        }
+        return true;
     }
 
     @Override
     public String toString()
     {
-        return "name: " + name + ", condition: " + conditionid;
-    }
-
-    @Override
-    public int hashCode()
-    {
-        int condidHashCode = 0;
-        if (conditionid != null)
+        StringBuffer ret = new StringBuffer("name: " + name + ", condition: " + conditionid + ", checkonce: " + checkonce);
+        if (value != null)
         {
-            condidHashCode = conditionid.hashCode();
+            ret.append(", value: " + value.toString());
         }
-        return name.hashCode() ^ condidHashCode;
+        if (filters != null)
+        {
+            ret.append(", filters: ");
+            boolean appended = false;
+            for (ValueFilter valueFilter : filters)
+            {
+                if (appended)
+                {
+                    ret.append(",");
+                }
+                ret.append(valueFilter.toString());
+                appended = true;
+            }
+        }
+        return ret.toString();
     }
 
     @Override

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/ValueImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/ValueImpl.java
@@ -49,4 +49,20 @@ public abstract class ValueImpl implements Value
     {
         this.installData = installData;
     }
+
+    @Override
+    public String toString()
+    {
+        return this.getClass().getName();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if ((obj == null) || !(obj instanceof ValueImpl))
+        {
+            return false;
+        }
+        return true;
+    }
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/filters/CaseStyleFilter.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/filters/CaseStyleFilter.java
@@ -10,15 +10,15 @@ public class CaseStyleFilter implements ValueFilter
 
     public enum Style {LOWER,UPPER};
     private Style style;
-    
-    public CaseStyleFilter(Style style) 
+
+    public CaseStyleFilter(Style style)
     {
-       this.style = style; 
+       this.style = style;
     }
 
     public CaseStyleFilter(String style)
     {
-        try 
+        try
         {
             this.style = Style.valueOf(style.toUpperCase());
         }
@@ -28,10 +28,15 @@ public class CaseStyleFilter implements ValueFilter
         }
     }
 
+    public Style getStyle()
+    {
+        return style;
+    }
+
     @Override
     public void validate() throws Exception
     {
-        if (style==null) 
+        if (style==null)
         {
             throw new CompilerException("case Filter has been initialized with unknown style");
         }
@@ -46,5 +51,21 @@ public class CaseStyleFilter implements ValueFilter
         case UPPER: return value.toUpperCase();
         default:        throw new CompilerException("case Filter has been initialized with unimplemented style");
         }
+    }
+
+    @Override
+    public String toString()
+    {
+        return "(style: " + style.toString()+ ")";
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if ((obj == null) || !(obj instanceof CaseStyleFilter))
+        {
+            return false;
+        }
+        return style.equals(((CaseStyleFilter)obj).getStyle());
     }
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/filters/LocationFilter.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/filters/LocationFilter.java
@@ -43,4 +43,21 @@ public class LocationFilter implements ValueFilter
 
         return FilenameUtils.concat(_baseDir_, value);
     }
+
+    @Override
+    public String toString()
+    {
+        return "(location: " + baseDir + ")";
+    }
+
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if ((obj == null) || !(obj instanceof LocationFilter))
+        {
+            return false;
+        }
+        return baseDir.equals(((LocationFilter)obj).getBaseDir());
+    }
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/filters/RegularExpressionFilter.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/filters/RegularExpressionFilter.java
@@ -158,4 +158,35 @@ public class RegularExpressionFilter implements ValueFilter
         return processor.execute();
     }
 
+    @Override
+    public String toString()
+    {
+        return "(regexp: " + regexp
+                + ", replace: " + replace
+                + ", select: " + select
+                + ", default: " + defaultValue
+                + ", casesensitive: " + casesensitive
+                + ", global: " + global + ")"
+                ;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if ((obj == null) || !(obj instanceof RegularExpressionFilter))
+        {
+            return false;
+        }
+        String compareRegexp = ((RegularExpressionFilter)obj).getRegexp();
+        String compareReplace = ((RegularExpressionFilter)obj).getReplace();
+        String compareSelect = ((RegularExpressionFilter)obj).getSelect();
+        String compareDefaultValue = ((RegularExpressionFilter)obj).getDefaultValue();
+        return regexp!=null?regexp.equals(compareRegexp):compareRegexp==null
+                && replace!=null?replace.equals(compareReplace):compareReplace==null
+                && select!=null?select.equals(compareSelect):compareSelect==null
+                && defaultValue!=null?defaultValue.equals(compareDefaultValue):compareDefaultValue==null
+                && Boolean.valueOf(casesensitive).equals(((RegularExpressionFilter)obj).getCasesensitive())
+                && Boolean.valueOf(global).equals(((RegularExpressionFilter)obj).getGlobal())
+                ;
+    }
 }


### PR DESCRIPTION
Fix for https://jira.codehaus.org/browse/IZPACK-1242:

Provided a definition like this:
```xml
    <variable name="db.name" value="${db.url}" checkonce="true" condition="NotInstall+haveDatabaseURL+useMssql">
      <filters>
        <regex regexp="jdbc:jtds:sqlserver://[^:]+:\d+.*;DatabaseName=([^;]*)" select="\1" />
      </filters>
    </variable>
    <variable name="db.name" value="${db.url}" checkonce="true" condition="NotInstall+haveDatabaseURL+useMssql">
      <filters>
        <regex regexp="jdbc:jtds:sqlserver://[^:]+:\d+/([^:;]+)" select="\1" />
      </filters>
    </variable>
```
currently the first of the above two definitions withing <dynamicvariables> is ignored. A warning comes up during compiling:
*Variable definition 'db.name' will be overwritten.*

The currently rule for uniqueness of a dynamic variable is bound to comparing just its name and conditionid.

This is not correct. Both definitions should apply. If one of them results in a null value the one providing a non-null value should provide the final value.
