### PR TITLE
[IZPACK-1284] Rule field value does not always show the current value of the underlying variable

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -234,8 +234,6 @@ public class UserInputPanel extends IzPanel
             updateUIElements();
             eventsActivated = true;
         }
-        
-        updateDialog();
 
         if (firstFocusedComponent != null)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldFactory.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/FieldFactory.java
@@ -154,7 +154,7 @@ public class FieldFactory
                 result = new RadioField(new SimpleChoiceReader(element, config, installData), installData);
                 break;
             case RULE:
-                result = new RuleField(new RuleFieldReader(element, config), installData, config.getFactory());
+                result = new RuleField(new RuleFieldReader(element, config), installData);
                 break;
             case SEARCH:
                 result = new SearchField(new SearchFieldReader(element, config, matcher), installData);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/rule/RuleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/rule/RuleField.java
@@ -25,11 +25,9 @@ import java.util.logging.Logger;
 
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.IzPackException;
-import com.izforge.izpack.api.factory.ObjectFactory;
 import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.panels.userinput.field.FieldProcessor;
 import com.izforge.izpack.panels.userinput.field.ValidationStatus;
-import com.izforge.izpack.panels.userinput.processor.Processor;
 
 
 /**
@@ -76,14 +74,13 @@ public class RuleField extends Field
      *
      * @param config      the field configuration
      * @param installData the installation data
-     * @param factory     the factory for creating {@link Processor} instances
      * @throws IzPackException if the field cannot be read
      */
