### PR TITLE
Added console uninstaller dependency

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/data/UninstallDataWriter.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/data/UninstallDataWriter.java
@@ -205,6 +205,10 @@ public class UninstallDataWriter
 
         // indirectly required by Librarian, which pulls in IoHelper. TODO
         uninstallerMerge.addAll(pathResolver.getMergeableFromPath("org/apache/tools/zip/"));
+		
+		//required by console uninstaller
+        uninstallerMerge.addAll(pathResolver.getMergeableFromPath("jline/console/completer/"));
+        uninstallerMerge.addAll(pathResolver.getMergeableFromPath("jline/internal/"));
 
         if (!uninstallData.getUninstallerListeners().isEmpty())
         {


### PR DESCRIPTION
Console uninstaller depends on jline. It had to be written to uninstaller JAR. This fixes console uninstaller not working. I elaborated on this bug here: https://groups.google.com/forum/#!topic/izpack-dev/A7nR6In_XC4