### PR TITLE
Update UserInputPanel.java

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -229,9 +229,13 @@ public class UserInputPanel extends IzPanel
         }
         else
         {
+            eventsActivated = false;
             buildUI();
             updateUIElements();
+            eventsActivated = true;
         }
+        
+        updateDialog();
 
         if (firstFocusedComponent != null)
         {


### PR DESCRIPTION
When activating a panel, the event handling should be deactivated. Only after the UI being built and the values being assigned to the Fields from the variables, then the updateDialog() should be called to make necessary UI update.

This will resolve the problem as below:
If a variable of a RadioField has been updated in a previous panel, for example, by loading a property file from the disk, when the current panel is being activated and the updateUIElements() is called, the value of the variable will be assigned to the RadioField. This assignment will trigger the update listener of the RadioField. The listener will call updateDialog() method. This method will read all values from the UI and buildUI again. But some fields in the UI might haven't been updated with variables value at the moment. When this panel is shown, these fields will show blank rather then the value from the variables.