### PR TITLE
Fixed problem with uninstaller.jar merge content

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/merge/jar/JarMerge.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/merge/jar/JarMerge.java
@@ -66,7 +66,7 @@ public class JarMerge extends AbstractMerge
     {
         this.jarPath = jarPath;
         this.mergeContent = mergeContent;
-        destination = FileUtil.convertUrlToFilePath(resource).replaceAll(this.jarPath, "").replaceAll("file:",
+        destination = FileUtil.convertUrlToFilePath(resource).replace(this.jarPath, "").replaceAll("file:",
                                                                                                       "").replaceAll(
                 "!/?", "").replaceAll("//", "/");
 


### PR DESCRIPTION
Related to https://jira.codehaus.org/browse/IZPACK-1250:

There is problem with uninstaller.jar content when we use installer jar with "(1)" for example `install (1).jar` it very often case when we download installer several times.
In this case `JarMerge` performs `replaceAll` with "(1)" that treated as regular expression.