### PR TITLE
[IZPACK-1300] Validate all XML descriptors against XML Schema Definitions during compiling

### DIFF
--- a/izpack-ant/src/main/java/com/izforge/izpack/ant/IzPackTask.java
+++ b/izpack-ant/src/main/java/com/izforge/izpack/ant/IzPackTask.java
@@ -100,6 +100,11 @@ public class IzPackTask extends Task implements PackagerListener
     private Boolean inheritAll = false;
 
     /**
+     * should we validate XML descriptors?
+     */
+    private Boolean validating = true;
+
+    /**
      * Creates new IZPackTask
      */
     public IzPackTask()
@@ -209,7 +214,8 @@ public class IzPackTask extends Task implements PackagerListener
             ClassLoader loader = new URLClassLoader(getUrlsForClassloader());
             Class runableClass = loader.loadClass("com.izforge.izpack.ant.IzpackAntRunnable");
             Constructor constructor = runableClass.getConstructors()[0];
-            Object instance = constructor.newInstance(compression, kind, input, configText, basedir, output, mkdirs, compressionLevel, properties, inheritAll, getProject().getProperties(), izPackDir);
+            Object instance = constructor.newInstance(compression, kind, input, configText, basedir, output, mkdirs,
+                    validating, compressionLevel, properties, inheritAll, getProject().getProperties(), izPackDir);
             final Thread thread = new Thread((Runnable) instance);
             thread.setContextClassLoader(loader);
             thread.start();
@@ -332,10 +338,12 @@ public class IzPackTask extends Task implements PackagerListener
 
     /**
      * If true, pass all Ant properties to IzPack. Defaults to false;
+     *
+     * @param inheritAll true if all Ant properties should be passed to IzPack.
      */
