### PR TITLE
Fix last-minute regressions for IzPack 5.0.0

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -271,11 +271,9 @@ public abstract class UnpackerBase implements IUnpacker
                 if (exception instanceof InstallerException)
                 {
                     InstallerException ie = (InstallerException) exception;
-                    ize = (IzPackException)ie.getCause();
-                    if (ize == null)
-                    {
-                        ize = new IzPackException(messages.get("installer.errorMessage"), exception);
-                    }
+                    Throwable t = ie.getCause();
+                    ize = new IzPackException(messages.get("installer.errorMessage"),
+                            t != null ? t : exception);
                 }
                 else if (exception instanceof IzPackException)
                 {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
@@ -879,6 +879,8 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
                 }
                 else
                 {
+                    // Allocate empty elements to support indexes beginning from a number > 0
+                    while (configurable.length(newKey) <= pos) {configurable.add(newKey, null);}
                     configurable.put(newKey, newValue, pos);
                 }
             }

--- a/izpack-util/src/test/java/com/izforge/izpack/util/config/SingleConfigurableTaskTest.java
+++ b/izpack-util/src/test/java/com/izforge/izpack/util/config/SingleConfigurableTaskTest.java
@@ -245,6 +245,38 @@ public class SingleConfigurableTaskTest
         assertEquals("value_unnumbered_overridden", result.get("abc.xyz.unnumbered"));
     }
 
+    @Test
+    public void testAutoNumberingPatchPreserveEntriesAndValuesFromIndex1() throws Exception
+    {
+        Config config = new Config();
+        config.setAutoNumbering(true);
+        Options fromOptions = new Options(config);
+        Options toOptions = new Options(config);
+
+        SingleOptionTestTask task = new SingleOptionTestTask(fromOptions, toOptions);
+        task.setAutoNumbering(true);
+        task.setPatchPreserveEntries(true);
+        task.setPatchPreserveValues(true);
+        Entry entry = new Entry();
+        entry.setKey("abc.xyz0.1");
+        entry.setValue("value1_overridden");
+        task.addEntry(entry);
+        entry = new Entry();
+        entry.setKey("abc.xyz0.2");
+        entry.setValue("value2_overridden");
+        task.addEntry(entry);
+        task.execute();
+        Options result = task.getResult();
+        Assert.assertTrue(result.keySet().contains("abc.xyz0."));
+        assertEquals( 3, result.length("abc.xyz0.") );
+        Assert.assertNull(result.get("abc.xyz0.1"));
+        Assert.assertNull(result.get("abc.xyz0.2"));
+        Assert.assertNull(result.get("abc.xyz0.", 0));
+        Assert.assertNotNull(result.get("abc.xyz0.", 1));
+        Assert.assertNotNull(result.get("abc.xyz0.", 2));
+        assertEquals("value1_overridden", result.get("abc.xyz0.", 1));
+        assertEquals("value2_overridden", result.get("abc.xyz0.", 2));
+    }
 
     @Test
     public void testIniCommentsAtEnd() throws IOException, URISyntaxException


### PR DESCRIPTION
- Fixed regression of [IZPACK-1257](https://izpack.atlassian.net/browse/IZPACK-1257) - ConfigurationInstallerListener: Preserving auto-numbered options broken:
 Index > 0 in auto-numbered options led to IndexOutOfBoundException - allow indexes > 0, added also a new unit test for this situation.
- Fixed regression in implementation of [IZPACK-1253](https://izpack.atlassian.net/browse/IZPACK-1253) - ClassCastException in Unpacker if non-IzPackException is given as root cause to InstallerException from listener:
 ClassCastExceptions on InstallerException with root cause exception different than IzPackException.
