### PR TITLE
Added the saveprevious attribute

### DIFF
--- a/src/dtd/event/registry.dtd
+++ b/src/dtd/event/registry.dtd
@@ -17,8 +17,7 @@ $Id$
     -->
     <!ELEMENT pack (key*,value*)>
         <!ATTLIST pack name CDATA #REQUIRED>
-        <!-- Every pack is allowed to have a condition
-        -->
+        <!-- Every pack is allowed to have a condition -->
         <!ATTLIST pack condition CDATA #IMPLIED>
         <!-- The key section. It defines, what key should be created
         -->
@@ -46,6 +45,8 @@ $Id$
             <!ATTLIST value root (HKCR|HKCU|HKLM|HKU|HKPD|HKCC|HKDDS) #REQUIRED>
             <!-- Override an existent value or not -->
             <!ATTLIST value override (true|false) "true">
+            <!-- Remember the previous value if one exists -->
+			<!ATTLIST value saveprevious (true|false) "true">
             <!-- Contents part. Only one entry of it should be done !!
             -->
             <!-- Contents for value of type STRING -->


### PR DESCRIPTION
registry.dtd was missing an attribute for a VALUE where IzPack decides
wether to store an already existing registry entry or not.

This is a standalone commit and has no connection to any open issue.