### PR TITLE
[IZPACK-1247] Console installer - no title displayed for warning/error messages in comparison to GUI installer

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
@@ -21,6 +21,8 @@
 
 package com.izforge.izpack.core.handler;
 
+import jline.TerminalFactory;
+
 import com.izforge.izpack.api.handler.AbstractPrompt;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.resource.Messages;
@@ -154,7 +156,15 @@ public class ConsolePrompt extends AbstractPrompt
     public Option confirm(Type type, String title, String message, Options options, Option defaultOption)
     {
         Option result;
+        final int maxlength = TerminalFactory.get().getWidth();
+        final String hline = new String(new char[maxlength]).replace("\0", "\u2500");
+        console.println(hline);
+        if (title != null)
+        {
+            console.println(title);
+        }
         console.println(message);
+        console.println(hline);
         if (options == Options.OK_CANCEL)
         {
             String defaultValue = (defaultOption != null && defaultOption == Option.OK) ? ok : cancel;


### PR DESCRIPTION
Currently, the title for warning and error messages is not shown in console installations. This makes ot hard for the user know what's going on.
There should be a more user-firendly console interface as equivalent to error and warning messageboxes in Swing installers.

Example of the current behavior:
There is just shown the warning message of a panel validator:
```
Could not connect to broker URL: tcp://localhost:7000. Reason: java.net.ConnectException: Connection refused
Enter O for OK, C to Cancel: 
```

Example of the desired behavior:
There should eb also shown the title and some horizontal lines as separators to recognize a messagebox equivalent:
```
------------------------------------------------------------------------------------------------------------
Validation failed - continuing installation
Could not connect to broker URL: tcp://localhost:7000. Reason: java.net.ConnectException: Connection refused
------------------------------------------------------------------------------------------------------------
Enter O for OK, C to Cancel: 
```
