### PR TITLE
[IZPACK-1263] ConfigurationInstallerListener: configurableset ignores autonumbered properties beginning on index > 0

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
@@ -472,7 +472,7 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
                             // Replace all key values with the preserved values instead of mixing them
                             ((Options) configurable).remove(key);
                         }
-                        int i = 0;
+                        int i = 0, firstIndex = -1;
                         String fromValue;
                         do
                         {
@@ -482,6 +482,10 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
                                 fromValue = (patchResolveVariables
                                         ? ((Options) fromConfigurable).fetch(key, i)
                                         : ((Options) fromConfigurable).get(key, i));
+                                if (fromValue != null && firstIndex < 0)
+                                {
+                                    firstIndex = i;
+                                }
                                 if (patchPreserveEntries && !keyFound)
                                 {
                                     logger.fine("Preserve auto-numbered  option file entry \"" + key + i + "\"");
@@ -500,7 +504,8 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
                                 fromValue = null;
                             }
                         }
-                        while (fromValue != null);
+                        // until the last value has been reached or as long as the first index hasn't been reached
+                        while (fromValue != null || firstIndex < 0);
                     }
                     else
                     {


### PR DESCRIPTION
This change fixes [IZPACK-1263](https://izpack.atlassian.net/browse/IZPACK-1263):

Provided the following constellation:

Resource ConfigurationActionsSpec.xml:
```xml
      <configurableset type="options" cleanup="true"
                       keepOldKeys="false" keepOldValues="true" overwrite="true"
                       todir="${INSTALL_PATH}/config"
                       condition="Update">
        <fileset dir="${INSTALL_PATH}/config">
          <include name="http.properties.configbak"/>
        </fileset>
        <mapper type="glob" from="*.properties.configbak" to="*.properties"/>
      </configurableset>
```

Preinstalled and renamed ${INSTALL_PATH}/config/http.properties.configbak:
```
http.servlet.jnlp.param.resources.jar.1=lib/server
http.servlet.jnlp.param.resources.jar.2=lib/shared
http.servlet.jnlp.param.resources.jar.3=lib/client
```

New ${INSTALL_PATH}/config/http.properties:
```
http.servlet.jnlp.param.resources.jar.1=lib/server
http.servlet.jnlp.param.resources.jar.2=lib/shared
http.servlet.jnlp.param.resources.jar.3=lib/client
```

The resulting ${INSTALL_PATH}/config/http.properties doesn't contain any of the above property keys http.servlet.jnlp.param.resources.jar.<number> although it should contain all.

This does not happen if the first index equals 0 instead of a value > 0.