### PR TITLE
[IZPACK-1238] UserInputPanel: input fields not focused automatically on panel activation - post fix

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -237,6 +237,7 @@ public class UserInputPanel extends IzPanel
         if (firstFocusedComponent != null)
         {
             setInitialFocus(firstFocusedComponent);
+            firstFocusedComponent.requestFocusInWindow();
         }
     }
 
@@ -333,11 +334,6 @@ public class UserInputPanel extends IzPanel
 
             updated |= view.translateStaticText();
             updated |= view.updateView();
-        }
-
-        if (firstFocusedComponent != null)
-        {
-            firstFocusedComponent.requestFocusInWindow();
         }
 
         if (updated)


### PR DESCRIPTION
This is a postfix for the above issue:
The first field of an UserInputPanel panel has been focused twice (the focus jumped back unexpectedly)