### PR TITLE
Update Librarian.java

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/Librarian.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Librarian.java
@@ -184,8 +184,13 @@ public class Librarian implements CleanupClient
      */
     protected URL getResourcePath(String name)
     {
-        String resource = "/" + NATIVE + name + extension;
-        return getClass().getResource(resource);
+        String resource = "/" + NATIVE + "/izpack/" + name + extension;
+        URL url = getClass().getResource(resource);
+        if (url == null) {
+            resource = "/" + NATIVE + "/3rdparty/" + name + extension;
+            url = getClass().getResource(resource);
+        }
+        return url;
     }
 
     /**


### PR DESCRIPTION
The native DLL files were moved from the NATIVE package further down to NATIVE/izpack or NATIVE/3rdparty. So changed the getResourcePath method to seek these two sub-package.