### PR TITLE
[IZPACK-1248] UserInputPanel - "custom" input field layout improvements for console/GUI installers

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleField.java
@@ -93,6 +93,16 @@ public abstract class ConsoleField extends AbstractFieldView
     }
 
     /**
+     * Prints a message to the console without a new line.
+     *
+     * @param message the message to print
+     */
+    protected void print(String message)
+    {
+        console.print(message);
+    }
+
+    /**
      * Displays an error message.
      *
      * @param message the message

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputField.java
@@ -1,5 +1,17 @@
 package com.izforge.izpack.panels.userinput.gui.custom;
 
+import java.awt.Component;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+import javax.swing.JButton;
+import javax.swing.JPanel;
+
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.installer.data.GUIInstallData;
@@ -8,12 +20,6 @@ import com.izforge.izpack.panels.userinput.FieldCommand;
 import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.panels.userinput.field.UserInputPanelSpec;
 import com.izforge.izpack.panels.userinput.field.custom.CustomField;
-
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.List;
 
 /**
  * JPanel that contains the possible rows of fields defined by the user,
@@ -33,6 +39,11 @@ import java.util.List;
  */
 public class CustomInputField extends JPanel implements ActionListener
 {
+    /**
+     *
+     */
+    private static final long serialVersionUID = -5954748826095621101L;
+
     private GUIInstallData installData;
 
     private IzPanel parent;
@@ -53,16 +64,15 @@ public class CustomInputField extends JPanel implements ActionListener
     {
         this.parent = parent;
         this.installData = installData;
+
         this.rows = new CustomInputRows(customField, createField, userInputPanelSpec, spec, installData);
         this.header = rows.getHeader();
         this.controlPanel = initializeControlPanel();
 
         GridBagLayout gridBagLayout = new GridBagLayout();
-        gridBagLayout.columnWidths = new int[] { 190 };
-        gridBagLayout.columnWeights = new double[] { 0.0, 1.0 };
-        gridBagLayout.rowWeights = new double[] { 0.0, Double.MIN_VALUE };
-        
+
         this.setLayout(gridBagLayout);
+
         this.addComponents(rows, controlPanel);
         updateControlPanel();
     }
@@ -91,12 +101,13 @@ public class CustomInputField extends JPanel implements ActionListener
 
         add(rows, rowConstraints);
 
-
         GridBagConstraints controlPanelConstraints = new GridBagConstraints();
         controlPanelConstraints.fill = GridBagConstraints.NONE;
-        controlPanelConstraints.anchor = GridBagConstraints.EAST;
+        controlPanelConstraints.anchor = GridBagConstraints.SOUTHEAST;
         controlPanelConstraints.gridx = 0;
         controlPanelConstraints.gridy = 2;
+        controlPanelConstraints.weighty = 1.0; //request any extra vertical space
+        controlPanelConstraints.insets = new Insets(5,0,0,0); //top padding
 
         add(controlPanel, controlPanelConstraints);
     }
@@ -110,15 +121,14 @@ public class CustomInputField extends JPanel implements ActionListener
     {
         JPanel controlPanel = new JPanel(new GridLayout(1, 2));
 
-        JButton addButton = new JButton("add");
+        JButton addButton = new JButton("Add");
         addButton.setActionCommand(addCommand);
         addButton.addActionListener(this);
 
-        JButton removeButton = new JButton("remove");
+        JButton removeButton = new JButton("Remove");
         removeButton.setEnabled(false);
         removeButton.setActionCommand(removeCommand);
         removeButton.addActionListener(this);
-
 
         controlPanel.add(addButton);
         controlPanel.add(removeButton);
@@ -166,9 +176,9 @@ public class CustomInputField extends JPanel implements ActionListener
         repaint();
     }
 
-    public boolean updateField(Prompt prompt)
+    public boolean updateField(Prompt prompt, boolean skipValidation)
     {
-        return rows.updateField(prompt);
+        return rows.updateField(prompt, skipValidation);
     }
 
     public List<String> getLabels()

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputRows.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputRows.java
@@ -1,5 +1,16 @@
 package com.izforge.izpack.panels.userinput.gui.custom;
 
+import java.awt.GridLayout;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextPane;
+
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.installer.data.GUIInstallData;
@@ -11,13 +22,6 @@ import com.izforge.izpack.panels.userinput.field.custom.Column;
 import com.izforge.izpack.panels.userinput.field.custom.CustomField;
 import com.izforge.izpack.panels.userinput.gui.Component;
 import com.izforge.izpack.panels.userinput.gui.GUIField;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * JPanel that contains the possible rows of fields defined by the user.
@@ -173,7 +177,7 @@ public class CustomInputRows extends JPanel
      * @param prompt
      * @return
      */
-    public boolean updateField(Prompt prompt)
+    public boolean updateField(Prompt prompt, boolean skipValidation)
     {
         installData.setVariable(customInfoField.getVariable(), numberOfRows+"");
         for (int i = 1; i <= numberOfRows; i++)
@@ -182,7 +186,7 @@ public class CustomInputRows extends JPanel
             {
                 if (guiField.isDisplayed())
                 {
-                    if (!guiField.updateField(prompt))
+                    if (!guiField.updateField(prompt, skipValidation))
                     {
                         return false;
                     }
@@ -193,11 +197,14 @@ public class CustomInputRows extends JPanel
         String [] columnVariables = getVariablesByColumn();
         for (int i = 0; i < columnVariables.length; i++)
         {
-            ValidationStatus status = columns.get(i).validate(columnVariables[i]);
-            if (!status.isValid())
+            if (!skipValidation)
             {
-                prompt.warn(status.getMessage());
-                return false;
+                ValidationStatus status = columns.get(i).validate(columnVariables[i]);
+                if (!status.isValid())
+                {
+                    prompt.warn(status.getMessage());
+                    return false;
+                }
             }
         }
 
@@ -316,6 +323,7 @@ public class CustomInputRows extends JPanel
         }
         return header;
     }
+
     @Override
     public void setEnabled(boolean enabled)
     {
@@ -324,4 +332,5 @@ public class CustomInputRows extends JPanel
             component.setEnabled(enabled);
         }
     }
+
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/GUICustomField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/GUICustomField.java
@@ -52,9 +52,9 @@ public class GUICustomField extends GUIField implements CustomFieldType
     }
 
     @Override
-    public boolean updateField(Prompt prompt)
+    public boolean updateField(Prompt prompt, boolean skipValidation)
     {
-        return customInputField.updateField(prompt);
+        return customInputField.updateField(prompt, skipValidation);
     }
 
     @Override


### PR DESCRIPTION
For console as well as GUI installers there is a few complaints about the layout of the new "custom" type input field:

- GUI: the button labels of "add"/"remove" should be "Add"/"Remove".
- GUI: The insets of the "Add"/"Remove" buttons against the input rows should be increased.
- Console: There is no user-friendly recognition which are the rows available for inputs, rather add row numbers or some indentations.
- Console: It should be possible to directly edit specific rows without redisplaying and navigating all valid rows before.

TODO: There is still to be solved the translations of the user tests of the custom field for both installer types.