### PR TITLE
[IZPACK-1285] UserInputPanel: Fields not rendered after activating panel the first time

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -235,6 +235,8 @@ public class UserInputPanel extends IzPanel
             eventsActivated = true;
         }
 
+        updateDialog();
+
         if (firstFocusedComponent != null)
         {
             setInitialFocus(firstFocusedComponent);


### PR DESCRIPTION
This issue concerns [https://izpack.atlassian.net/browse/IZPACK-1285](IZPACK-1285) has been introduced with [https://izpack.atlassian.net/browse/IZPACK-1284](IZPACK-1284):

Some panels are not rendered correctly after being activated the first time, there are missing fields which appear after pressing Next and Previous subsequentially.

Apologises. Fix will be released soon. 