-    public void setInheritAll(boolean value)
+    public void setInheritAll(boolean inheritAll)
     {
-        inheritAll = value;
+        this.inheritAll = inheritAll;
     }
 
     /**
@@ -355,6 +363,17 @@ public class IzPackTask extends Task implements PackagerListener
     {
         this.compressionLevel = compressionLevel;
     }
+
+    /**
+     * If true, all XML descriptors are validated against the according XSD during compiling. Defaults to true;
+     *
+     * @param validating true if all XML descriptors should be validated against the according XSD during compiling.
+     */
+    public void setValidating(boolean validating)
+    {
+        this.validating = validating;
+    }
+
 
     /**
      * Ant will call this for each &lt;property&gt; tag to the IzPack task.

--- a/izpack-ant/src/main/java/com/izforge/izpack/ant/IzpackAntRunnable.java
+++ b/izpack-ant/src/main/java/com/izforge/izpack/ant/IzpackAntRunnable.java
@@ -20,13 +20,13 @@ public class IzpackAntRunnable implements Runnable
     private final String input;
     private final Properties properties;
     private final Boolean inheritAll;
-    private Hashtable projectProps;
+    private Hashtable<String, String> projectProps;
 
     public IzpackAntRunnable(String compression, String kind, String input, String configText, String basedir,
-                             String output, boolean mkdirs, int compressionLevel, Properties properties,
-                             Boolean inheritAll, Hashtable antProjectProperties, String izPackDir)
+                             String output, boolean mkdirs, boolean validating, int compressionLevel, Properties properties,
+                             Boolean inheritAll, Hashtable<String, String> antProjectProperties, String izPackDir)
     {
-        this.compilerData = new CompilerData(compression, kind, input, configText, basedir, output, mkdirs,
+        this.compilerData = new CompilerData(compression, kind, input, configText, basedir, output, mkdirs, validating,
                                              compressionLevel);
         this.input = input;
         this.properties = properties;
@@ -48,7 +48,7 @@ public class IzpackAntRunnable implements Runnable
 
         if (properties != null)
         {
-            Enumeration e = properties.keys();
+            Enumeration<Object> e = properties.keys();
             while (e.hasMoreElements())
             {
                 String name = (String) e.nextElement();
@@ -60,11 +60,11 @@ public class IzpackAntRunnable implements Runnable
 
         if (inheritAll)
         {
-            Enumeration e = projectProps.keys();
+            Enumeration<String> e = projectProps.keys();
             while (e.hasMoreElements())
             {
-                String name = (String) e.nextElement();
-                String value = (String) projectProps.get(name);
+                String name = e.nextElement();
+                String value = projectProps.get(name);
                 value = fixPathString(value);
                 propertyManager.addProperty(name, value);
             }

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/AutomatedInstallData.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/AutomatedInstallData.java
@@ -336,23 +336,6 @@ public class AutomatedInstallData implements InstallData
         }
     }
 
-    /**
-     * Set Locale in xml, installdata, and langpack.
-     *
-     * @param locale         Locale to set
-     * @param localeDatabase database containing the desired locale
-     */
-    @Deprecated
-    public void setAndProcessLocal(String locale, LocaleDatabase localeDatabase)
-    {
-        // We add an xml data information
-        getInstallationRecord().setAttribute("langpack", locale);
-        // We load the langpack
-        setVariable(ScriptParserConstant.ISO3_LANG, getLocaleISO3());
-        setVariable(ScriptParserConstant.ISO2_LANG, getLocaleISO3());
-        setMessages(localeDatabase);
-    }
-
     @Override
     public RulesEngine getRules()
     {
@@ -428,18 +411,6 @@ public class AutomatedInstallData implements InstallData
     public Messages getMessages()
     {
         return messages;
-    }
-
-    @Deprecated
-    public LocaleDatabase getLangpack()
-    {
-        return (LocaleDatabase) messages;
-    }
-
-    @Deprecated
-    public void setLangpack(LocaleDatabase langpack)
-    {
-        setMessages(langpack);
     }
 
     @Override

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/LocaleDatabase.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/LocaleDatabase.java
@@ -43,20 +43,7 @@ import com.izforge.izpack.api.resource.Messages;
  */
 public class LocaleDatabase extends TreeMap<String, String> implements Messages
 {
-
     /**
-     * The directory where language packs are kept inside the installer jar file.
-     */
-    @Deprecated
-    public static final String LOCALE_DATABASE_DIRECTORY = "/langpacks/";
-
-    /**
-     * The suffix for language pack definitions (.xml).
-     */
-    @Deprecated
-    public static final String LOCALE_DATABASE_DEF_SUFFIX = ".xml";
-
-    /*
      * static character for replacing quotes
      */
     private static final char TEMP_QUOTING_CHARACTER = '\uffff';
@@ -130,7 +117,8 @@ public class LocaleDatabase extends TreeMap<String, String> implements Messages
 
         try
         {
-            IXMLParser parser = new XMLParser();
+            // Do not validate during installation, but when compiling
+            IXMLParser parser = new XMLParser(false);
             data = parser.parse(in);
         }
         catch (XMLException exception)
@@ -148,7 +136,7 @@ public class LocaleDatabase extends TreeMap<String, String> implements Messages
         for (IXMLElement child : data.getChildren())
         {
             String text = child.getContent();
-            if (text != null && !"".equals(text))
+            if (text != null && !text.isEmpty())
             {
                 put(child.getAttribute("id"), text.trim());
             }
@@ -263,27 +251,6 @@ public class LocaleDatabase extends TreeMap<String, String> implements Messages
         Messages result = new LocaleDatabase(this, locales);
         result.add(child);
         return result;
-    }
-
-    /**
-     * Convenience method to retrieve an element.
-     *
-     * @param key The key of the element to retrieve.
-     * @return The element value or the key if not found.
-     * @deprecated use {@link #get(String, Object...)}
-     */
-    @Deprecated
-    public String getString(String key)
-    {
-        String val = get(key);
-        // At a change of the return value at val == null the method
-        // com.izforge.izpack.installer.IzPanel.getI18nStringForClass
-        // should be also addapted.
-        if (val == null)
-        {
-            val = key;
-        }
-        return val;
     }
 
     /**

--- a/izpack-api/src/main/java/com/izforge/izpack/api/resource/Resources.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/resource/Resources.java
@@ -37,6 +37,22 @@ import com.izforge.izpack.api.exception.ResourceNotFoundException;
  */
 public interface Resources
 {
+    /**
+     * The base name of the XML file that specifies the custom langpack. Searched is for the file
+     * with the name expanded by _ISO3.
+     */
+    public static final String CUSTOM_TRANSLATIONS_RESOURCE_NAME = "CustomLangPack.xml";
+
+    /**
+     * The base name of the XML file that specifies the pack langpack. Searched is for the file
+     * with the name expanded by _ISO3.
+     */
+    public static final String PACK_TRANSLATIONS_RESOURCE_NAME = "packsLang.xml";
+
+    /**
+     * The base name of the XML file that specifies the custom icons.
+     */
+    public static final String CUSTOM_ICONS_RESOURCE_NAME = "customicons.xml";
 
     /**
      * Returns the stream to a resource.

--- a/izpack-api/src/test/java/com/izforge/izpack/api/adaptator/XMLParserTest.java
+++ b/izpack-api/src/test/java/com/izforge/izpack/api/adaptator/XMLParserTest.java
@@ -22,22 +22,22 @@
 
 package com.izforge.izpack.api.adaptator;
 
-import com.izforge.izpack.api.adaptator.impl.XMLParser;
-
-import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import static junit.framework.Assert.assertEquals;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
 
 /**
  * Test on the XMLElement
@@ -56,7 +56,7 @@ public class XMLParserTest
     private static final String parseErrorXincludeFilename = "xinclude-notvalid.xml";
 
 
-    @org.junit.Test
+    @Test
     public void testParseFile() throws Exception
     {
         InputStream input;
@@ -74,7 +74,7 @@ public class XMLParserTest
         IXMLElement spec;
         String substitutedSpec = FileUtils.readFileToString(
                 new File(XMLParserTest.class.getResource(filename).toURI()));
-        IXMLParser parser = new XMLParser();
+        IXMLParser parser = new XMLParser(false);
         spec = parser.parse(substitutedSpec);
         Assert.assertEquals("izpack:shortcuts", spec.getName());
     }
@@ -88,13 +88,13 @@ public class XMLParserTest
         }
     }
 
-    @org.junit.Test
+    @Test
     public void testLineNumber() throws SAXException, ParserConfigurationException, IOException, TransformerException
     {
         InputStream input = XMLParserTest.class.getResourceAsStream(lnFilename);
         IXMLElement elt;
 
-        IXMLParser parser = new XMLParser();
+        IXMLParser parser = new XMLParser(false);
         elt = parser.parse(input);
 
         checkEltLN(elt);
@@ -106,7 +106,7 @@ public class XMLParserTest
     {
         URL url = XMLParserTest.class.getResource(xlnFilename);
 
-        IXMLParser parser = new XMLParser();
+        IXMLParser parser = new XMLParser(false);
         IXMLElement elt = parser.parse(url);
 
         checkEltLN(elt);

--- a/izpack-api/src/test/java/com/izforge/izpack/api/adaptator/xinclude/XIncludeParseFileTestCase.java
+++ b/izpack-api/src/test/java/com/izforge/izpack/api/adaptator/xinclude/XIncludeParseFileTestCase.java
@@ -38,7 +38,7 @@ public class XIncludeParseFileTestCase extends BaseXIncludeTestCase
         URL expectURL = getClass().getResource(fileBase + "-expect.xml");
         File fileInput = new File(inputURL.toURI());
         File fileExcept = new File(expectURL.toURI());
-        IXMLParser parser = new XMLParser();
+        IXMLParser parser = new XMLParser(false);
         IXMLElement inputElement = parser.parse(new FileInputStream(fileInput), fileInput.getAbsolutePath());
         IXMLElement expectedElement = parser.parse(new FileInputStream(fileExcept), fileInput.getAbsolutePath());
         deepEqual(expectedElement, inputElement);

--- a/izpack-api/src/test/java/com/izforge/izpack/api/adaptator/xinclude/XIncludeParseStreamTestCase.java
+++ b/izpack-api/src/test/java/com/izforge/izpack/api/adaptator/xinclude/XIncludeParseStreamTestCase.java
@@ -34,7 +34,7 @@ public class XIncludeParseStreamTestCase extends BaseXIncludeTestCase
     {
         URL inputURL = getClass().getResource(fileBase + "-input.xml");
         URL expectURL = getClass().getResource(fileBase + "-expect.xml");
-        IXMLParser parser = new XMLParser();
+        IXMLParser parser = new XMLParser(false);
         IXMLElement inputElement = parser.parse(inputURL.openStream(), inputURL.toExternalForm());
         IXMLElement expectedElement = parser.parse(expectURL.openStream());
         deepEqual(expectedElement, inputElement);

--- a/izpack-api/src/test/java/com/izforge/izpack/api/adaptator/xinclude/XIncludeParseURLTestCase.java
+++ b/izpack-api/src/test/java/com/izforge/izpack/api/adaptator/xinclude/XIncludeParseURLTestCase.java
@@ -34,7 +34,7 @@ public class XIncludeParseURLTestCase extends BaseXIncludeTestCase
         URL inputURL = getClass().getResource(fileBase + "-input.xml");
         URL expectURL = getClass().getResource(fileBase + "-expect.xml");
         // set up a new parser to parse the input xml (with includes)
-        IXMLParser parser = new XMLParser();
+        IXMLParser parser = new XMLParser(false);
         IXMLElement inputElement = parser.parse(inputURL);
         IXMLElement expectedElement = parser.parse(expectURL);
         deepEqual(expectedElement, inputElement);

--- a/izpack-api/src/test/java/com/izforge/izpack/api/data/LocaleDatabaseTest.java
+++ b/izpack-api/src/test/java/com/izforge/izpack/api/data/LocaleDatabaseTest.java
@@ -1,15 +1,15 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,13 +52,6 @@ public class LocaleDatabaseTest
     {
         assertEquals("Argument1: one, Argument2: two", db.get("string.with.arguments", "one", "two"));
         assertEquals("Argument1: 'one', Argument2: 'two'", db.get("string.with.quoted.arguments", "one", "two"));
-    }
-
-    @Test
-    public void testGetString() throws Exception
-    {
-        assertEquals("String Text", db.getString("string"));
-        assertEquals("none", db.getString("none"));
     }
 
     @Test

--- a/izpack-api/src/test/resources/com/izforge/izpack/api/data/testing-langpack.xml
+++ b/izpack-api/src/test/resources/com/izforge/izpack/api/data/testing-langpack.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF8"?>
 
-<langpack>
+<izpack:langpack version="5.0"
+ xmlns:izpack="http://izpack.org/schema/langpack"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
     <str id="string" txt="String Text" />
     <str id="string.with.arguments" txt="Argument1: {0}, Argument2: {1}" />
     <str id="string.with.quoted.arguments" txt="Argument1: '{0}', Argument2: '{1}'" />
 
-</langpack>
+</izpack:langpack>

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/cli/CliAnalyzer.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/cli/CliAnalyzer.java
@@ -45,6 +45,7 @@ public class CliAnalyzer {
     private static final String ARG_OUTPUT = "o";
     private static final String ARG_COMPRESSION_FORMAT = "c";
     private static final String ARG_COMPRESSION_LEVEL = "l";
+    private static final String ARG_SCHEMA_VALIDATION = "v";
 
 
     /**
@@ -66,6 +67,8 @@ public class CliAnalyzer {
                 "default is the internal deflate compression\n");
         options.addOption(ARG_COMPRESSION_LEVEL, true, "compression-level : indicates the level for the used compression format"
                 + " if supported. Only integer are valid\n");
+        options.addOption(ARG_SCHEMA_VALIDATION, true, "schema-validation : indicates whether XML descriptors should " +
+                "be validated during compilation (true|false; default is true)\n");
         return options;
     }
 
@@ -147,15 +150,15 @@ public class CliAnalyzer {
             printHelp();
             throw new HelpRequestedException();
         }
-        List argList = commandLine.getArgList();
-        installFile = (String) argList.get(0);
+        List<String> argList = commandLine.getArgList();
+        installFile = argList.get(0);
         if (commandLine.hasOption(ARG_BASEDIR)) {
             baseDir = commandLine.getOptionValue(ARG_BASEDIR).trim();
         }
         if (commandLine.hasOption(ARG_OUTPUT)) {
             output = commandLine.getOptionValue(ARG_OUTPUT).trim();
         }
-        CompilerData compilerData = new CompilerData(installFile, baseDir, output, false);
+        CompilerData compilerData = new CompilerData(installFile, baseDir, output, false, true);
 
 
         if (commandLine.hasOption(ARG_COMPRESSION_FORMAT)) {
@@ -169,6 +172,9 @@ public class CliAnalyzer {
         }
         if (commandLine.hasOption(ARG_KIND)) {
             compilerData.setKind(commandLine.getOptionValue(ARG_KIND).trim());
+        }
+        if (commandLine.hasOption(ARG_SCHEMA_VALIDATION)) {
+            compilerData.setValidating(Boolean.parseBoolean(commandLine.getOptionValue(ARG_SCHEMA_VALIDATION).trim()));
         }
 
         return compilerData;

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/data/CompilerData.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/data/CompilerData.java
@@ -86,6 +86,12 @@ public class CompilerData
     private boolean mkdirs = false;
 
     /**
+     * Specifies that the compiler will validate each descriptor using W3C XML Schema as they are parsed.
+     * By default the value of this is set to false.
+     */
+    private boolean validating = false;
+
+    /**
      * Compression level
      */
     private int comprLevel = -1;
@@ -122,19 +128,20 @@ public class CompilerData
         }
     }
 
-    public CompilerData(String installFile, String basedir, String output, boolean mkdirs)
+    public CompilerData(String installFile, String basedir, String output, boolean mkdirs, boolean validating)
     {
         this();
         this.installFile = installFile;
         this.basedir = basedir;
         this.output = output;
         this.mkdirs = mkdirs;
+        this.validating = validating;
     }
 
     public CompilerData(String comprFormat, String kind, String installFile, String installText, String basedir,
-                        String output, boolean mkdirs, int comprLevel)
+                        String output, boolean mkdirs, boolean validating, int comprLevel)
     {
-        this(installFile, basedir, output, mkdirs);
+        this(installFile, basedir, output, mkdirs, validating);
         this.comprFormat = comprFormat;
         this.kind = kind;
         this.installText = installText;
@@ -142,9 +149,9 @@ public class CompilerData
     }
 
     public CompilerData(String comprFormat, String kind, String installFile, String installText, String basedir,
-                        String output, boolean mkdirs, int comprLevel, Info externalInfo)
+                        String output, boolean mkdirs, boolean validating, int comprLevel, Info externalInfo)
     {
-        this(comprFormat, kind, installFile, installText, basedir, output, mkdirs, comprLevel);
+        this(comprFormat, kind, installFile, installText, basedir, output, mkdirs, validating, comprLevel);
         this.externalInfo = externalInfo;
     }
 
@@ -206,6 +213,30 @@ public class CompilerData
     public void setMkdirs(boolean mkdirs)
     {
         this.mkdirs = mkdirs;
+    }
+
+    /**
+     * Indicates whether the compiler will validate each descriptor using W3C XML Schema as it is
+     * parsed.
+     *
+     * @return {@code true} if the compiler will validate each descriptor as it is parsed;
+     * {@code false} otherwise.
+     */
+    public boolean isValidating()
+    {
+        return validating;
+    }
+
+    /**
+     * Specifies that the compiler will validate each descriptor using W3C XML Schema as it is
+     * parsed. By default the value of this is set to false.
+     *
+     * @param validating {@code true} if the compiler will validate each descriptor as it is parsed;
+     * {@code false} otherwise.
+     */
+    public void setValidating(boolean validating)
+    {
+        this.validating = validating;
     }
 
     public String getComprFormat()

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/resource/ResourceFinder.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/resource/ResourceFinder.java
@@ -27,7 +27,6 @@ import java.net.URL;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLParser;
-import com.izforge.izpack.api.adaptator.impl.XMLParser;
 import com.izforge.izpack.api.exception.CompilerException;
 import com.izforge.izpack.compiler.data.CompilerData;
 import com.izforge.izpack.compiler.data.PropertyManager;
@@ -156,9 +155,8 @@ public class ResourceFinder
      *                             For problems with the installation file
      * @throws java.io.IOException for errors reading the installation file
      */
