### PR TITLE
added getConsoleMode() method to detect current consoleAction

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -50,6 +50,7 @@ public class Installer
      * Used to keep track of the current installation mode.
      */
     private static int installerMode = 0;
+    private static int consoleMode = 0;
     private static Logger logger;
 
     public static final int INSTALLER_GUI = 0, INSTALLER_AUTO = 1, INSTALLER_CONSOLE = 2;
@@ -210,6 +211,7 @@ public class Installer
         }
 
         installerMode = type;
+        consoleMode = consoleAction;
 
         switch (type)
         {
@@ -265,5 +267,5 @@ public class Installer
     public static int getInstallerMode() {
         return installerMode;
     }
-
+    public static int getConsoleMode() { return consoleMode; }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -212,6 +212,7 @@ public class Installer
 
         installerMode = type;
         consoleMode = consoleAction;
+        propsPath = path;
 
         switch (type)
         {
@@ -268,4 +269,5 @@ public class Installer
         return installerMode;
     }
     public static int getConsoleMode() { return consoleMode; }
+    public static String getPropsPath() { return propsPath; }
 }


### PR DESCRIPTION
Allows to determine if we're running with -options argument specified (i.e. unattended mode). Can be used to skip Panel validators in non-automated installs, like this:

```Java
// Let's skip UserInputPanel_0 validation in case there is no -options argument.
if (Installer.getConsoleMode() != Installer.CONSOLE_FROM_TEMPLATE) {
    return Status.OK;
}
```