### PR TITLE
Izpack 1276: dynamic variable: Default for ignorefailure does not match documentation

### DIFF
--- a/izpack-core/.gitignore
+++ b/izpack-core/.gitignore
@@ -1,0 +1,1 @@
+/test-output/

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -52,7 +52,7 @@ public class DynamicVariableImpl implements DynamicVariable
 
     private boolean autounset = true;
 
-    private boolean ignorefailure = true;
+    private boolean ignorefailure = false;
 
     private transient String currentValue;
     private transient boolean checked = false;

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -611,7 +611,6 @@ public class DefaultVariablesTest
        variables.set("var4", "static");
        variables.set("var5", "static");
        variables.set("var6", "static");
-       variables.add(createDynamicFromIni("found",unset));
        variables.add(createDynamicFromIni("var1",unset));
        variables.add(createDynamicFromIni("var2",unset));
        variables.add(createDynamicFromIni("var3",unset));
@@ -622,8 +621,6 @@ public class DefaultVariablesTest
        // common tests for testMixedVariablesFromIniFileUnsetTrue and testMixedVariablesFromIniFileUnsetFalse
        assertEquals("static value", "static", variables.get("var1"));       // dynamic variable not resolved till variables refreshed
        variables.refresh();
-       assertEquals("ini not found","true",   variables.get("found"));      // check, whether ini was found at all
-
        // static variable replaced by dynamic value from ini
        assertEquals("value from ini", "ini1", variables.get("var1"));
        assertEquals("value from ini with spaces", "ini2", variables.get("var2")); 

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/variable/test.ini
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/variable/test.ini
@@ -1,5 +1,4 @@
 [test]
-found=true
 var1=ini1
 
 # test with spaces around '='


### PR DESCRIPTION
Pull request does include IzPack-1275, because this fix does make one of the checks obsolete. So please import Izpack 1275 first.