### PR TITLE
[IZPACK-1257] ConfigurationInstallerListener: Preserving auto-numbered options broken

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/OptionsBuilder.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/base/spi/OptionsBuilder.java
@@ -63,7 +63,7 @@ public class OptionsBuilder implements OptionsHandler
     @Override public void handleOption(String name, String value)
     {
         String newName = name;
-        if (getConfig().isAutoNumbering() && name.matches("([^\\d]+\\.)+[\\d]+"))
+        if (getConfig().isAutoNumbering() && name.matches("(.+\\.)+[\\d]+"))
         {
             String[] parts = name.split("\\.");
             newName = name.substring(0, name.length() - parts[parts.length - 1].length() - 1) + ".";

--- a/izpack-util/src/test/java/com/izforge/izpack/util/config/SingleOptionTestTask.java
+++ b/izpack-util/src/test/java/com/izforge/izpack/util/config/SingleOptionTestTask.java
@@ -1,0 +1,39 @@
+package com.izforge.izpack.util.config;
+
+import com.izforge.izpack.util.config.base.Options;
+
+public class SingleOptionTestTask extends SingleConfigurableTask
+{
+
+    private Options fromOptions, toOptions;
+
+    public SingleOptionTestTask(Options fromOptions, Options toOptions)
+    {
+        this.fromOptions = fromOptions;
+        this.toOptions = toOptions;
+    }
+
+    @Override
+    protected void readSourceConfigurable() throws Exception
+    {
+        fromConfigurable = fromOptions;
+    }
+
+    @Override
+    protected void readConfigurable() throws Exception
+    {
+        configurable = toOptions;
+    }
+
+    @Override
+    protected void writeConfigurable() throws Exception {}
+
+    public Options getResult()
+    {
+        return toOptions;
+    }
+
+    @Override
+    protected void checkAttributes() throws Exception {} {}
+
+}


### PR DESCRIPTION
This fix solves several issues with properties auto-numbering and patching them described in [IZPACK-1257](https://izpack.atlassian.net/browse/IZPACK-1257):

Patching auto-numbered properties ending on .0, .1 etc. using ConfigurationInstallerListeners is broken, The installer reads such keys in its special mannerf but does never use them for patching although this is intended.

For an example, consider the following situation:

cluster.properties coming with a new installer:
```
failover.connection.0=10.1.1.1:8000
failover.connection.1=10.1.1.2:8000
```

cluster.properties.configbak previously installed and automatically renamed by the installer before overwriting:
```
failover.connection.0=192.168.1.1:8000
failover.connection.1=192.168.1.2:8000
failover.connection.2=192.168.1.3:8000
```

Resource {{ConfigurationActionsSpec.xml}}
```xml
    ...
    <configurable type="options" cleanup="true"
                  keepOldKeys="true" keepOldValues="true"
                  patchfile="${INSTALL_PATH}/config/cluster.properties.configbak"
                  tofile="${INSTALL_PATH}/config/cluster.properties"
                  condition="Update"/>
    ...
```

should result in this cluster.properties:
```
failover.connection.0=192.168.1.1:8000
failover.connection.1=192.168.1.2:8000
failover.connection.2=192.168.1.3:8000
```

The equivalent problem is for *keepOldKeys="true" keepOldValues="false"* if the previous file didn't contain the according auto-numbered entries.In this case they are not added from  the new file.