### PR TITLE
[IZPACK-1262] UserInputPanel - dir/file input field: If user input do es not exist as path offer the best bet (nearest existing path) in the directory dialog

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/FileInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/FileInputField.java
@@ -87,14 +87,25 @@ public class FileInputField extends JPanel implements ActionListener
     {
         if (arg0.getSource() == browseBtn)
         {
-            logger.fine("Show directory chooser");
-            String initialPath = ".";
-            if (filetxt.getText() != null)
+            logger.fine("Show file/directory chooser");
+            File initialPath = null;
+            String initialText = filetxt.getText();
+            if (initialText != null)
             {
-                initialPath = filetxt.getText();
+                initialPath = new File(initialText);
             }
-            JFileChooser filechooser = new JFileChooser(initialPath);
+            JFileChooser filechooser = new JFileChooser();
             prepareFileChooser(filechooser);
+
+            File prev = null;
+            while (!filechooser.isTraversable(initialPath) && prev != initialPath) {
+                prev = initialPath;
+                if (initialPath != null)
+                {
+                    initialPath = initialPath.getParentFile();
+                }
+            }
+            filechooser.setCurrentDirectory(initialPath);
 
             if (filechooser.showOpenDialog(parentFrame) == JFileChooser.APPROVE_OPTION)
             {


### PR DESCRIPTION
This change fixes [IZPACK-1262](https://izpack.atlassian.net/browse/IZPACK-1262):

Currently, if a path entered by the user in a directory or file input field does not exist, the user's home path is offered in the according Swing dialog by default.

Better would be to offer the nearest path existing according to the user input.

For example if the (root) user entered:
*/usr/java/jdk1.7.0_67/*
and this doesn't exist, but /usr/java does, open
*/usr/java/*
by default in the Swing dialog instead of just
*/root*.