-    public IXMLElement getXMLTree() throws IOException
+    public IXMLElement getXMLTree(IXMLParser parser) throws IOException
     {
-        IXMLParser parser = new XMLParser();
         IXMLElement data;
         if (compilerData.getInstallFile() != null)
         {

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/AntActionSpecXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/AntActionSpecXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the AntActions listener spec IzPack resource with activated schema validation
+ * using the according built-in XSD.
+ */
+public class AntActionSpecXmlParser extends XMLParser
+{
+    public AntActionSpecXmlParser()
+    {
+        super(true, XMLSchemaDefinition.ANTACTIONS.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/ConfigurationActionSpecXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/ConfigurationActionSpecXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the ConfigurationActions listener spec IzPack resource with activated schema
+ * validation using the according built-in XSD.
+ */
+public class ConfigurationActionSpecXmlParser extends XMLParser
+{
+    public ConfigurationActionSpecXmlParser()
+    {
+        super(true, XMLSchemaDefinition.CONFIGURATIONACTIONS.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/IconsSpecXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/IconsSpecXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the custom icons spec IzPack resource with activated schema validation using the
+ * according built-in XSD.
+ */
+public class IconsSpecXmlParser extends XMLParser
+{
+    public IconsSpecXmlParser()
+    {
+        super(true, XMLSchemaDefinition.ICONS.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/InstallationXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/InstallationXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the installation descriptor with activated schema validation using the according
+ * built-in XSD.
+ */
+public class InstallationXmlParser extends XMLParser
+{
+    public InstallationXmlParser()
+    {
+        super(true, XMLSchemaDefinition.INSTALLATION.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/LangPackXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/LangPackXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the IzPack langpack resources with activated schema validation using the
+ * according built-in XSD.
+ */
+public class LangPackXmlParser extends XMLParser
+{
+    public LangPackXmlParser()
+    {
+        super(true, XMLSchemaDefinition.LANGPACK.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/ProcessingSpecXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/ProcessingSpecXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the ProcessPanel spec IzPack resource with activated schema validation using the
+ * according built-in XSD.
+ */
+public class ProcessingSpecXmlParser extends XMLParser
+{
+    public ProcessingSpecXmlParser()
+    {
+        super(true, XMLSchemaDefinition.PROCESSING.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/RegistrySpecXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/RegistrySpecXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the Registry listener spec IzPack resource with activated schema validation using
+ * the according built-in XSD.
+ */
+public class RegistrySpecXmlParser extends XMLParser
+{
+    public RegistrySpecXmlParser()
+    {
+        super(true, XMLSchemaDefinition.REGISTRY.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/ShortcutSpecXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/ShortcutSpecXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the shortcuts spec IzPack resource with activated schema validation using the
+ * according built-in XSD.
+ */
+public class ShortcutSpecXmlParser extends XMLParser
+{
+    public ShortcutSpecXmlParser()
+    {
+        super(true, XMLSchemaDefinition.SHORTCUTS.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/UserInputSpecXmlParser.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/UserInputSpecXmlParser.java
@@ -1,0 +1,32 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+
+/**
+ * XML parser for the user input spec IzPack resource with activated schema validation using the
+ * according built-in XSD.
+ */
+public class UserInputSpecXmlParser extends XMLParser
+{
+    public UserInputSpecXmlParser()
+    {
+        super(true, XMLSchemaDefinition.USERINPUT.createStreamSources());
+    }
+}

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/XMLSchemaDefinition.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/xml/XMLSchemaDefinition.java
@@ -1,0 +1,76 @@
+/*
+ * IzPack - Copyright 2001-2015 Julien Ponge, René Krell, All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.compiler.xml;
+
+import javax.xml.transform.stream.StreamSource;
+
+import static com.izforge.izpack.compiler.data.CompilerData.VERSION;
+
+public enum XMLSchemaDefinition
+{
+
+    ANTACTIONS("antactions"),
+    BSFACTIONS("bsfactions"),
+    COMPILATION("compilation"),
+    CONDITIONS("conditions"),
+    CONFIGURATIONACTIONS("configurationactions"),
+    ICONS("icons"),
+    INSTALLATION("installation"),
+    LANGPACK("langpack"),
+    PROCESSING("processing"),
+    REGISTRY("registry"),
+    SHORTCUTS("shortcuts"),
+    USERINPUT("userinput");
+
+    private final String[] resources;
+    private final String[] systemIds;
+
+    XMLSchemaDefinition(final String shortName)
+    {
+        this.resources = new String[]{
+                "/schema/" + VERSION + "/izpack-types-" + VERSION + ".xsd",
+                "/schema/" + VERSION + "/izpack-" + shortName + "-" + VERSION + ".xsd"};
+        this.systemIds = new String[]{
+                "http://izpack.org/schema/types",
+                "http://izpack.org/schema/" + shortName};
+    }
+
+    private String[] resources()
+    {
+        return this.resources;
+    }
+
+    private String[] systemIds()
+    {
+        return this.systemIds;
+    }
+
+    StreamSource[] createStreamSources()
+    {
+        final String[] resources = resources();
+        final String[] systemIds = systemIds();
+        StreamSource[] sources = new StreamSource[resources.length];
+        for (int i = 0; i < resources.length; i++)
+        {
+            sources[i] = new StreamSource(XMLSchemaDefinition.class.getResourceAsStream(resources[i]), systemIds[i]);
+        }
+        return sources;
+    }
+
+    ;
+}

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-antactions-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-antactions-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~
@@ -112,6 +112,12 @@
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="loglevel" default="info">
+            <xs:annotation>
+                <xs:documentation>
+                    The Ant log priority level the action should use when logging.
+                    This will be handed out to Ant and is the threshold which must be reached before Ant logs a message.
+                </xs:documentation>
+            </xs:annotation>
             <xs:simpleType>
                 <xs:restriction base="xs:NMTOKEN">
                     <xs:enumeration value="error"/>
@@ -122,11 +128,49 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-        <xs:attribute name="logfile" type="xs:string"/>
-        <xs:attribute name="logfile_append" type="xs:boolean" default="false"/>
+        <xs:attribute name="severity" default="error">
+            <xs:annotation>
+                <xs:documentation>
+                    The severity of this action in case of errors.
+                    This tells the installer how to deal with an Ant build failure, e. g. which types of user dialogs
+                    should pop up with the given message.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="information"/>
+                    <xs:enumeration value="question"/>
+                    <xs:enumeration value="warning"/>
+                    <xs:enumeration value="error"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="logfile" type="xs:string" use="optional"/>
+        <xs:attribute name="logfile_append" type="xs:boolean" use="optional" default="false"/>
         <xs:attribute name="messageid" type="xs:string"/>
-        <xs:attribute name="buildfile" type="xs:string"/>
-        <xs:attribute name="buildresource" type="xs:string"/>
+        <xs:attribute name="buildfile" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The Ant buildfile that must be preinstalled before.
+                    Cannot be just together with "buildresource".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="buildresource" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The Ant build resource that must be declared with this name in the resources section.
+                    Cannot be just together with "buildfile".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="dir" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The base directory for the called Ant build.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
     </xs:complexType>
 

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-bsfactions-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-bsfactions-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~
@@ -23,31 +23,35 @@
 <xs:schema attributeFormDefault="unqualified"
            elementFormDefault="unqualified"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://izpack.org/schema/langpack"
-           xmlns="http://izpack.org/schema/langpack">
+           targetNamespace="http://izpack.org/schema/bsfactions"
+           xmlns="http://izpack.org/schema/bsfactions">
 
-    <xs:element name="langpack">
+    <xs:element name="bsfactions">
         <xs:annotation>
-            <xs:documentation>The root element</xs:documentation>
+            <xs:documentation>
+                Defines actions for the BSFInstallerListener and BSFUninstallerListener
+            </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="str" maxOccurs="unbounded">
-                    <xs:annotation>
-                        <xs:documentation>A string definition</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                        <xs:simpleContent>
-                            <xs:extension base="xs:string">
-                                <xs:attribute name="id" type="xs:string" use="required"/>
-                                <xs:attribute name="txt" type="xs:string" use="required"/>
-                            </xs:extension>
-                        </xs:simpleContent>
-                    </xs:complexType>
-                </xs:element>
+                <xs:element name="pack" type="packType" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <xs:attribute name="version" type="xs:string" fixed="5.0" use="required"/>
         </xs:complexType>
     </xs:element>
 
+    <xs:complexType name="packType">
+        <xs:sequence>
+            <xs:element name="script" type="scriptType" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="scriptType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="language" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 </xs:schema>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-compilation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-compilation-5.0.xsd
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-conditions-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-conditions-5.0.xsd
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-configurationactions-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-configurationactions-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~
@@ -108,7 +108,7 @@
         <xs:attribute name="resolveExpressions" type="xs:boolean" use="optional"/>
         <xs:attribute name="failonerror" type="xs:boolean" use="optional"/>
         <xs:attribute name="includeemptydirs" type="xs:boolean" use="optional"/>
-        <xs:attribute name="overwrite" type="xs:boolean" use="optional"/>
+        <xs:attribute name="overwrite" type="xs:boolean" use="optional" default="false"/>
         <xs:attribute name="preservelastmodified" type="xs:boolean" use="optional"/>
         <xs:attribute name="enablemultiplemappings" type="xs:boolean" use="optional"/>
         <xs:attribute name="condition" type="xs:string" use="required"/>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-icons-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-icons-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~
@@ -52,6 +52,12 @@
             </xs:choice>
             <xs:attribute name="version" type="xs:string" fixed="5.0"/>
         </xs:complexType>
+        <!-- TODO NEW -->
+        <xs:unique name="oneConditionForEachConditionID">
+            <xs:selector xpath="conditions/condition" />
+            <xs:field xpath="@id" />
+        </xs:unique>
+
     </xs:element>
 
 
@@ -394,15 +400,15 @@
     <!-- Packs                                                                                                  -->
     <!--                                                                                                        -->
     <xs:complexType name="packsType">
-        <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="pack" type="packType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="refpack" type="refpackType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="refpackset" type="refpackSetType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
     </xs:complexType>
 
     <xs:complexType name="packType">
-        <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="description" type="xs:string" maxOccurs="1"/>
             <xs:element name="onSelect" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
@@ -426,7 +432,7 @@
             <xs:element name="updatecheck" type="updateCheckType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="validator" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="name" type="xs:string"/>
         <xs:attribute name="required" type="types:yesNoTrueFalseType"/>
@@ -462,6 +468,7 @@
         <xs:attribute name="targetdir" type="xs:string" use="optional" default="${INSTALL_PATH}"/>
         <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
         <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
+        <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
     </xs:complexType>
 
@@ -484,7 +491,8 @@
         <xs:attribute name="src" type="xs:string" use="required"/>
         <xs:attribute name="targetdir" type="xs:string" use="required"/>
         <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
-        <xs:attribute name="blockable" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
+        <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="unpack" type="xs:boolean" use="optional" default="false"/>
         <xs:attribute name="casesensitive" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="defaultexcludes" type="xs:boolean" use="optional" default="true"/>
@@ -500,7 +508,8 @@
         <xs:attribute name="src" type="xs:string" use="required"/>
         <xs:attribute name="target" type="xs:string" use="required"/>
         <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
-        <xs:attribute name="blockable" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
+        <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="unpack" type="xs:boolean" use="optional" default="false"/>
     </xs:complexType>
 
@@ -562,6 +571,13 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="blockableType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="auto"/>
+            <xs:enumeration value="force"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <!--                                                                                                        -->
     <!-- Natives                                                                                                -->

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-langpack-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-langpack-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~
@@ -23,35 +23,31 @@
 <xs:schema attributeFormDefault="unqualified"
            elementFormDefault="unqualified"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://izpack.org/schema/bsfactions"
-           xmlns="http://izpack.org/schema/bsfactions">
+           targetNamespace="http://izpack.org/schema/langpack"
+           xmlns="http://izpack.org/schema/langpack">
 
-    <xs:element name="bsfactions">
+    <xs:element name="langpack">
         <xs:annotation>
-            <xs:documentation>
-                Defines actions for the BSFInstallerListener and BSFUninstallerListener
-            </xs:documentation>
+            <xs:documentation>The root element</xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="pack" type="packType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="str" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>A string definition</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:string">
+                                <xs:attribute name="id" type="xs:string" use="required"/>
+                                <xs:attribute name="txt" type="xs:string" use="required"/>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
             </xs:sequence>
             <xs:attribute name="version" type="xs:string" fixed="5.0" use="required"/>
         </xs:complexType>
     </xs:element>
 
-    <xs:complexType name="packType">
-        <xs:sequence>
-            <xs:element name="script" type="scriptType" maxOccurs="unbounded"/>
-        </xs:sequence>
-        <xs:attribute name="name" type="xs:string" use="required"/>
-    </xs:complexType>
-
-    <xs:complexType name="scriptType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="language" type="xs:string" use="required"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
 </xs:schema>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-processing-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-processing-5.0.xsd
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-registry-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-registry-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-shortcuts-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-shortcuts-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version = "1.0" encoding = "utf-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2013 Julien Ponge, All Rights Reserved.
   ~

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -41,17 +41,18 @@
     <!-- Conditions                                                                                             -->
     <!--                                                                                                        -->
     <xs:complexType name="conditionsType">
-        <xs:sequence>
-            <xs:element name="condition" type="conditionType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="condition" type="conditionType"/>
             <xs:element name="panelcondition" type="panelConditionType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+            <xs:element name="packcondition" type="packConditionType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
     </xs:complexType>
 
     <xs:complexType name="conditionType">
-        <xs:sequence>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
             <xs:element name="condition" type="conditionType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="value" type="valueElementType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="variable" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="arg1" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="arg2" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -61,7 +62,7 @@
             <xs:element name="java" type="javaType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="returnvalue" type="returnValueType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="requiredusername" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="refid" type="xs:string"/>
         <xs:attribute name="type" use="optional">
@@ -86,12 +87,22 @@
         </xs:attribute>
     </xs:complexType>
 
+    <xs:complexType name="valueElementType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="caseInsensitive" type="xs:boolean" use="optional" default="false"/>
+                <xs:attribute name="regex" type="xs:boolean" use="optional" default="false"/>
+                <xs:attribute name="byLine" type="xs:boolean" use="optional" default="true"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
     <xs:complexType name="javaType">
-        <xs:sequence>
+        <xs:all>
             <xs:element name="class" type="xs:string"/>
             <xs:element name="method" type="xs:string" minOccurs="0"/>
             <xs:element name="field" type="xs:string" minOccurs="0"/>
-        </xs:sequence>
+        </xs:all>
     </xs:complexType>
 
     <xs:complexType name="returnValueType" mixed="true">
@@ -105,8 +116,20 @@
     </xs:complexType>
 
     <xs:complexType name="panelConditionType">
-        <xs:attribute name="conditionid" type="xs:string" use="required"/>
         <xs:attribute name="panelid" type="xs:string" use="required"/>
+        <xs:attribute name="conditionid" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="packConditionType">
+        <xs:attribute name="packid" type="xs:string" use="required"/>
+        <xs:attribute name="conditionid" type="xs:string" use="required"/>
+        <xs:attribute name="optional" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether an optional pack installation is allowed if condition is not met,
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <!--                                                                                                        -->
@@ -121,11 +144,11 @@
     <!-- Dynamic variables                                                                                      -->
     <!--                                                                                                        -->
     <xs:complexType name="dynamicVariableType">
-        <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="value" minOccurs="0" maxOccurs="1"/>
             <xs:element name="filters" type="dynamicVariableFiltersType" minOccurs="0"/>
             <xs:element name="arg" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute type="xs:string" name="name" use="required"/>
         <xs:attribute type="xs:boolean" name="checkonce" use="optional" default="false"/>
         <xs:attribute type="xs:string" name="condition" use="optional"/>
@@ -137,6 +160,7 @@
         <xs:attribute type="xs:string" name="file" use="optional"/>
         <xs:attribute type="xs:string" name="section" use="optional"/>
         <xs:attribute type="xs:string" name="key" use="optional"/>
+        <xs:attribute type="xs:boolean" name="escape" use="optional" default="true"/>
         <!-- configuration file in zip/jar file -->
         <xs:attribute type="xs:string" name="zipfile" use="optional"/>
         <xs:attribute type="xs:string" name="jarfile" use="optional"/>
@@ -165,12 +189,12 @@
     </xs:complexType>
 
     <xs:complexType name="dynamicVariableFiltersType">
-        <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="regex" type="dynamicVariableRegexFilterType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="location" type="dynamicVariableLocationFilterType"
                         minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="case" type="dynamicVariableCaseFilterType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
     </xs:complexType>
 
     <xs:complexType name="dynamicVariableRegexFilterType">
@@ -178,8 +202,8 @@
         <xs:attribute type="xs:string" name="select" use="optional"/>
         <xs:attribute type="xs:string" name="replace" use="optional"/>
         <xs:attribute type="xs:string" name="defaultvalue" use="optional"/>
-        <xs:attribute type="xs:boolean" name="global" use="optional"/>
-        <xs:attribute type="xs:boolean" name="casesensitive" use="optional"/>
+        <xs:attribute type="xs:boolean" name="global" use="optional" default="false"/>
+        <xs:attribute type="xs:boolean" name="casesensitive" use="optional" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="dynamicVariableLocationFilterType">

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!--
   ~ IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
   ~
@@ -35,14 +35,14 @@
     <xs:import namespace="http://izpack.org/schema/types"
                schemaLocation="http://izpack.org/schema/5.0/izpack-types-5.0.xsd"/>
 
-    <xs:element name="userInput">
+    <xs:element name="userinput">
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="variable" type="types:variableType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="panel" minOccurs="0" maxOccurs="unbounded">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element minOccurs="0" name="createForPack">
+                            <xs:element minOccurs="0" maxOccurs="unbounded" name="createForPack">
                                 <xs:complexType>
                                     <xs:attribute name="name" type="xs:string" use="required"/>
                                 </xs:complexType>
@@ -67,6 +67,29 @@
                                     When set to true, fields on this panel will be shown as disabled when the field's
                                     conditionid evaluates to false. When set to false or not specified, fields will be
                                     hidden if its conditionid evaluates to false.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="displayHiddenCondition" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The condition to activate the "displayHidden" mode.
+                                    Cannot be used with displayHidden="true" at the same time.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="readonly" type="xs:boolean" use="optional" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    When set to true, all fields on this panel will be shown as disabled.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="readonlyCondition" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The condition to activate the "readonly" mode.
+                                    Cannot be used with readonly="true" at the same time.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
@@ -99,7 +122,7 @@
     </xs:element>
 
     <xs:complexType name="fieldType">
-        <xs:sequence minOccurs="0">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="description" minOccurs="0">
                 <xs:complexType>
                     <xs:attribute name="id" type="xs:string" use="optional"/>
@@ -108,10 +131,11 @@
             </xs:element>
             <xs:element name="spec">
                 <xs:complexType>
-                    <xs:sequence minOccurs="0">
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
                         <xs:element name="pwd" type="passwordSpecType" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element name="choice" type="choiceSpecType" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:sequence>
+                        <xs:element name="col" type="columnFieldColSpecType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:choice>
                     <xs:attribute name="id" type="xs:string" use="optional"/>
                     <xs:attribute name="false" type="xs:string" use="optional"/>
                     <xs:attribute name="filename" type="xs:string" use="optional">
@@ -178,16 +202,59 @@
                     </xs:attribute>
                     <xs:attribute name="mustExist" type="xs:boolean" use="optional" default="true">
                         <xs:annotation>
-                            <xs:documentation>Used by "dir", file fields</xs:documentation>
+                            <xs:documentation>
+                              Determines if the directory must exist to continue.
+                              Used by the "dir" field.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="create" type="xs:boolean" use="optional" default="false">
+                        <xs:annotation>
+                            <xs:documentation>
+                              Determines if the directory are created if they don't exist.
+                              Used by the "dir" field.
+                            </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
                     <xs:attribute name="layout" type="xs:string" use="optional">
                         <xs:annotation>
-                            <xs:documentation>Used by "rule" fields</xs:documentation>
+                            <xs:documentation>
+                                Used by the "rule" field.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="resultFormat" type="ruleFieldResultFormatType" use="optional">
+                        <xs:annotation>
+                            <xs:documentation>
+                                How the result should be assembled back from the single field parts of a rule field.
+                                Used by the "rule" field.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="separator" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation>
+                                This is a string used as the alternative separator string when assembling the result.
+                                Used by the "rule" field when using resultFormat="specialSeparator".
+                            </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
                     <xs:attribute name="size" type="xs:unsignedByte" use="optional"/>
-                    <xs:attribute name="set" type="xs:string" use="optional"/>
+                    <xs:attribute name="set" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The value for this field forced to be set as initial value and which overrides previous
+                                values.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="default" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The default value for this field is the assigned "variable" has not been initialized.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
                     <xs:attribute name="true" type="xs:string" use="optional"/>
                     <xs:attribute name="txt" type="xs:string" use="optional"/>
                 </xs:complexType>
@@ -197,22 +264,8 @@
                     <xs:attribute name="family" type="xs:string" use="optional"/>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="validator" minOccurs="0" maxOccurs="unbounded">
-                <xs:complexType>
-                    <xs:sequence minOccurs="0">
-                        <xs:element maxOccurs="unbounded" name="param">
-                            <xs:complexType>
-                                <xs:attribute name="name" type="xs:string" use="required"/>
-                                <xs:attribute name="value" type="xs:string" use="required"/>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                    <xs:attribute name="class" type="xs:string" use="required"/>
-                    <xs:attribute name="txt" type="xs:string" use="required"/>
-                    <xs:attribute name="id" type="xs:string" use="optional"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
+            <xs:element name="validator" type="fieldValidatorType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
         <xs:attribute name="type" type="typeType" use="required"/>
         <xs:attribute name="variable" type="xs:string" use="optional"/>
         <xs:attribute name="conditionid" type="xs:string" use="optional"/>
@@ -253,11 +306,50 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="displayHiddenCondition" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The condition to activate the "displayHidden" mode for this field.
+                    Cannot be used with displayHidden="true" at the same time.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="readonly" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    When set to true, this field will be shown as disabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="readonlyCondition" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The condition to activate the "readonly" mode for this field.
+                    Cannot be used with readonly="true" at the same time.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="tooltip" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The tooltip attribute allows a UserInputPanel field to add the specified tooltip to its
                     component children. The value of tooltip must be the id of the string in langpacks.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="minRow" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Minimal number of rows displayed in a "custom" field.
+                    Used by "custom" fields.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxRow" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Maximal number of rows displayed in a "custom" field, before the Add button gets deactivated.
+                    Used by "custom" fields.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -278,6 +370,7 @@
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
+        <xs:attribute name="conditionid" type="xs:string" use="optional"/>
         <xs:attribute name="processor" type="xs:string" use="optional"/>
         <xs:attribute name="set" type="xs:string" use="optional"/>
         <xs:attribute name="id" type="xs:string" use="optional">
@@ -321,6 +414,34 @@
         <xs:attribute name="set" type="xs:string" use="optional"/>
     </xs:complexType>
 
+    <xs:complexType name="columnFieldColSpecType">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="field" type="fieldType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="validator" type="fieldValidatorType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="fieldValidatorType">
+        <xs:sequence minOccurs="0">
+            <xs:element maxOccurs="unbounded" name="param">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="value" type="xs:string" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+        <xs:attribute name="txt" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The default text to display on a validation error when no translation can be found for
+                    the "id".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="id" type="xs:string" use="optional"/>
+    </xs:complexType>
+
     <!--                                                                                                        -->
     <!-- Field type                                                                                             -->
     <!--                                                                                                        -->
@@ -328,6 +449,7 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="check"/>
             <xs:enumeration value="combo"/>
+            <xs:enumeration value="custom"/>
             <xs:enumeration value="dir"/>
             <xs:enumeration value="divider"/>
             <xs:enumeration value="file"/>
@@ -358,6 +480,43 @@
             <xs:enumeration value="file"/>
             <xs:enumeration value="directory"/>
             <xs:enumeration value="parentdir"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="ruleFieldResultFormatType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="plainString">
+                <as:annotation>
+                    <xs:documentation>
+                        Specifies to return the contents of all fields concatenated into one long string, with
+                        separation between each component.
+                    </xs:documentation>
+                </as:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="displayFormat">
+                <as:annotation>
+                    <xs:documentation>
+                        Specifies to return the contents of all fields together with all separators as specified in the
+                        field format concatenated into one long string.
+                        In this case the resulting string looks just like the user saw it during data entry.
+                    </xs:documentation>
+                </as:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="specialSeparator">
+                <as:annotation>
+                    <xs:documentation>
+                        Specifies to return the contents of all fields concatenated into one long string, with a
+                        special separator string inserted in between the individual components.
+                    </xs:documentation>
+                </as:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="processed">
+                <as:annotation>
+                    <xs:documentation>
+                        Specifies to return the contents of all fields using a Processor.
+                    </xs:documentation>
+                </as:annotation>
+            </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/CompilerConfigMockedTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/CompilerConfigMockedTest.java
@@ -58,6 +58,9 @@ import com.izforge.izpack.util.Platforms;
  */
 public class CompilerConfigMockedTest
 {
+    private final String START_TAG = "<izpack:installation version=\"5.0\" xmlns:izpack=\"http://izpack.org/schema/installation\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd\">";
+    private final String END_TAG = "</izpack:installation>";
+
     private Map<String, List<DynamicVariable>> mapStringListDyn;
     private XMLParser xmlParser = new XMLParser();
     private CompilerConfig compilerConfig;
@@ -80,10 +83,14 @@ public class CompilerConfigMockedTest
         Mockito.when(packager.getVariables()).thenReturn(variable);
 
         IXMLElement element = xmlParser.parse(
-                "<root><dynamicvariables><variable name=\"myPath\" value=\"$INSTALLPATH/test\"/></dynamicvariables></root>");
+                START_TAG
+                + "<dynamicvariables><variable name=\"myPath\" value=\"$INSTALLPATH/test\"/></dynamicvariables>"
+                + END_TAG);
         compilerConfig.addDynamicVariables(element);
         element = xmlParser.parse(
-                "<root><variables><variable name=\"INSTALLPATH\" value=\"thePath\"/></variables></root>");
+                START_TAG
+                + "<variables><variable name=\"INSTALLPATH\" value=\"thePath\"/></variables>"
+                + END_TAG);
         compilerConfig.addVariables(element);
 
         verifyCallToMap(mapStringListDyn, "myPath", new PlainValue("thePath/test"));
@@ -96,7 +103,9 @@ public class CompilerConfigMockedTest
         Mockito.when(packager.getDynamicVariables()).thenReturn(mapStringListDyn);
 
         IXMLElement element = xmlParser.parse(
-                "<root><dynamicvariables><variable name=\"myPath\" value=\"$INSTALLPATH/test\"/></dynamicvariables></root>");
+                START_TAG
+                + "<dynamicvariables><variable name=\"myPath\" value=\"$INSTALLPATH/test\"/></dynamicvariables>"
+                + END_TAG);
         compilerConfig.addDynamicVariables(element);
 
         verifyCallToMap(mapStringListDyn, "myPath", new PlainValue("$INSTALLPATH/test"));
@@ -116,7 +125,9 @@ public class CompilerConfigMockedTest
     public void compilerShouldAddVariable() throws Exception
     {
         IXMLElement xmlData = xmlParser.parse(
-                "<root><variables><variable name=\"scriptFile\" value=\"script.bat\"/></variables></root>");
+                START_TAG
+                + "<variables><variable name=\"scriptFile\" value=\"script.bat\"/></variables>"
+                + END_TAG);
         Properties variable = Mockito.mock(Properties.class);
         Mockito.when(packager.getVariables()).thenReturn(variable);
         compilerConfig.addVariables(xmlData);
@@ -127,7 +138,9 @@ public class CompilerConfigMockedTest
     public void shouldAddDynamicVariable() throws Exception
     {
         IXMLElement xmlData = xmlParser.parse(
-                "<root><dynamicvariables><variable name='myPath' value='$INSTALLPATH/test'/></dynamicvariables></root>");
+                START_TAG
+                + "<dynamicvariables><variable name='myPath' value='$INSTALLPATH/test'/></dynamicvariables>"
+                + END_TAG);
         Map variable = Mockito.mock(Map.class);
 
         Mockito.when(variable.containsKey("myPath")).thenReturn(false);
@@ -135,7 +148,6 @@ public class CompilerConfigMockedTest
 
         compilerConfig.addDynamicVariables(xmlData);
 
-        new ArrayList();
         DynamicVariable dynamicVariable = new DynamicVariableImpl();
         dynamicVariable.setName("myPath");
         dynamicVariable.setValue(new PlainValue("$INSTALLPATH/test"));

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/bootstrap/CompilerLauncherTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/bootstrap/CompilerLauncherTest.java
@@ -68,7 +68,7 @@ public class CompilerLauncherTest
                         baseDir + "src/test/resources/bindingTest.xml",
                         "",
                         baseDir + "/target/output.jar",
-                        false)
+                        false, true)
         );
         JarOutputStream jarOutputStream = compilerContainer.getComponent(JarOutputStream.class);
         assertThat(jarOutputStream, IsNull.notNullValue());
@@ -92,7 +92,7 @@ public class CompilerLauncherTest
                         baseDir + "src/test/resources/bindingTest.xml",
                         "",
                         baseDir + "/target/output.jar",
-                        false)
+                        false, true)
         );
         CompilerData data = compilerContainer.getComponent(CompilerData.class);
         assertThat(data, IsNull.notNullValue());

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/compressor/CompressorTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/compressor/CompressorTest.java
@@ -46,7 +46,7 @@ public class CompressorTest
                 "",
                 baseDir,
                 baseDir + "/target/output.jar",
-                false);
+                false, false);
         data.setComprFormat("bzip2");
         data.setComprLevel(5);
         JarOutputStreamProvider jarOutputStreamProvider = new JarOutputStreamProvider();

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/container/TestCompilerContainer.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/container/TestCompilerContainer.java
@@ -116,7 +116,7 @@ public class TestCompilerContainer extends CompilerContainer
         File out = new File(baseDir, "out" + Math.random() + ".jar");
         out.deleteOnExit();
         CompilerData data = new CompilerData(installerFile.getAbsolutePath(), baseDir.getAbsolutePath(),
-                                             out.getAbsolutePath(), false);
+                                             out.getAbsolutePath(), false, true);
         addComponent(CompilerData.class, data);
         addComponent(File.class, out);
 

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/packager/impl/MultiVolumePackagerTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/packager/impl/MultiVolumePackagerTest.java
@@ -62,7 +62,7 @@ public class MultiVolumePackagerTest extends AbstractPackagerTest
                 "",
                 baseDir,
                 baseDir + "/target/test.jar",
-                true);
+                true, false);
         MultiVolumePackager packager = new MultiVolumePackager(properties, listener, jar, mergeManager,
                                                                pathResolver, resolver, compressor, data);
         packager.setInfo(new Info());

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/packager/impl/PackagerTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/packager/impl/PackagerTest.java
@@ -53,7 +53,7 @@ public class PackagerTest extends AbstractPackagerTest
         PackCompressor compressor = Mockito.mock(PackCompressor.class);
         CompilerPathResolver pathResolver = Mockito.mock(CompilerPathResolver.class);
         MergeableResolver resolver = Mockito.mock(MergeableResolver.class);
-        CompilerData data = new CompilerData("", "", "", true);
+        CompilerData data = new CompilerData("", "", "", true, false);
         Packager packager = new Packager(properties, listener, jar, compressor, jar, mergeManager,
                                          pathResolver, resolver, data);
         packager.setInfo(new Info());

--- a/izpack-compiler/src/test/resources/samples/izpack.xml
+++ b/izpack-compiler/src/test/resources/samples/izpack.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">

--- a/izpack-compiler/src/test/resources/samples/silverpeas/postprocess.xml
+++ b/izpack-compiler/src/test/resources/samples/silverpeas/postprocess.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<izpack:processing version="5.0"
+  xmlns:izpack="http://izpack.org/schema/processing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://izpack.org/schema/processing http://izpack.org/schema/5.0/izpack-processing-5.0.xsd"
+>
+
+  <job name="do xyz">
+    <os family="windows" />
+    <executefile name="$INSTALL_PATH/scripts/xyz.bat" workingDir="$INSTALL_PATH">
+      <arg>doit</arg><arg>$variable</arg>
+    </executefile>
+  </job>
+
+</izpack:processing>

--- a/izpack-dist/pom.xml
+++ b/izpack-dist/pom.xml
@@ -99,6 +99,19 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>Unpack schema</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>izpack-compiler</includeArtifactIds>
+                            <excludeTransitive>true</excludeTransitive>
+                            <includes>schema/**</includes>
+                            <outputDirectory>${staging.dir}</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>Copy libs</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -110,7 +123,6 @@
                             <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
-
                 </executions>
             </plugin>
 

--- a/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
@@ -70,7 +70,7 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
     /**
      * The name of the XML file that specifies the registry entries.
      */
-    static final String SPEC_FILE_NAME = "RegistrySpec.xml";
+    public static final String SPEC_FILE_NAME = "RegistrySpec.xml";
 
     private static final String REG_KEY = "key";
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedInstaller.java
@@ -230,7 +230,8 @@ public class AutomatedInstaller implements InstallerBase
         FileInputStream in = new FileInputStream(input);
 
         // Initialises the parser
-        IXMLParser parser = new XMLParser();
+        // TODO: Create an XSD for auto-install files and activate validation here
+        IXMLParser parser = new XMLParser(false);
         IXMLElement rtn = parser.parse(in, input.getAbsolutePath());
         in.close();
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
@@ -25,12 +25,6 @@ import java.util.logging.Logger;
 public abstract class AbstractInstallDataProvider implements Provider
 {
     /**
-     * The base name of the XML file that specifies the custom langpack. Searched is for the file
-     * with the name expanded by _ISO3.
-     */
-    protected static final String CUSTOM_TRANSLATIONS_RESOURCE_NAME = "CustomLangPack.xml";
-
-    /**
      * The logger.
      */
     private static final Logger logger = Logger.getLogger(AbstractInstallDataProvider.class.getName());
@@ -188,7 +182,7 @@ public abstract class AbstractInstallDataProvider implements Provider
         // We try to load and add a custom langpack.
         try
         {
-            installData.getMessages().add(locales.getMessages(CUSTOM_TRANSLATIONS_RESOURCE_NAME));
+            installData.getMessages().add(locales.getMessages(Resources.CUSTOM_TRANSLATIONS_RESOURCE_NAME));
             logger.fine("Found custom langpack for " + installData.getLocaleISO3());
         }
         catch (ResourceNotFoundException exception)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
@@ -4,12 +4,14 @@ import java.awt.Color;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
 import javax.swing.UIDefaults;
 import javax.swing.UIManager;
 import javax.swing.plaf.metal.MetalLookAndFeel;
@@ -286,10 +288,18 @@ public class GUIInstallDataProvider extends AbstractInstallDataProvider
                 variant = substanceVariants.get("default");
             }
             logger.info("Using laf " + variant);
-            UIManager.setLookAndFeel(variant);
-            UIManager.getLookAndFeelDefaults().put("ClassLoader", JPanel.class.getClassLoader());
-
-            checkSubstanceLafLoaded();
+            SwingUtilities.invokeLater(new Runnable() {
+                public void run() {
+                  try {
+                      UIManager.setLookAndFeel(variant);
+                      UIManager.getLookAndFeelDefaults().put("ClassLoader", JPanel.class.getClassLoader());
+                      checkSubstanceLafLoaded();
+                  } catch (Exception e) {
+                      logger.log(Level.SEVERE, "Error loading Substance look and feel: " + e.getMessage(), e);
+                    System.out.println("Substance Graphite failed to initialize");
+                  }
+                }
+              });
         }
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/IconsProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/IconsProvider.java
@@ -23,11 +23,6 @@ public class IconsProvider implements Provider
 {
     private static final Logger logger = Logger.getLogger(IconsProvider.class.getName());
 
-    /**
-     * Resource name for custom icons
-     */
-    private static final String CUSTOM_ICONS_RESOURCEFILE = "customicons.xml";
-
     public IconsDatabase provide(Resources resources) throws Exception
     {
         IconsDatabase icons = new IconsDatabase();
@@ -64,11 +59,11 @@ public class IconsProvider implements Provider
         InputStream inXML = null;
         try
         {
-            inXML = resources.getInputStream(CUSTOM_ICONS_RESOURCEFILE);
+            inXML = resources.getInputStream(Resources.CUSTOM_ICONS_RESOURCE_NAME);
         }
         catch (Throwable exception)
         {
-            logger.warning("Resource " + CUSTOM_ICONS_RESOURCEFILE
+            logger.warning("Resource " + Resources.CUSTOM_ICONS_RESOURCE_NAME
                                    + " not defined. No custom icons available");
             return;
         }
@@ -87,7 +82,7 @@ public class IconsProvider implements Provider
     {
         ImageIcon img;
         // Initialises the parser
-        IXMLParser parser = new XMLParser();
+        IXMLParser parser = new XMLParser(false);
 
         // We get the data
         IXMLElement data = parser.parse(inXML);
@@ -115,7 +110,7 @@ public class IconsProvider implements Provider
 
     /**
      * Loads an icon declared in an XML file.
-     * 
+     *
      * @param icon
      *            the XML element that declares the icon
      * @return the icon or <code>null</icon> if it does not exist

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -64,7 +64,6 @@ import javax.swing.border.TitledBorder;
 import javax.swing.text.JTextComponent;
 
 import com.izforge.izpack.api.data.Info;
-import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.event.ProgressListener;
@@ -979,30 +978,6 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
     {
         Messages messages = locales.getMessages();
         return messages;
-    }
-
-    /**
-     * Returns the locale-specific messages.
-     *
-     * @return the messages
-     * @deprecated use {@link #getMessages()}
-     */
-    @Deprecated
-    public LocaleDatabase getLangpack()
-    {
-        Messages messages = locales.getMessages();
-        return (LocaleDatabase) messages;
-    }
-
-    /**
-     * Sets the locale specific messages.
-     *
-     * @param langpack the language pack
-     * @deprecated no replacement
-     */
-    @Deprecated
-    public void setLangpack(LocaleDatabase langpack)
-    {
     }
 
     public IconsDatabase getIcons()

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -32,6 +32,7 @@ import com.izforge.izpack.api.handler.AbstractPrompt;
 import com.izforge.izpack.api.handler.AbstractUIHandler;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.core.handler.ProgressHandler;
@@ -840,7 +841,7 @@ public abstract class UnpackerBase implements IUnpacker
             if (messages != null)
             {
               try {
-                packMessages = messages.newMessages(PackHelper.LANG_FILE_NAME);
+                packMessages = messages.newMessages(Resources.PACK_TRANSLATIONS_RESOURCE_NAME);
               } catch (Exception ex){
                 logger.fine(ex.getLocalizedMessage());
               }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PackHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PackHelper.java
@@ -32,11 +32,6 @@ import com.izforge.izpack.api.resource.Messages;
 public class PackHelper
 {
     /**
-     * The name of the XML file that specifies the panel langpack
-     */
-    public static final String LANG_FILE_NAME = "packsLang.xml";
-
-    /**
      * Returns a localised name for a pack.
      * <p/>
      * This uses {@link Pack#getLangPackId()} to locate the localised name for the pack.

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/container/provider/AutomatedInstallDataProviderTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/container/provider/AutomatedInstallDataProviderTest.java
@@ -49,6 +49,7 @@ import com.izforge.izpack.api.data.InstallerRequirement;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Locales;
 import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.core.resource.DefaultLocales;
 import com.izforge.izpack.core.resource.ResourceManager;
@@ -104,7 +105,7 @@ public class AutomatedInstallDataProviderTest
                                                 "str id='overridden.message' txt='Message overridden'");
 
         mock(loader, "resources/langpacks/eng.xml", defaultPack);
-        mock(loader, "resources/" + AbstractInstallDataProvider.CUSTOM_TRANSLATIONS_RESOURCE_NAME + "_eng", customPack);
+        mock(loader, "resources/" + Resources.CUSTOM_TRANSLATIONS_RESOURCE_NAME + "_eng", customPack);
 
         // set up the locale to english because the mock resources contain only a langpack for english
         Locales locales = new DefaultLocales(resources, Locale.ENGLISH);
@@ -140,12 +141,16 @@ public class AutomatedInstallDataProviderTest
     {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         OutputStreamWriter writer = new OutputStreamWriter(stream);
-        writer.write("<langpack>\n");
+        writer.write("<izpack:langpack");
+        writer.write(" version=\"5.0\"");
+        writer.write(" xmlns:izpack=\"http://izpack.org/schema/langpack\"");
+        writer.write(" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
+        writer.write(" xsi:schemaLocation=\"http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd\">\n");
         for (String message : messages)
         {
             writer.write("<" + message + "/>\n");
         }
-        writer.write("</langpack>");
+        writer.write("</izpack:langpack>");
         writer.close();
         return new ByteArrayInputStream(stream.toByteArray());
     }

--- a/izpack-maven-plugin/src/main/java/org/izpack/mojo/IzPackNewMojo.java
+++ b/izpack-maven-plugin/src/main/java/org/izpack/mojo/IzPackNewMojo.java
@@ -92,6 +92,14 @@ public class IzPackNewMojo extends AbstractMojo
     private boolean mkdirs;
 
     /**
+     * Specifies that the XML parser will validate each descriptor using W3C XML Schema as they are parsed.
+     * By default the value of this is set to false.
+     *
+     * @parameter default-value="true"
+     */
+    private boolean validating;
+
+    /**
      * Compression level of the installation. Deactivated by default (-1)
      *
      * @parameter default-value="-1"
@@ -282,7 +290,7 @@ public class IzPackNewMojo extends AbstractMojo
             }
         }
         return new CompilerData(comprFormat, kind, installFile, null, baseDir, jarFile.getPath(),
-                                mkdirs, comprLevel, info);
+                                mkdirs, validating, comprLevel, info);
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksConsolePanel.java
@@ -34,6 +34,7 @@ import com.izforge.izpack.api.handler.Prompt.Option;
 import com.izforge.izpack.api.handler.Prompt.Options;
 import com.izforge.izpack.api.handler.Prompt.Type;
 import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.console.AbstractConsolePanel;
 import com.izforge.izpack.installer.console.ConsolePanel;
 import com.izforge.izpack.installer.panel.PanelView;
@@ -62,11 +63,11 @@ public class PacksConsolePanel extends AbstractConsolePanel implements ConsolePa
         super(panel);
         this.prompt = prompt;
         this.installData = installData;
-        
+
         //load the packs lang messages if exists
         try
         {
-            messages = installData.getMessages().newMessages(PackHelper.LANG_FILE_NAME);
+            messages = installData.getMessages().newMessages(Resources.PACK_TRANSLATIONS_RESOURCE_NAME);
         }
         catch (ResourceNotFoundException exception)
         {
@@ -140,10 +141,10 @@ public class PacksConsolePanel extends AbstractConsolePanel implements ConsolePa
     {
         Pack p = names.get(pack);
         Boolean conditionSatisfied = checkCondition(installData, p);
-        
+
         //get the pack localized name
         String packName = PackHelper.getPackName(p, messages);
-        
+
         final boolean required = p.isRequired();
         final boolean packConditionTrue = conditionSatisfied == null || conditionSatisfied.booleanValue();
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModel.java
@@ -29,6 +29,7 @@ import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.data.PackColor;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.installer.util.PackHelper;
 
@@ -78,7 +79,7 @@ public class PacksModel extends AbstractTableModel
         this.installData = idata;
         this.rules = idata.getRules();
         try{
-          this.messages = idata.getMessages().newMessages(PackHelper.LANG_FILE_NAME);
+          this.messages = idata.getMessages().newMessages(Resources.PACK_TRANSLATIONS_RESOURCE_NAME);
         } catch(com.izforge.izpack.api.exception.ResourceNotFoundException ex){
           this.messages=idata.getMessages();
         }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelBase.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelBase.java
@@ -63,7 +63,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.exception.ResourceNotFoundException;
@@ -192,7 +191,7 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
 
         try
         {
-            messages = installData.getMessages().newMessages(PackHelper.LANG_FILE_NAME);
+            messages = installData.getMessages().newMessages(Resources.PACK_TRANSLATIONS_RESOURCE_NAME);
         }
         catch (ResourceNotFoundException exception)
         {
@@ -229,13 +228,6 @@ public abstract class PacksPanelBase extends IzPanel implements PacksPanelInterf
     public Messages getMessages()
     {
         return messages;
-    }
-
-    @Deprecated
-    @Override
-    public LocaleDatabase getLangpack()
-    {
-        return (LocaleDatabase) messages;
     }
 
     @Override

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelInterface.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelInterface.java
@@ -1,17 +1,17 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2004 Gaganis Giorgos
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@
 
 package com.izforge.izpack.panels.packs;
 
-import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.installer.debugger.Debugger;
 
@@ -40,11 +39,7 @@ import com.izforge.izpack.installer.debugger.Debugger;
  */
 public interface PacksPanelInterface
 {
-
     public Messages getMessages();
-
-    @Deprecated
-    public LocaleDatabase getLangpack();
 
     public long getBytes();
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelWorker.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelWorker.java
@@ -41,7 +41,7 @@ public class ProcessPanelWorker implements Runnable
     /**
      * Name of resource for specifying processing parameters.
      */
-    private static final String SPEC_RESOURCE_NAME = "ProcessPanel.Spec.xml";
+    public static final String SPEC_RESOURCE_NAME = "ProcessPanel.Spec.xml";
 
     private AbstractUIProcessHandler handler;
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConstants.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConstants.java
@@ -31,7 +31,7 @@ public class ShortcutConstants
 
     static final String SEPARATOR_LINE = "--------------------------------------------------------------------------------";
 
-    static final String SPEC_FILE_NAME = "shortcutSpec.xml";
+    public static final String SPEC_FILE_NAME = "shortcutSpec.xml";
 
     // ------------------------------------------------------
     // spec file section keys

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksConsolePanel.java
@@ -1,11 +1,11 @@
 /*
  * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
+ *
  * http://izpack.org/
  * http://izpack.codehaus.org/
- * 
+ *
  * Copyright 2003 Jonathan Halliday
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -32,6 +32,7 @@ import com.izforge.izpack.api.exception.ResourceNotFoundException;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.handler.Prompt.Type;
 import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.console.AbstractConsolePanel;
 import com.izforge.izpack.installer.console.ConsolePanel;
 import com.izforge.izpack.installer.panel.PanelView;
@@ -55,7 +56,6 @@ public class TreePacksConsolePanel extends AbstractConsolePanel implements Conso
     private final InstallData installData;
 
     private PacksModel packsModel;
-    private static final String LANG_FILE_NAME = "packsLang.xml";
 
     private static final String REQUIRED = "TreePacksPanel.required";
     private static final String UNSELECTABLE = "TreePacksPanel.unselectable";
@@ -68,7 +68,7 @@ public class TreePacksConsolePanel extends AbstractConsolePanel implements Conso
     private static final String PROMPT = "TreePacksPanel.prompt";
     private static final String INVALID = "TreePacksPanel.invalid";
     private static final String REQUIRED_SPACE = "TreePacksPanel.space.required";
-    
+
     /**
      * Constructs a {@code TreePacksConsolePanel}.
      *
@@ -108,7 +108,7 @@ public class TreePacksConsolePanel extends AbstractConsolePanel implements Conso
 
         try
         {
-            messages = installData.getMessages().newMessages(LANG_FILE_NAME);
+            messages = installData.getMessages().newMessages(Resources.PACK_TRANSLATIONS_RESOURCE_NAME);
         }
         catch (ResourceNotFoundException exception)
         {
@@ -216,7 +216,7 @@ public class TreePacksConsolePanel extends AbstractConsolePanel implements Conso
         String dependencies = "";
         String children = "";
         String marker = " ";
-        
+
         if (packsModel.isChecked(row))
         {
             marker = "x";

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -70,7 +70,6 @@ public class TreePacksPanel extends IzPanel
     protected JScrollPane tableScroller;
 
     private Messages messages;
-    private static final String LANG_FILE_NAME = "packsLang.xml";
 
     private final Map<String, Pack> namesToPacks;
     private final Map<Pack, Integer> packsToRowNumbers;
@@ -666,7 +665,7 @@ public class TreePacksPanel extends IzPanel
                 try
                 {
                     java.net.URL url = new java.net.URL(
-                            webDir + "/langpacks/" + LANG_FILE_NAME + installData.getLocaleISO3());
+                            webDir + "/langpacks/" + Resources.PACK_TRANSLATIONS_RESOURCE_NAME + installData.getLocaleISO3());
                     langPackStream = new WebAccessor(null).openInputStream(url);
                     messages = new LocaleDatabase(langPackStream, messages, locales);
                     fallback = false;
@@ -682,7 +681,7 @@ public class TreePacksPanel extends IzPanel
             }
             if (fallback)
             {
-                messages = messages.newMessages(LANG_FILE_NAME);
+                messages = messages.newMessages(Resources.PACK_TRANSLATIONS_RESOURCE_NAME);
             }
         }
         catch (Throwable t)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
@@ -99,7 +99,7 @@ public class Config
     public Config(String path, Resources resources, InstallData installData, ObjectFactory factory,
                   Messages messages)
     {
-        IXMLParser parser = new XMLParser();
+        IXMLParser parser = new XMLParser(false);
 
         URL url = resources.getURL(path);
         this.path = url.getPath();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/UserInputPanelSpec.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/UserInputPanelSpec.java
@@ -48,6 +48,11 @@ public class UserInputPanelSpec
     public static final String SPEC_FILE_NAME = "userInputSpec.xml";
 
     /**
+     * The user input language pack resource name.
+     */
+    public static final String LANG_FILE_NAME = "userInputLang.xml";
+
+    /**
      * Panel element name.
      */
     public static final String PANEL = "panel";
@@ -66,11 +71,6 @@ public class UserInputPanelSpec
      * The platform-model matcher.
      */
     private final PlatformModelMatcher matcher;
-
-    /**
-     * The user input language pack resource name.
-     */
-    private static final String LANG_FILE_NAME = "userInputLang.xml";
 
     /**
      * The panel identifier attribute name

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/DirFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/file/DirFieldReader.java
@@ -45,9 +45,9 @@ public class DirFieldReader extends AbstractFileFieldReader implements DirFieldC
     }
 
     /**
-     * Determines if directories must exist.
+     * Determines whether the directory must in order to continue.
      *
-     * @return {@code true} if the directories must exist
+     * @return {@code true} if the directory must exist
      */
     public boolean getMustExist()
     {
@@ -55,9 +55,9 @@ public class DirFieldReader extends AbstractFileFieldReader implements DirFieldC
     }
 
     /**
-     * Determines if directories can be created if they don't exist.
+     * Determines whether the directory must be created if it doesn't exist.
      *
-     * @return {@code true} if directories can be created if they don't exist
+     * @return {@code true} if the directory must be created if they don't exist
      */
     public boolean getCreate()
     {

--- a/izpack-test/src/test/java/com/izforge/izpack/compiler/container/TestCompilationContainer.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/compiler/container/TestCompilationContainer.java
@@ -151,7 +151,7 @@ public class TestCompilationContainer extends CompilerContainer
         File out = new File(targetDir, "out" + Math.random() + ".jar");
         out.deleteOnExit();
         CompilerData data = new CompilerData(file.getAbsolutePath(), baseDir.getAbsolutePath(), out.getAbsolutePath(),
-                                             false);
+                                             false, true);
         container.addConfig("installFile", file.getAbsolutePath());
         container.addComponent(CompilerData.class, data);
         container.addComponent(File.class, out);

--- a/izpack-test/src/test/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeUnpackerTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeUnpackerTest.java
@@ -322,7 +322,7 @@ public class MultiVolumeUnpackerTest
         CompilerPathResolver resolver = Mockito.mock(CompilerPathResolver.class);
         MergeableResolver mergeableResolver = Mockito.mock(MergeableResolver.class);
         PackCompressor compressor = new DefaultPackCompressor();
-        CompilerData data = new CompilerData(null, baseDir.getPath(), installerJar.getPath(), true);
+        CompilerData data = new CompilerData(null, baseDir.getPath(), installerJar.getPath(), true, false);
         MultiVolumePackager packager = new MultiVolumePackager(properties, packagerListener, jar, mergeManager,
                                                                resolver, mergeableResolver, compressor, data);
         packager.setInfo(new Info());

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/console/PacksConsoleInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/console/PacksConsoleInstallationTest.java
@@ -80,8 +80,8 @@ public class PacksConsoleInstallationTest extends AbstractConsoleInstallationTes
         TestConsole console = installer.getConsole();
         console.addScript("HelloPanel", "1");
         console.addScript("TargetPanel", "\n", "1");
-        console.addScript("PacksPanel", "N", "\n", "1");
-        console.addScript("UserInputPanel", "1");
+        console.addScript("PacksPanel", "N", "N", "1");
+        console.addScript("UserInputPanel", "\n", "1");
 
         checkInstall(installer, getInstallData(), false, false);
     }

--- a/izpack-test/src/test/resources/samples/console/packs/install.xml
+++ b/izpack-test/src/test/resources/samples/console/packs/install.xml
@@ -1,45 +1,50 @@
-<?xml version="1.0" encoding="iso-8859-1" ?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <izpack:installation version="5.0"
-                     xmlns:izpack="http://izpack.org/schema/installation"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:izpack="http://izpack.org/schema/installation"
+  xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd"
+>
 
-    <info>
-        <appname>Test Installation</appname>
-        <appversion>1.0a</appversion>
-        <uninstaller write="no"/>
-    </info>
+  <info>
+    <appname>Test Installation</appname>
+    <appversion>1.0a</appversion>
+    <uninstaller write="no" />
+  </info>
 
-    <guiprefs width="640" height="480" resizable="yes"/>
+  <guiprefs width="640" height="480" resizable="yes" />
 
-    <locale>
-        <langpack iso3="eng"/>
-        <langpack iso3="deu"/>
-    </locale>
+  <locale>
+    <langpack iso3="eng" />
+    <langpack iso3="deu" />
+  </locale>
 
-    <resources>
-        <res id="userInputSpec.xml" src="userInput.xml"/>
-    </resources>
+  <resources>
+    <res id="userInputSpec.xml" src="userInput.xml" />
+  </resources>
 
-    <panels>
-        <panel classname="HelloPanel"/>
-        <panel classname="TargetPanel"/>
-        <panel classname="PacksPanel"/>
-        <panel classname="UserInputPanel" id="panel.all"/>
-        <panel classname="UserInputPanel" id="panel.pack2"/>
-        <panel classname="InstallPanel"/>
-        <panel classname="FinishPanel"/>
-    </panels>
+  <panels>
+    <panel classname="HelloPanel" />
+    <panel classname="TargetPanel" />
+    <panel classname="PacksPanel" />
+    <panel classname="UserInputPanel" id="panel.all" />
+    <panel classname="UserInputPanel" id="panel.pack2_3" />
+    <panel classname="InstallPanel" />
+    <panel classname="FinishPanel" />
+  </panels>
 
-    <packs>
-        <pack name="Pack 1" required="yes">
-            <description>Pack 1</description>
-            <file src="file_1.txt" targetdir="$INSTALL_PATH"/>
-        </pack>
-        <pack name="Pack 2" required="no">
-            <description>Pack 2</description>
-            <file src="file_2.txt" targetdir="$INSTALL_PATH"/>
-        </pack>
-    </packs>
+  <packs>
+    <pack name="Pack 1" required="yes">
+      <description>Pack 1</description>
+      <file src="file_1.txt" targetdir="$INSTALL_PATH" />
+    </pack>
+    <pack name="Pack 2" required="no">
+      <description>Pack 2</description>
+      <file src="file_2.txt" targetdir="$INSTALL_PATH" />
+    </pack>
+    <pack name="Pack 3" required="no">
+      <description>Pack 3</description>
+      <file src="file_3.txt" targetdir="$INSTALL_PATH" />
+    </pack>
+  </packs>
 
 </izpack:installation>

--- a/izpack-test/src/test/resources/samples/console/packs/userInput.xml
+++ b/izpack-test/src/test/resources/samples/console/packs/userInput.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <izpack:userinput version="5.0"
-    xmlns:izpack="http://izpack.org/schema/userinput"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://izpack.org/schema/userinput http://izpack.org/schema/5.0/izpack-userinput-5.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:izpack="http://izpack.org/schema/userinput"
+  xsi:schemaLocation="http://izpack.org/schema/userinput http://izpack.org/schema/5.0/izpack-userinput-5.0.xsd"
+>
 
-    <panel id="panel.all" summaryKey="key.precheck.title">
-        <field id="panel.all.title" txt="Common Panel" type="title"/>
-    </panel>
+  <panel id="panel.all" summaryKey="key.precheck.title">
+    <field id="panel.all.title" txt="Common Panel" type="title" />
+  </panel>
 
-    <panel id="panel.pack2">
-        <createForPack name="Pack 2"/>
-        <field id="panel.pack2.title" txt="Panel for Pack 2" type="title"/>
-        <field type="dir" variable="subdir">
-            <spec create="false" id="subdir.label" mustExist="false" size="25" txt="Subdirectory:"/>
-            <validator
-                class="com.izforge.izpack.panels.userinput.validator.NotEmptyValidator"
-                id="subdir.error.empty" txt="This path is mandatory!"/>
-        </field>
-    </panel>
+  <panel id="panel.pack2_3">
+    <createForPack name="Pack 2" />
+    <createForPack name="Pack 3" />
+    <field id="panel.pack2_3.title" txt="Panel for packs 2/3" type="title" />
+    <field type="dir" variable="subdir">
+      <spec create="false" id="subdir.label" mustExist="false"
+        size="25" txt="Subdirectory:" />
+      <validator
+        class="com.izforge.izpack.panels.userinput.validator.NotEmptyValidator"
+        id="subdir.error.empty" txt="This path is mandatory!" />
+    </field>
+  </panel>
 
 </izpack:userinput>

--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4</version>
+          <version>2.6</version>
         </plugin>
         <!-- Testing -->
         <plugin>
@@ -608,6 +608,7 @@
             </execution>
           </executions>
           <configuration>
+            <encoding>UTF-8</encoding>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>


### PR DESCRIPTION
This is an implementation of [IZPACK-1300](https://izpack.atlassian.net/browse/IZPACK-1300).

In the past there have been many reports and discussions caused by using elements, attributes and attribute values in one ore more of the following XML descriptors:
* main installation descriptors:
  * `install.xml`
  * `conditions.xml` (external conditions)
* Language pack resources:
  * `CustomLangPack.xml`
  * `userInputLang.xml`
  * `packsLang.xml`
* `shortcutSpec.xml` resource
* `customicons.xml` resource
* `userInputSpec.xml` resource
* `AntActionsSpec.xml` resource
* `ConfigurationActionsSpec.xml` resource
* `RegistrySpec.xml` resource
* `ProcessPanel.Spec.xml` resource

the compiler _ignored and did not complain as wrong_. In worst case it came just from a wrong letter case, like using `defaultValue` instead of `defaultvalue` as attribute name.

Beginning from 5.0, for all the above descriptors there are XSDs (XML Schema Definition language v1.0), available on the website for online validation and distributed with the project installer.

It's high time to activate the validation for the compiling process and force the verification of all of these descriptors to avoid ambiguous XML. Validation should be done based on the built-in XSD resources to avoid network access during the validation.

This should be ideally non-breaking for existing environments and can be scheduled within the current 5.0 branch. For the case of trouble with some incomplete XSD description this feature should be made optional, but activated by default for compiling launched by different facilities, preferably by the Izpack Maven plugin.

Beyond this developers should be forced to adapt the XSD along with the current implementation and as much as possible unit and integration tests testing or just using parts of the compiler will have the schema validation activated.

Note: This is just a small step towards a better compiling implementation. The pitfall for IzPack is currently that XML Schema 1.0 does not cleanly cover the descriptors used in IzPack. The problematic elements here are:
- `//conditions/condition`
- `//dynamicvariables/variable`

which have alternatives due to the setting of the `type` attribute. XSD 1.0 knows just the built-in `xsi:type` for switching to different subtypes of conditions or dynamic variables, XSD 1.1 provides the `xs:alternative` tag which allows to use a custom attribute name like our `type`. So why not using XSD 1.1 directly? Simply it is still in W3C recommendation state and not really delivered in any JDK, even not in JDK 9. There is just a beta version of Xerces 2.11.0 especially compiled with XSD 1.1 support, or you're forced to use Saxon. Furthermore, there is still no JAXB support for XSD 1.1, and migrating to JAXB along with a big compiler refactoring would be the next logical step here. So we stuck at XSD 1.0 and must still keep many semantic checks in the code.