### PR TITLE
[IZPACK-1254] UserInputPanel: readonly/displayHidden fields not displayed read-only

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/Component.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/Component.java
@@ -55,24 +55,22 @@ public class Component
         return constraints;
     }
 
-    public void setEnabled(boolean enabled)
+    public boolean setEnabled(boolean enabled)
     {
         if (component instanceof JLabel || component instanceof JPanel || component instanceof JTextPane)
         {
-            enabled = false;
-            return;
+           return false;
         }
         if (component instanceof JTextComponent)
         {
             JTextComponent textComponent = ((JTextComponent)component);
             if (!textComponent.isFocusable() || !textComponent.isEditable())
             {
-                enabled = false;
-                return;
+                return false;
             }
         }
-        enabled = true;
-        component.setEnabled(true);
+        component.setEnabled(enabled);
+        return true;
     }
 
     public boolean isEnabled()


### PR DESCRIPTION
This request solves [IZPACK-1254](https://izpack.atlassian.net/browse/IZPACK-1254):

There's a regression that breaks the feature introduced with some earlier 5.0 RC5 snapshot:
Read-only fields according to https://izpack.atlassian.net/wiki/display/IZPACK/Displaying+panels+and+fields+read-only not displayed read-only in Swing installer, although there values are not processed.