-    public RuleField(RuleFieldConfig config, InstallData installData, ObjectFactory factory)
+    public RuleField(RuleFieldConfig config, InstallData installData)
     {
         super(config, installData);
         this.layout = new FieldLayout(config.getLayout());
-        String value = super.getInitialValue();
+        String value = config.getInitialValue();
         if (value != null)
         {
             ValidationStatus status = validateFormatted(value);
@@ -93,7 +90,7 @@ public class RuleField extends Field
         {
             this.initialValues = null;
         }
-        value = super.getDefaultValue();
+        value = config.getDefaultValue();
         if (value != null)
         {
             ValidationStatus status = validateFormatted(value);
@@ -125,7 +122,12 @@ public class RuleField extends Field
     @Override
     public String getInitialValue()
     {
-        String result = format(initialValues);
+        String result = null;
+        if (!getInstallData().getVariables().isBlockedVariableName(getVariable()))
+        {
+            result = getInstallData().getVariables().replace(format(initialValues));
+        }
+
         if (result == null)
         {
             result = getValue();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
@@ -109,7 +109,8 @@ public class GUITextField extends GUIField implements FocusListener, DocumentLis
     public boolean updateView()
     {
         boolean result = false;
-        String value = getField().getInitialValue();
+        Field f = getField();
+        String value = f.getInitialValue();
 
         if (value != null)
         {
@@ -119,7 +120,6 @@ public class GUITextField extends GUIField implements FocusListener, DocumentLis
         else
         {
             // Set default value here for getting current variable values replaced
-            Field f = getField();
             String defaultValue = f.getDefaultValue();
             if (defaultValue != null)
             {

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/rule/ConsoleRuleFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/rule/ConsoleRuleFieldTest.java
@@ -26,9 +26,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import com.izforge.izpack.api.factory.ObjectFactory;
-import com.izforge.izpack.core.container.DefaultContainer;
-import com.izforge.izpack.core.factory.DefaultObjectFactory;
 import com.izforge.izpack.panels.userinput.console.AbstractConsoleFieldTest;
 import com.izforge.izpack.panels.userinput.field.rule.RuleField;
 import com.izforge.izpack.panels.userinput.field.rule.RuleFormat;
@@ -42,20 +39,6 @@ import com.izforge.izpack.panels.userinput.field.rule.TestRuleFieldConfig;
  */
 public class ConsoleRuleFieldTest extends AbstractConsoleFieldTest
 {
-
-    /**
-     * The object factory.
-     */
-    private final ObjectFactory factory;
-
-    /**
-     * Default constructor.
-     */
-    public ConsoleRuleFieldTest()
-    {
-        factory = new DefaultObjectFactory(new DefaultContainer());
-    }
-
     /**
      * Tests selection of the default value.
      */
@@ -70,7 +53,7 @@ public class ConsoleRuleFieldTest extends AbstractConsoleFieldTest
         TestRuleFieldConfig config = new TestRuleFieldConfig(variable, layout, separator, RuleFormat.DISPLAY_FORMAT);
         config.setInitialValue(initialValue);
 
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
 
         ConsoleRuleField field = new ConsoleRuleField(model, console, prompt);
         console.addScript("Select default", "\n");
@@ -92,7 +75,7 @@ public class ConsoleRuleFieldTest extends AbstractConsoleFieldTest
 
         TestRuleFieldConfig config = new TestRuleFieldConfig(variable, layout, separator, RuleFormat.DISPLAY_FORMAT);
         config.setInitialValue(initialValue);
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
 
         ConsoleRuleField field = new ConsoleRuleField(model, console, prompt);
         console.addScript("Set value", "127.0.0.1");

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/field/rule/RuleFieldValidatorTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/field/rule/RuleFieldValidatorTest.java
@@ -90,7 +90,7 @@ public class RuleFieldValidatorTest
         parameters.put(RegularExpressionValidator.PATTERN_PARAM, "\\b.*\\:(6553[0-5]|655[0-2]\\d|65[0-4]\\d{2}|6[0-4]\\d{3}|[1-5]\\d{4}|[1-9]\\d{0,3})\\b");
         FieldValidator fieldValidator = new FieldValidator( RegularExpressionValidator.class.getName(), parameters, "Regex validation failed", factory);
         config.addValidator(fieldValidator);
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
         ValidationStatus status = model.validate(new String[] {"127.0.0.1", "1234"});
         assertTrue(status.isValid());
     }
@@ -107,7 +107,7 @@ public class RuleFieldValidatorTest
         config.setInitialValue(initialValue);
         FieldValidator fieldValidator = new FieldValidator( HostAddressValidator.class, "Host address validation failed", factory);
         config.addValidator(fieldValidator);
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
         ValidationStatus status = model.validate(new String[] {"127.0.0.1", "1234"});
         assertTrue(status.isValid());
     }
@@ -130,7 +130,7 @@ public class RuleFieldValidatorTest
         FieldValidator fieldValidator = new FieldValidator( RegularExpressionValidator.class.getName(), regexp, "Host address validation failed", factory);
         config.addValidator(fieldValidator);
 
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
 
         assertArrayEquals(new String[] { "abc", "1234"}, model.getInitialValues());
     }
@@ -153,7 +153,7 @@ public class RuleFieldValidatorTest
         FieldValidator fieldValidator = new FieldValidator( RegularExpressionValidator.class.getName(), regexp, "Host address validation failed", factory);
         config.addValidator(fieldValidator);
 
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
         model.setValue("my-second-server:1234");
 
         assertArrayEquals(model.getInitialValues(), new String[] { "my-second-server", "1234"});
@@ -181,10 +181,11 @@ public class RuleFieldValidatorTest
         FieldValidator fieldValidator = new FieldValidator( RegularExpressionValidator.class.getName(), regexp, "Host address validation failed", factory);
         config.addValidator(fieldValidator);
 
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
         model.setValue("my-second-server:4321");
 
-        assertArrayEquals(model.getInitialValues(), new String[] { "my-server", "1234"});
+        assertArrayEquals(model.getInitialValues(), new String[] { "${host}", "1234"});
+        assertEquals(model.getInitialValue(), "my-server:1234");
         assertEquals(model.getValue(), "my-second-server:4321");
     }
 

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleFieldTest.java
@@ -28,11 +28,9 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import com.izforge.izpack.api.factory.ObjectFactory;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.core.container.DefaultContainer;
 import com.izforge.izpack.core.data.DefaultVariables;
-import com.izforge.izpack.core.factory.DefaultObjectFactory;
 import com.izforge.izpack.core.rules.ConditionContainer;
 import com.izforge.izpack.core.rules.RulesEngineImpl;
 import com.izforge.izpack.installer.data.GUIInstallData;
@@ -57,11 +55,6 @@ public class GUIRuleFieldTest
      */
     private GUIInstallData installData;
 
-    /**
-     * The object factory.
-     */
-    private ObjectFactory factory;
-
 
     /**
      * Default constructor.
@@ -72,7 +65,6 @@ public class GUIRuleFieldTest
         RulesEngine rules = new RulesEngineImpl(new ConditionContainer(new DefaultContainer()),
                                                 installData.getPlatform());
         installData.setRules(rules);
-        factory = new DefaultObjectFactory(new DefaultContainer());
     }
 
     /**
@@ -89,7 +81,7 @@ public class GUIRuleFieldTest
         TestRuleFieldConfig config = new TestRuleFieldConfig(variable, layout, separator, RuleFormat.DISPLAY_FORMAT);
         config.setInitialValue(initialValue);
 
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
 
         GUIRuleField field = new GUIRuleField(model);
         assertFalse(field.updateView());               // should be nothing to update
@@ -129,7 +121,7 @@ public class GUIRuleFieldTest
         String separator = null;
         TestRuleFieldConfig config = new TestRuleFieldConfig(variable, layout, separator, RuleFormat.DISPLAY_FORMAT);
         config.setInitialValue("localhost");
-        RuleField model = new RuleField(config, installData, factory);
+        RuleField model = new RuleField(config, installData);
 
         GUIRuleField field = new GUIRuleField(model);
         assertEquals("localhost", field.getValue());


### PR DESCRIPTION
This one is to solve [IZPACK-1284](https://izpack.atlassian.net/browse/IZPACK-1284):

Provided a definition like this:

install.xml:
```xml
    <variable name="appserver.port" value="8080" condition="TomcatSelected" />
    <variable name="appserver.port" value="50000" condition="NetweaverSelected" />
```

userInputSpec.xml:
```xml
  <panel id="panel.appserver">
    ...
    <field type="rule" variable="appserver.port">
      <spec txt="Application server port:" id="text.appserver.port" layout="N:5:5" />
      ...
    </field>
  </panel>
```

If one of both alternative conditions is true by default from the beginning, either `TomcatSelected` or `NetweaverSelected`, the variable `appserver.port` is set to the according value. Fine so far.

But if the opposite condition gets true for example as a result of a certain user input on previous panels, the rule field still presents the old value, not the value according to the new conditions.

In case of using a field of type `text` in case of `rule` the behavior is correct.

There is also some cleanup work in the code, not having any obvious functional implications.