### PR TITLE
[IZPACK-1297] Linux Shortcuts not installed when run as sudo

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/util/os/Shortcut.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/util/os/Shortcut.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2002 Elmar Grom
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,10 +21,10 @@
 
 package com.izforge.izpack.util.os;
 
-import com.izforge.izpack.installer.data.UninstallData;
-
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+
+import com.izforge.izpack.installer.data.UninstallData;
 
 /*---------------------------------------------------------------------------*/
 
@@ -37,7 +37,7 @@ import java.util.List;
  * @version 0.0.1 / 3/4/02
  * @see com.izforge.izpack.util.TargetFactory
  */
-public class Shortcut
+public abstract class Shortcut
 {
 
     // ------------------------------------------------------------------------
@@ -113,9 +113,7 @@ public class Shortcut
      * @param type the type or classification of the program group in which the link should exist.
      * @param name the name of the shortcut.
      */
-    public void initialize(int type, String name) throws Exception
-    {
-    }
+    public abstract void initialize(int type, String name) throws Exception;
 
     /*--------------------------------------------------------------------------*/
 
@@ -141,45 +139,36 @@ public class Shortcut
      * Start Menu\Programs menu would be returned.
      *
      * @param userType the type of user for the program group set.
-     * @return a <code>Vector</code> of <code>String</code> objects that represent the names of
-     *         the existing program groups. It is theoretically possible that this list is empty.
+     * @return a <code>Vector</code> of <code>String</code> objects that represent the names of the
+     * existing program groups. It is theoretically possible that this list is empty.
      * @see #APPLICATIONS
      * @see #START_MENU
      */
-    public List<String> getProgramGroups(int userType)
-    {
-        return null;
-    }
+    public abstract List<String> getProgramGroups(int userType);
 
     /*--------------------------------------------------------------------------*/
 
     /**
      * Subclass implementations return the fully qualified file name under which the link is saved
-     * on disk. <b>Note:</b> this method returns valid results only if the instance was created
-     * from a file on disk or after a successful save operation. An instance of this class returns
-     * an empty string.
+     * on disk. <b>Note:</b> this method returns valid results only if the instance was created from
+     * a file on disk or after a successful save operation. An instance of this class returns an
+     * empty string.
      *
      * @return an empty <code>String</code>
      */
-    public String getFileName()
-    {
-        return ("");
-    }
+    public abstract String getFileName();
 
     /*--------------------------------------------------------------------------*/
 
     /**
      * Subclass implementations return the path of the directory where the link file is stored, if
      * it was necessary during the previous save operation to create the directory. This method
-     * returns <code>null</code> if no save operation was carried out or there was no need to
-     * create a directory during the previous save operation.
+     * returns <code>null</code> if no save operation was carried out or there was no need to create
+     * a directory during the previous save operation.
      *
      * @return this implementation returns always <code>null</code>.
      */
-    public String getDirectoryCreated()
-    {
-        return (null);
-    }
+    public abstract String getDirectoryCreated();
 
     /*--------------------------------------------------------------------------*/
 
@@ -188,10 +177,7 @@ public class Shortcut
      *
      * @return <code>true</code> if the target OS supports current and all users.
      */
-    public boolean multipleUsers()
-    {
-        return (false);
-    }
+    public abstract boolean multipleUsers();
 
     /*--------------------------------------------------------------------------*/
 
@@ -206,13 +192,10 @@ public class Shortcut
      * client code can now determine by calling this method if the active OS is supported and take
      * appropriate action.
      *
-     * @return <code>true</code> if the creation of shortcuts is supported, <code>false</code>
-     *         if this is not supported.
+     * @return <code>true</code> if the creation of shortcuts is supported, <code>false</code> if
+     * this is not supported.
      */
-    public boolean supported()
-    {
-        return (false);
-    }
+    public abstract boolean supported();
 
     /*--------------------------------------------------------------------------*/
 
@@ -221,9 +204,7 @@ public class Shortcut
      *
      * @param arguments the command line arguments
      */
-    public void setArguments(String arguments)
-    {
-    }
+    public abstract void setArguments(String arguments);
 
     /*--------------------------------------------------------------------------*/
 
@@ -232,34 +213,27 @@ public class Shortcut
      *
      * @param description the descriptiojn string
      */
-    public void setDescription(String description)
-    {
-    }
+    public abstract void setDescription(String description);
 
     /*--------------------------------------------------------------------------*/
 
     /**
-     * Sets the location of the icon that is shown for the shortcut on the desktop.
+     * Sets the path of the shortcut icon that will be shown on the desktop.
      *
-     * @param path  a fully qualified file name of a file that contains the icon.
+     * @param path a fully qualified file name of a file that contains the icon.
      * @param index the index of the specific icon to use in the file. If there is only one icon in
-     *              the file, use an index of 0.
+     * the file, use an index of 0.
      */
-    public void setIconLocation(String path, int index)
-    {
-    }
+    public abstract void setIconLocation(String path, int index);
 
     /*--------------------------------------------------------------------------*/
 
     /**
-     * returns icon Location
+     * Returns the path of the shortcut icon that will be shown on the desktop.
      *
-     * @return iconLocation
+     * @return icon path
      */
-    public String getIconLocation()
-    {
-        return "";
-    }
+    public abstract String getIconLocation();
 
     /*--------------------------------------------------------------------------*/
 
@@ -268,9 +242,7 @@ public class Shortcut
      *
      * @param groupName the name of the program group
      */
-    public void setProgramGroup(String groupName)
-    {
-    }
+    public abstract void setProgramGroup(String groupName);
 
     /*--------------------------------------------------------------------------*/
 
@@ -280,22 +252,20 @@ public class Shortcut
      * minimized, maximized or visible at all. <br>
      * <br>
      * <b>Note:</b><br>
-     * Using <code>HIDE</code> will cause the target window not to show at all. There is not even
-     * a button on the taskbar. This is a very useful setting when batch files are used to launch a
+     * Using <code>HIDE</code> will cause the target window not to show at all. There is not even a
+     * button on the taskbar. This is a very useful setting when batch files are used to launch a
      * Java application as it will then appear to run just like any native Windows application.<br>
      *
      * @param show the show command. Valid settings are: <br>
-     *             <ul>
-     *             <li>{@link com.izforge.izpack.util.os.Shortcut#HIDE}
-     *             <li>{@link com.izforge.izpack.util.os.Shortcut#NORMAL}
-     *             <li>{@link com.izforge.izpack.util.os.Shortcut#MINIMIZED}
-     *             <li>{@link com.izforge.izpack.util.os.Shortcut#MAXIMIZED}
-     *             </ul>
+     * <ul>
+     * <li>{@link com.izforge.izpack.util.os.Shortcut#HIDE}
+     * <li>{@link com.izforge.izpack.util.os.Shortcut#NORMAL}
+     * <li>{@link com.izforge.izpack.util.os.Shortcut#MINIMIZED}
+     * <li>{@link com.izforge.izpack.util.os.Shortcut#MAXIMIZED}
+     * </ul>
      * @see #getShowCommand
      */
-    public void setShowCommand(int show)
-    {
-    }
+    public abstract void setShowCommand(int show);
 
     /*
      * retrieves showCommand from the OS. Translates it into Shortcut.XXX terms.
@@ -313,9 +283,7 @@ public class Shortcut
      *
      * @param path the fully qualified file name of the target
      */
-    public void setTargetPath(String path)
-    {
-    }
+    public abstract void setTargetPath(String path);
 
     /*--------------------------------------------------------------------------*/
 
@@ -324,9 +292,7 @@ public class Shortcut
      *
      * @param dir the working directory
      */
-    public void setWorkingDirectory(String dir)
-    {
-    }
+    public abstract void setWorkingDirectory(String dir);
 
     /*--------------------------------------------------------------------------*/
 
@@ -346,11 +312,9 @@ public class Shortcut
      * Sets the name shown in a menu or on the desktop for the link.
      *
      * @param name The name that the link should display on a menu or on the desktop. Do not include
-     *             a file extension.
+     * a file extension.
      */
-    public void setLinkName(String name)
-    {
-    }
+    public abstract void setLinkName(String name);
 
     /*--------------------------------------------------------------------------*/
 
@@ -363,11 +327,7 @@ public class Shortcut
      * <li>{@link com.izforge.izpack.util.os.Shortcut#START_UP}
      * </ul>
      */
-    public int getLinkType()
-    {
-        // fake default.
-        return Shortcut.DESKTOP;
-    }
+    public abstract int getLinkType();
 
     /*--------------------------------------------------------------------------*/
 
@@ -375,18 +335,17 @@ public class Shortcut
      * Sets the type of link
      *
      * @param type The type of link desired. The following values can be set:<br>
-     *             <ul>
-     *             <li>{@link com.izforge.izpack.util.os.Shortcut#DESKTOP}
-     *             <li>{@link com.izforge.izpack.util.os.Shortcut#APPLICATIONS}
-     *             <li>{@link com.izforge.izpack.util.os.Shortcut#START_MENU}
-     *             <li>{@link com.izforge.izpack.util.os.Shortcut#START_UP}
-     *             </ul>
-     * @throws IllegalArgumentException     if an an invalid type is passed
+     * <ul>
+     * <li>{@link com.izforge.izpack.util.os.Shortcut#DESKTOP}
+     * <li>{@link com.izforge.izpack.util.os.Shortcut#APPLICATIONS}
+     * <li>{@link com.izforge.izpack.util.os.Shortcut#START_MENU}
+     * <li>{@link com.izforge.izpack.util.os.Shortcut#START_UP}
+     * </ul>
+     * @throws IllegalArgumentException if an an invalid type is passed
      * @throws UnsupportedEncodingException
      */
-    public void setLinkType(int type) throws IllegalArgumentException, UnsupportedEncodingException
-    {
-    }
+    public abstract void setLinkType(int type)
+            throws IllegalArgumentException, UnsupportedEncodingException;
 
     /*--------------------------------------------------------------------------*/
 
@@ -397,9 +356,7 @@ public class Shortcut
      * @see #CURRENT_USER
      * @see #ALL_USERS
      */
-    public void setUserType(int type)
-    {
-    }
+    public abstract void setUserType(int type);
 
     /*--------------------------------------------------------------------------*/
 
@@ -410,17 +367,15 @@ public class Shortcut
      * @see #CURRENT_USER
      * @see #ALL_USERS
      */
-    public int getUserType()
-    {
-        return CURRENT_USER;
-    }
+    public abstract int getUserType();
 
     /**
      * Determines if the shortcut target should be run with administrator privileges.
      *
      * @param runAsAdministrator if {@code true}, run the target with administrator privileges.
      */
-    public void setRunAsAdministrator(boolean runAsAdministrator) {
+    public void setRunAsAdministrator(boolean runAsAdministrator)
+    {
     }
 
     /**
@@ -428,7 +383,8 @@ public class Shortcut
      *
      * @return {@code true}, if the target will run with administrator privileges
      */
-    public boolean getRunAsAdministrator() {
+    public boolean getRunAsAdministrator()
+    {
         return false;
     }
 
@@ -439,9 +395,7 @@ public class Shortcut
      *
      * @throws Exception if problems are encountered
      */
-    public void save() throws Exception
-    {
-    }
+    public abstract void save() throws Exception;
 
     /*--------------------------------------------------------------------------*/
 
@@ -545,10 +499,7 @@ public class Shortcut
      * @param current_user one of current or all
      * @return The Foldername or null on unsupported platforms.
      */
-    public String getProgramsFolder(int current_user)
-    {
-        return null;
-    }
+    public abstract String getProgramsFolder(int current_user);
 
     /**
      * Sets the flag which indicates, that this should created for all.
@@ -603,19 +554,17 @@ public class Shortcut
      */
     public void execPostAction()
     {
-        //Debug.log("Call of unused execPostAction Method in " + this.getClass().getName() );
+        // Debug.log("Call of unused execPostAction Method in " + this.getClass().getName() );
     }
 
     /**
-     * Clean Up Method to do some cleanups after Shortcut Creation.
-     * <br>
+     * Clean Up Method to do some cleanups after Shortcut Creation. <br>
      * currently unused.
      */
     public void cleanUp()
     {
-        //Debug.log("Call of unused cleanUp Method in " + this.getClass().getName() );     
+        // Debug.log("Call of unused cleanUp Method in " + this.getClass().getName() );
     }
 
 }
 /*---------------------------------------------------------------------------*/
-

--- a/izpack-installer/src/main/java/com/izforge/izpack/util/os/Unix_Shortcut.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/util/os/Unix_Shortcut.java
@@ -85,7 +85,7 @@ public class Unix_Shortcut extends Shortcut
     // ***********************************************************************
     // ~ Static fields/initializers
     // ***********************************************************************
-    
+
     private static final Logger logger = Logger.getLogger(Unix_Shortcut.class.getName());
 
     /**
@@ -274,10 +274,10 @@ public class Unix_Shortcut extends Shortcut
                 result.append(S).append(arguments);
             result.append(N);
         }
-        
+
         result.append("GenericName=").append(N);
         result.append("GenericName[").append(userLanguage).append("]=").append(N);
-        
+
         result.append("Icon=").append(iconLocation).append(N);
         result.append("MimeType=").append(mimeType).append(N);
         result.append("Name=").append(linkName).append(N);
@@ -287,13 +287,13 @@ public class Unix_Shortcut extends Shortcut
         result.append("ServiceTypes=").append(N);
         result.append("SwallowExec=").append(N);
         result.append("SwallowTitle=").append(N);
-        
+
         result.append("Terminal=").append(terminal).append(N);
         if (!terminal.isEmpty() && !terminal.equals("true") && !terminal.equals("false"))
             logger.warning(String.format("Shortcut '%s' has terminal '%s' but should be 'true' or 'false'", linkName, terminal));
-        
+
         result.append("TerminalOptions=").append(terminalOptions).append(N);
-        
+
         result.append("Type=").append(type).append(N);
         if (type.equalsIgnoreCase("Link") && url.isEmpty())
                 logger.warning(String.format("Shortcut '%s' has type '%s' but URL is empty", linkName, type));
@@ -304,14 +304,14 @@ public class Unix_Shortcut extends Shortcut
             if (!type.equalsIgnoreCase("Link"))
                 logger.warning(String.format("Shortcut '%s' has URL but type ('%s') is not 'Link'", linkName, type));
         }
-        
+
         result.append("X-KDE-SubstituteUID=").append(kdeSubstituteUID).append(N);
         result.append("X-KDE-Username=").append(kdeUserName).append(N);
         result.append(N);
         result.append(C + "created by" + S).append(getClass().getName()).append(S).append(rev).append(
                 N);
         result.append(C).append(version);
-        
+
         return result.toString();
     }
 
@@ -334,7 +334,7 @@ public class Unix_Shortcut extends Shortcut
     /**
      * This indicates that Unix will be supported.
      *
-     * @return 
+     * @return
      * @see com.izforge.izpack.util.os.Shortcut#supported()
      */
     @Override
@@ -343,11 +343,11 @@ public class Unix_Shortcut extends Shortcut
         return true;
     }
 
-    
+
     /**
      * Dummy
      *
-     * @return 
+     * @return
      * @see com.izforge.izpack.util.os.Shortcut#getDirectoryCreated()
      */
     @Override
@@ -356,11 +356,11 @@ public class Unix_Shortcut extends Shortcut
         return this.createdDirectory; // while not stored...
     }
 
-    
+
     /**
      * Dummy
      *
-     * @return 
+     * @return
      * @see com.izforge.izpack.util.os.Shortcut#getFileName()
      */
     @Override
@@ -369,11 +369,11 @@ public class Unix_Shortcut extends Shortcut
         return (this.itsFileName);
     }
 
-    
+
     /**
      * Overridden compatibility method. Returns all directories in $USER/.kde/share/applink.
      *
-     * @return 
+     * @return
      * @see com.izforge.izpack.util.os.Shortcut#getProgramGroups(int)
      */
     @Override
@@ -404,11 +404,11 @@ public class Unix_Shortcut extends Shortcut
         return groups;
     }
 
-    
+
     /**
      * Gets the Programsfolder for the given User (non-Javadoc).
      *
-     * @return 
+     * @return
      * @see com.izforge.izpack.util.os.Shortcut#getProgramsFolder(int)
      */
     @Override
@@ -445,20 +445,20 @@ public class Unix_Shortcut extends Shortcut
 
     }
 
-    
+
     /**
      * Makes a filename usable in a script by escaping spaces.
-     * This should <b>not</b> be used for filenames passed to Java filesystem 
+     * This should <b>not</b> be used for filenames passed to Java filesystem
      * methods.
      * @param filename
-     * @return 
+     * @return
      */
     private String makeFilenameScriptable(String filename)
     {
         return filename.replace(" ", "\\ ");
     }
-    
-    
+
+
     /**
      * overridden method
      *
@@ -472,7 +472,7 @@ public class Unix_Shortcut extends Shortcut
         return (true);
     }
 
-    
+
     /**
      * Creates and stores the shortcut-files.
      *
@@ -549,15 +549,15 @@ public class Unix_Shortcut extends Shortcut
                 createExtXdgDesktopIconCmd(shortCutLocation);
                 // / TODO: DELETE the ScriptFiles
                 myInstallScript.appendln(new String[]{
-                    makeFilenameScriptable(myXdgDesktopIconCmd), 
+                    makeFilenameScriptable(myXdgDesktopIconCmd),
                     "install",
-                    "--novendor", 
+                    "--novendor",
                     StringTool.escapeSpaces(writtenDesktopFile.toString())});
                 ShellScript myUninstallScript = new ShellScript();
                 myUninstallScript.appendln(new String[]{
-                    makeFilenameScriptable(myXdgDesktopIconCmd), 
+                    makeFilenameScriptable(myXdgDesktopIconCmd),
                     "uninstall",
-                    "--novendor", 
+                    "--novendor",
                     StringTool.escapeSpaces(writtenDesktopFile.toString())});
                 uninstaller.addUninstallScript(myUninstallScript.getContentAsString());
             }
@@ -625,8 +625,8 @@ public class Unix_Shortcut extends Shortcut
                     catch (Exception e)
                     {
                         logger.log(Level.WARNING,
-                                   "Could not copy " + theIcon + " to " + commonIcon + "( "
-                                           + e.getMessage() + " )",
+                                   "Could not copy " + theIcon + " to " + commonIcon + " ("
+                                           + e.getMessage() + ")",
                                    e);
                     }
 
@@ -673,10 +673,8 @@ public class Unix_Shortcut extends Shortcut
                 }
                 catch (Exception e)
                 {
-                    logger.log(Level.WARNING,
-                               "Could not copy " + theIcon + " to " + commonIcon + "( "
-                                       + e.getMessage() + " )",
-                               e);
+                    logger.log(Level.WARNING, "Could not copy " + theIcon + " to " + commonIcon
+                            + " (" + e.getMessage() + ")", e);
                 }
 
                 // write *.desktop in the local folder
@@ -763,7 +761,7 @@ public class Unix_Shortcut extends Shortcut
         return su;
     }
 
-    
+
     private String getXdgDesktopIconCmd()
     {
         if (xdgDesktopIconCmd == null)
@@ -773,7 +771,7 @@ public class Unix_Shortcut extends Shortcut
         return xdgDesktopIconCmd;
     }
 
-    
+
     private List<UnixUser> getUsers()
     {
         if (users == null)
@@ -783,7 +781,7 @@ public class Unix_Shortcut extends Shortcut
         return users;
     }
 
-    
+
     /**
      * @param writtenDesktopFile
      * @throws IOException
@@ -986,7 +984,7 @@ public class Unix_Shortcut extends Shortcut
         writtenFileName = s;
     }
 
-    
+
     /**
      * Write the given ShortDefinition in a File $ShortcutName-$timestamp.desktop in the given
      * TargetPath.
@@ -1001,7 +999,7 @@ public class Unix_Shortcut extends Shortcut
         return writeAppShortcutWithSimpleSpacehandling(targetPath, shortcutName, shortcutDef, false);
     }
 
-    
+
     /**
      * Write the given ShortDefinition in a File $ShortcutName-$timestamp.desktop in the given
      * TargetPath. ALSO all WhiteSpaces in the ShortCutName will be repalced with "-"
@@ -1017,7 +1015,7 @@ public class Unix_Shortcut extends Shortcut
         return writeAppShortcutWithSimpleSpacehandling(targetPath, shortcutName, shortcutDef, true);
     }
 
-    
+
     /**
      * Write the given ShortDefinition in a File $ShortcutName-$timestamp.desktop in the given
      * TargetPath. If the given replaceSpaces was true ALSO all WhiteSpaces in the ShortCutName will
@@ -1081,7 +1079,7 @@ public class Unix_Shortcut extends Shortcut
 
     }
 
-    
+
     /**
      * Set the command line Arguments
      *
@@ -1106,7 +1104,7 @@ public class Unix_Shortcut extends Shortcut
         this.categories = theCategories;
     }
 
-    
+
     /**
      * Sets the Description
      *
@@ -1118,7 +1116,7 @@ public class Unix_Shortcut extends Shortcut
         this.description = description;
     }
 
-    
+
     /**
      * Sets The Encoding
      *
@@ -1131,7 +1129,7 @@ public class Unix_Shortcut extends Shortcut
         this.encoding = aEncoding;
     }
 
-    
+
     /**
      * Sets The KDE Specific subst UID property
      *
@@ -1144,7 +1142,7 @@ public class Unix_Shortcut extends Shortcut
         this.kdeSubstituteUID = trueFalseOrNothing;
     }
 
-    
+
     /**
      * Sets The KDE Specific subst UID property
      *
@@ -1157,18 +1155,20 @@ public class Unix_Shortcut extends Shortcut
         this.kdeUserName = aUserName;
     }
 
-    /**
-     * Sets The Icon Path
-     *
-     * @see com.izforge.izpack.util.os.Shortcut#setIconLocation(java.lang.String, int)
-     */
+
     @Override
     public void setIconLocation(String path, int index)
     {
         this.iconLocation = path;
     }
 
-    
+    @Override
+    public String getIconLocation()
+    {
+        return this.iconLocation;
+    }
+
+
     /**
      * Sets the Name of this Shortcut
      *
@@ -1181,25 +1181,18 @@ public class Unix_Shortcut extends Shortcut
         this.linkName = aName;
     }
 
-    
-    /**
-     * Sets the type of this Shortcut
-     *
-     * @param aType
-     * @throws java.io.UnsupportedEncodingException
-     * @see com.izforge.izpack.util.os.Shortcut#setLinkType(int)
-     */
+
     @Override
     public void setLinkType(int aType) throws IllegalArgumentException,
             UnsupportedEncodingException
     {
         this.linkType = aType;
     }
+
     @Override
     public int getLinkType()
     {
         return linkType;
-        // return Shortcut.DESKTOP;
     }
 
 
@@ -1215,7 +1208,7 @@ public class Unix_Shortcut extends Shortcut
         this.mimeType = aMimeType;
     }
 
-    
+
     /**
      * Sets the ProgramGroup
      *
@@ -1228,7 +1221,7 @@ public class Unix_Shortcut extends Shortcut
         this.programGroup = aGroupName;
     }
 
-    
+
     /**
      * Sets the ShowMode
      *
@@ -1252,7 +1245,7 @@ public class Unix_Shortcut extends Shortcut
         this.targetPath = aPath;
     }
 
-    
+
     /**
      * Sets the user type.
      *
@@ -1267,7 +1260,7 @@ public class Unix_Shortcut extends Shortcut
     /**
      * Gets the user type of the Shortcut.
      *
-     * @return 
+     * @return
      * @see com.izforge.izpack.util.os.Shortcut#getUserType()
      */
     @Override
@@ -1277,7 +1270,7 @@ public class Unix_Shortcut extends Shortcut
     }
 
 
-    
+
     /**
      * Sets the working-directory
      *
@@ -1290,7 +1283,7 @@ public class Unix_Shortcut extends Shortcut
         this.workingDirectory = aDirectory;
     }
 
-    
+
     /**
      * Sets the terminal
      *
@@ -1327,7 +1320,7 @@ public class Unix_Shortcut extends Shortcut
         // currently ignored
     }
 
-    
+
     /**
      * Sets the Shortcut type (one of Application, Link or Device)
      *
@@ -1340,7 +1333,7 @@ public class Unix_Shortcut extends Shortcut
         this.type = aType;
     }
 
-    
+
     /**
      * Sets the Url for type Link. Can be also a absolute file/path
      *
@@ -1353,7 +1346,7 @@ public class Unix_Shortcut extends Shortcut
         this.url = anUrl;
     }
 
-    
+
     /**
      * Dumps the Name to console.
      *

--- a/izpack-installer/src/main/java/com/izforge/izpack/util/os/Win_Shortcut.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/util/os/Win_Shortcut.java
@@ -21,15 +21,15 @@
 
 package com.izforge.izpack.util.os;
 
-import com.izforge.izpack.util.Librarian;
-import com.izforge.izpack.util.StringTool;
-
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.izforge.izpack.util.Librarian;
+import com.izforge.izpack.util.StringTool;
 
 /*---------------------------------------------------------------------------*/
 

--- a/izpack-installer/src/test/java/com/izforge/izpack/util/InstallerTargetPlatformFactoryTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/util/InstallerTargetPlatformFactoryTest.java
@@ -116,10 +116,6 @@ public class InstallerTargetPlatformFactoryTest
             {
                 checkCreate(Shortcut.class, platform, Win_Shortcut.class);
             }
-            else
-            {
-                checkCreate(Shortcut.class, platform, Shortcut.class);
-            }
         }
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
@@ -297,7 +297,7 @@ public class ShortcutPanelLogic implements CleanupClient
     }
 
     /**
-     * @param panelRoot 
+     * @param panelRoot
      * @return a list of xml child elements to write a autoinstall.xml file for later execution
      */
     public List<IXMLElement> getAutoinstallXMLData(IXMLElement panelRoot)
@@ -992,9 +992,9 @@ public class ShortcutPanelLogic implements CleanupClient
                 /**
                  * Attribute: desktop
                  *
-                 * 	If the value is true, then a copy of the shortcut is placed on the desktop.
-                 * 	On Unix the shortcuts will only be placed on the KDE desktop of the user currently running the installer.
-                 * 	For Gnome the user can simply copy the .desktop files from *\/Desktop to /gnome-desktop.
+                 *     If the value is true, then a copy of the shortcut is placed on the desktop.
+                 *     On Unix the shortcuts will only be placed on the KDE desktop of the user currently running the installer.
+                 *     For Gnome the user can simply copy the .desktop files from *\/Desktop to /gnome-desktop.
                  */
                 if (XMLHelper.attributeIsTrue(shortcutSpec, SPEC_ATTRIBUTE_DESKTOP))
                 {
@@ -1048,8 +1048,8 @@ public class ShortcutPanelLogic implements CleanupClient
                 /**
                  *  Attribute: programGroup
                  *
-                 * 	If the value is true, then a copy of this shortcut will be placed in the group menu.
-                 * 	On Unix (KDE) this will always be placed on the top level.
+                 *     If the value is true, then a copy of this shortcut will be placed in the group menu.
+                 *     On Unix (KDE) this will always be placed on the top level.
                  */
                 if (XMLHelper.attributeIsTrue(shortcutSpec, SPEC_ATTRIBUTE_PROGRAM_GROUP))
                 {
@@ -1199,15 +1199,14 @@ public class ShortcutPanelLogic implements CleanupClient
         {
             if (execFiles != null)
             {
-                FileExecutor executor = new FileExecutor(execFiles);
-
                 //
                 // TODO: Hi Guys,
-                // TODO The following commented-out line sometimes produces an uncatchable
+                // TODO The following commented lines sometimes produces an uncatchable
                 // nullpointer Exception!
                 // TODO evaluate for what reason the files should exec.
                 // TODO if there is a serious explanation, why to do that,
                 // TODO the code must be more robust
+                //FileExecutor executor = new FileExecutor(execFiles);
                 // evaluate executor.executeFiles( ExecutableFile.NEVER, null );
             }
         }


### PR DESCRIPTION
This is a fix for https://izpack.atlassian.net/browse/IZPACK-1297.

There has been a missing override in com.izforge.izpack.util.os.Unix_Shortcut, which prevented to gather the icon filename completely in UNIX.