### PR TITLE
[IZPACK-1109] Panel conditions throw NPE when some condition does not exist in AND statement - post-fix

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -313,8 +313,7 @@ public class RulesEngineImpl implements RulesEngine
         {
             return isConditionTrue(cond, installData);
         }
-        logger.warning("Condition " + id + " not found");
-        return false;
+        throw new IzPackException("Condition " + id + " not found");
     }
 
     @Override
@@ -385,10 +384,15 @@ public class RulesEngineImpl implements RulesEngine
         String panelCondString = panel.getCondition();
         if (panelCondString != null)
         {
+            Condition panelCondition = getCondition(panelCondString);
+            if (panelCondition == null)
+            {
+                throw new IzPackException("Condition '" + panelCondString + "' of panel '" + panel.getPanelId() + "'" + "cannot be evaluated");
+            }
             AndCondition andCondition = new AndCondition(this);
             andCondition.setId(andCondition.toString());
             andCondition.addOperands(newCondition);
-            andCondition.addOperands(getCondition(panelCondString));
+            andCondition.addOperands(panelCondition);
             newCondition = andCondition;
         }
 


### PR DESCRIPTION
This is a post-fix for https://jira.codehaus.org/browse/IZPACK-1109:

The error reoccured for some usecase.

This should be additionally prevented at compile time. It should not be allowed to use undefined conditions. This PR aborts the compilation on any unresolved condition reference in any element that might have a 'condition' attribute.