### PR TITLE
IzPack 5.0.7 - main branch

### DIFF
--- a/izpack-compiler/pom.xml
+++ b/izpack-compiler/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>picocontainer</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -62,7 +62,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLParser;

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/helper/CompilerHelper.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/helper/CompilerHelper.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.jar.JarInputStream;
 import java.util.zip.ZipEntry;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 /**

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -449,6 +449,9 @@ public abstract class PackagerBase implements IPackager
         mergeManager.addResourceToMerge("com/coi/tools/");
         mergeManager.addResourceToMerge("org/apache/tools/zip/");
         mergeManager.addResourceToMerge("org/apache/commons/io/FilenameUtils.class");
+        mergeManager.addResourceToMerge("org/apache/commons/lang3/JavaVersion.class");
+        mergeManager.addResourceToMerge("org/apache/commons/lang3/SystemUtils.class");
+        mergeManager.addResourceToMerge("org/apache/commons/lang3/text/WordUtils.class");
         mergeManager.addResourceToMerge("jline/");
         mergeManager.addResourceToMerge("org/fusesource/");
         mergeManager.addResourceToMerge("META-INF/native/");

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-antactions-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-antactions-5.0.xsd
@@ -71,12 +71,12 @@
                 of installation with what environment.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="property" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="propertyfile" type="propertyFileType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="target" type="targetType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="uninstall_target" type="uninstallTargetType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="order" use="required">
             <xs:simpleType>
                 <xs:restriction base="xs:NMTOKEN">

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-compilation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-compilation-5.0.xsd
@@ -26,10 +26,10 @@
 
     <xs:element name="compilation">
         <xs:complexType>
-            <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
                 <xs:element name="global" type="globalType"/>
                 <xs:element name="jobs" type="jobsType"/>
-            </xs:sequence>
+            </xs:choice>
             <xs:attribute name="version" type="xs:string" fixed="5.0"/>
         </xs:complexType>
     </xs:element>
@@ -58,10 +58,10 @@
     </xs:complexType>
 
     <xs:complexType name="jobsType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="classpath" type="classpathType" minOccurs="0"/>
             <xs:element name="job" type="jobType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
     </xs:complexType>
 
     <xs:complexType name="classpathType">
@@ -71,7 +71,7 @@
 
     <xs:complexType name="jobType">
         <xs:choice>
-            <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
                 <xs:element name="packdependency" minOccurs="0" maxOccurs="unbounded">
                     <xs:complexType>
                         <xs:attribute name="name" type="xs:string" use="required"/>
@@ -90,7 +90,7 @@
                         </xs:complexType>
                     </xs:element>
                 </xs:choice>
-            </xs:sequence>
+            </xs:choice>
         </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-configurationactions-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-configurationactions-5.0.xsd
@@ -46,20 +46,20 @@
     </xs:complexType>
 
     <xs:complexType name="configurationActionType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="variable" type="types:dynamicVariableType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="configurableset" type="configurableSetType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="configurable" type="configurableType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="order" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="configurableType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="xpathproperty" type="xpathPropertyType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="entry" type="entryType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="fileset" type="fileSetType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="type" use="required">
             <xs:simpleType>
                 <xs:restriction base="xs:string">
@@ -88,10 +88,10 @@
     </xs:complexType>
 
     <xs:complexType name="configurableSetType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="fileset" type="fileSetType"/>
             <xs:element name="mapper" type="mapperType"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="type" use="required">
             <xs:simpleType>
                 <xs:restriction base="xs:string">
@@ -116,10 +116,10 @@
     </xs:complexType>
 
     <xs:complexType name="fileSetType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="include" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="exclude" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="dir" type="xs:string" use="required"/>
         <xs:attribute name="casesensitive" type="xs:boolean" use="optional"/>
         <xs:attribute name="defaultexcludes" type="xs:boolean" use="optional"/>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-icons-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-icons-5.0.xsd
@@ -28,10 +28,10 @@
 
     <xs:element name="icons">
         <xs:complexType>
-            <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
                 <xs:element name="icon" type="iconType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="sysicon" type="iconType" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
+            </xs:choice>
             <xs:attribute name="version" type="xs:string" fixed="5.0" use="required"/>
         </xs:complexType>
     </xs:element>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -192,7 +192,7 @@
     <!-- GUI preferences                                                                                        -->
     <!--                                                                                                        -->
     <xs:complexType name="guiPrefsType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="modifier" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:attribute name="key" type="xs:string" use="required"/>
@@ -201,15 +201,15 @@
             </xs:element>
             <xs:element name="laf" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
-                    <xs:sequence>
+                    <xs:choice maxOccurs="unbounded">
                         <xs:element name="param" type="nameValueType" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:sequence>
+                    </xs:choice>
                     <xs:attribute name="name" type="xs:string" use="required"/>
                 </xs:complexType>
             </xs:element>
             <xs:element name="splash" type="xs:string" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="height" type="xs:string"/>
         <xs:attribute name="resizable" type="xs:string"/>
         <xs:attribute name="width" type="xs:string"/>
@@ -340,7 +340,7 @@
     </xs:attributeGroup>
 
     <xs:complexType name="panelType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="configuration" minOccurs="0">
                 <xs:complexType>
                     <xs:sequence>
@@ -388,7 +388,7 @@
                     <xs:attribute name="src" type="xs:string" use="required"/>
                 </xs:complexType>
             </xs:element>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute type="xs:string" name="classname" use="optional"/>
         <xs:attribute type="xs:string" name="id" use="optional"/>
         <xs:attribute type="xs:string" name="encoding" use="optional"/>
@@ -456,12 +456,12 @@
     <!-- File sets                                                                                              -->
     <!--                                                                                                        -->
     <xs:complexType name="fileSetTypeDisk">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="include" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="exclude" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="additionaldata" type="additionalDataType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="dir" type="xs:string" use="required"/>
         <xs:attribute name="includes" type="xs:string" use="optional"/>
         <xs:attribute name="excludes" type="xs:string" use="optional"/>
@@ -473,21 +473,21 @@
     </xs:complexType>
 
     <xs:complexType name="fileSetTypePack">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="include" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="exclude" type="types:includeExcludeType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="includes" type="xs:string" use="optional"/>
         <xs:attribute name="excludes" type="xs:string" use="optional"/>
         <xs:attribute name="targetdir" type="xs:string" use="optional" default="${INSTALL_PATH}"/>
     </xs:complexType>
 
     <xs:complexType name="fileType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="condition" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="additionaldata" type="additionalDataType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="src" type="xs:string" use="required"/>
         <xs:attribute name="targetdir" type="xs:string" use="required"/>
         <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
@@ -500,11 +500,11 @@
     </xs:complexType>
 
     <xs:complexType name="singleFileType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="condition" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="additionaldata" type="additionalDataType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="src" type="xs:string" use="required"/>
         <xs:attribute name="target" type="xs:string" use="required"/>
         <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
@@ -514,10 +514,10 @@
     </xs:complexType>
 
     <xs:complexType name="parsableType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="fileset" type="fileSetTypePack" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="targetfile" type="xs:string" use="optional"/>
         <xs:attribute name="type" type="substitutionType" use="optional" default="plain"/>
         <xs:attribute name="encoding" type="xs:string" use="optional"/>
@@ -525,7 +525,7 @@
     </xs:complexType>
 
     <xs:complexType name="executableType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="fileset" type="fileSetTypePack" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="args" minOccurs="0">
                 <xs:complexType>
@@ -539,7 +539,7 @@
                 </xs:complexType>
             </xs:element>
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="targetfile" type="xs:string" use="optional"/>
         <xs:attribute name="stage" use="optional" default="never">
             <xs:simpleType>
@@ -555,10 +555,10 @@
     </xs:complexType>
 
     <xs:complexType name="updateCheckType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="include" type="types:includeExcludeType" maxOccurs="unbounded" minOccurs="0"/>
             <xs:element name="exclude" type="types:includeExcludeType" maxOccurs="unbounded" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
     </xs:complexType>
 
     <xs:simpleType name="overrideType">

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-processing-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-processing-5.0.xsd
@@ -32,23 +32,23 @@
 
     <xs:element name="processing">
         <xs:complexType>
-            <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
                 <xs:element name="logfiledir" type="xs:string" minOccurs="0"/>
                 <xs:element name="job" type="jobType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="onFail" type="onFailType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="onSuccess" type="onSuccessType" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
+            </xs:choice>
             <xs:attribute name="version" type="xs:string" fixed="5.0"/>
         </xs:complexType>
     </xs:element>
 
     <xs:complexType name="jobType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="executeForPack" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="executefile" type="executeFileType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="executeclass" type="executeClassType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
         <xs:attribute name="catch" type="xs:boolean" use="optional" default="false"/>
@@ -56,7 +56,7 @@
     </xs:complexType>
 
     <xs:complexType name="executeFileType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="arg" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="env" minOccurs="0" maxOccurs="unbounded">
                 <xs:simpleType>
@@ -65,7 +65,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="workingDir" type="xs:string" use="optional"/>
     </xs:complexType>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-registry-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-registry-5.0.xsd
@@ -44,10 +44,10 @@
                 actions are performed only for packs which are selected for installation.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="key" type="keyType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="value" type="valueType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
 
@@ -88,10 +88,10 @@
                 by the setting. Only one setting of the types are valid.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="bin" type="binType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="multi" type="multiType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>Name of the value to be set or modified</xs:documentation>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-shortcuts-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-shortcuts-5.0.xsd
@@ -32,14 +32,14 @@
 
     <xs:element name="shortcuts">
         <xs:complexType>
-            <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
                 <xs:element name="skipIfNotSupported" minOccurs="0"/>
                 <xs:element name="defaultCurrentUser" minOccurs="0"/>
                 <xs:element name="notSupported" minOccurs="0"/>
                 <xs:element name="lateShortcutInstall" minOccurs="0"/>
                 <xs:element name="programGroup" type="programGroupType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="shortcut" type="shortcutType" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
+            </xs:choice>
             <xs:attribute name="version" type="xs:string" fixed="5.0" use="required"/>
         </xs:complexType>
     </xs:element>
@@ -53,14 +53,14 @@
     </xs:complexType>
 
     <xs:complexType name="shortcutType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="os" type="types:osType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="createForPack" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:attribute name="name" type="xs:string" use="required"/>
                 </xs:complexType>
             </xs:element>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
         <xs:attribute name="subgroup" type="xs:string" use="optional"/>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -186,6 +186,7 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
+        <xs:attribute type="xs:boolean" name="unset" use="optional" default="false"/>
     </xs:complexType>
 
     <xs:complexType name="dynamicVariableFiltersType">

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -37,18 +37,18 @@
 
     <xs:element name="userinput">
         <xs:complexType>
-            <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
                 <xs:element name="variable" type="types:variableType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="panel" minOccurs="0" maxOccurs="unbounded">
                     <xs:complexType>
-                        <xs:sequence>
+                        <xs:choice maxOccurs="unbounded">
                             <xs:element minOccurs="0" maxOccurs="unbounded" name="createForPack">
                                 <xs:complexType>
                                     <xs:attribute name="name" type="xs:string" use="required"/>
                                 </xs:complexType>
                             </xs:element>
                             <xs:element name="field" type="fieldType" maxOccurs="unbounded"/>
-                        </xs:sequence>
+                        </xs:choice>
                         <xs:attribute name="id" type="xs:string" use="required"/>
                         <xs:attribute name="topBuffer" type="xs:integer" use="optional" default="25">
                             <xs:annotation>
@@ -116,7 +116,7 @@
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
-            </xs:sequence>
+            </xs:choice>
             <xs:attribute name="version" type="xs:string" fixed="5.0" use="required"/>
         </xs:complexType>
     </xs:element>

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
@@ -147,5 +147,12 @@ public abstract class AbstractConsolePanel implements ConsolePanel
     public void createInstallationRecord(IXMLElement rootElement)
     {
         // Default method, override to record panel contents
-    };
+    }
+
+    @Override
+    public boolean handlePanelValidationResult(boolean valid)
+    {
+        // Do nothing by default - to be overwritten in console panel implementations if necessary
+        return valid;
+    }    ;
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
@@ -162,7 +162,7 @@ public class ConsoleInstaller implements InstallerBase
                 panels.setAction(action);
                 while (panels.hasNext())
                 {
-                    success = panels.next();
+                    success = panels.getView().handlePanelValidationResult(panels.next());
                     if (!success)
                     {
                         break;
@@ -170,7 +170,8 @@ public class ConsoleInstaller implements InstallerBase
                 }
                 if (success)
                 {
-                    success = panels.isValid(); // last panel needs to be validated
+                    // last panel needs to be validated
+                    success = panels.getView().handlePanelValidationResult(panels.isValid());
                     if (success)
                     {
                         success = action.complete();

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
@@ -162,7 +162,8 @@ public class ConsoleInstaller implements InstallerBase
                 panels.setAction(action);
                 while (panels.hasNext())
                 {
-                    success = panels.getView().handlePanelValidationResult(panels.next());
+                    success = panels.next();
+                    success = panels.getView().handlePanelValidationResult(success);
                     if (!success)
                     {
                         break;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanel.java
@@ -72,4 +72,15 @@ public interface ConsolePanel
      * @param rootElement
      */
     public void createInstallationRecord(IXMLElement rootElement);
+
+    /**
+     * Do some user interaction on the console depending on the result of a panel validation.
+     * This is necessary to inform the user on the console about the forbidden progress and to prevent failing the
+     * installer in case the panel data validator treats the data to be wrong. Instead the user should be asked whether
+     * to redisplay the input fields to fix the wrong values.
+     * @param valid whether the validation has been successful
+     * @return false - let the installer fail, true - let the installer continue to run
+     * @see com.izforge.izpack.api.installer.DataValidator
+     */
+    boolean handlePanelValidationResult(boolean valid);
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsolePanels.java
@@ -51,7 +51,8 @@ public class ConsolePanels extends AbstractPanels<ConsolePanelView, ConsolePanel
      * Constructs a {@code ConsolePanels}.
      *
      * @param panels    the panels
-     * @param variables the variables. These are refreshed prior to each panel switch
+     * @param container the container to get instances from
+     * @param installData install data
      */
     public ConsolePanels(List<ConsolePanelView> panels, Container container, InstallData installData)
     {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
@@ -458,7 +458,6 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
      * validation or not.
      *
      * @param validator   the validator to evaluate
-     * @param index   the index in the list of validators for finding its appropriate validator condition
      * @param installData the installation data
      * @return {@code true} if the validator evaluated successfully, or with a warning that the user chose to skip;
      *         otherwise {@code false}

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanels.java
@@ -472,6 +472,7 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
     }
 
     /**
+     * TODO: validate parameter not used - refactor this
      * Switches panels.
      *
      * @param newIndex the index of the new panel

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
@@ -100,14 +100,14 @@ public class UserInputConsolePanel extends AbstractConsolePanel
     /**
      * Constructs an {@code UserInputConsolePanel}.
      *
-     * @param panel     the panel meta-data
      * @param resources the resources
      * @param factory   the object factory
      * @param rules     the rules
      * @param matcher   the platform-model matcher
      * @param console   the console
      * @param prompt    the prompt
-     * @param panel     the parent panel/view
+     * @param panelView     the parent panel/view
+     * @param installData   the install data
      */
     public UserInputConsolePanel(Resources resources, ObjectFactory factory,
                                  RulesEngine rules, PlatformModelMatcher matcher, Console console, Prompt prompt,
@@ -122,7 +122,6 @@ public class UserInputConsolePanel extends AbstractConsolePanel
         this.console = console;
         this.prompt = prompt;
 
-        //FIXME Initialize conditions like in UserInputPanel
         UserInputPanelSpec model = new UserInputPanelSpec(resources, installData, factory, matcher);
         Panel panel = getPanel();
         IXMLElement spec = model.getPanelSpec(panel);
@@ -314,5 +313,15 @@ public class UserInputConsolePanel extends AbstractConsolePanel
     public void createInstallationRecord(IXMLElement rootElement)
     {
         new UserInputPanelAutomationHelper(fields).createInstallationRecord(installData, rootElement);
+    }
+
+    @Override
+    public boolean handlePanelValidationResult(boolean valid)
+    {
+        if (!valid)
+        {
+            return promptRerunPanel(installData, console);
+        }
+        return true;
     }
 }

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/ExecutableFileTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/ExecutableFileTest.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/IzpackInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/IzpackInstallationTest.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.fest.swing.fixture.DialogFixture;
 import org.fest.swing.fixture.FrameFixture;
 import org.fest.swing.timing.Timeout;

--- a/izpack-util/pom.xml
+++ b/izpack-util/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>jline</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom2</artifactId>
             <version>2.0.5</version>

--- a/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
@@ -365,6 +365,10 @@ public class Console
                 break;
             }
         }
+        catch (jline.console.UserInterruptException e)
+        {
+            throw new UserInterruptException("CTRL-C pressed", e);
+        }
         catch (IOException e)
         {
             result = null;

--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,9 @@
 
       <!-- Commons apache -->
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.4</version>
       </dependency>
 
       <dependency>
@@ -360,7 +360,7 @@
       <dependency>
         <groupId>jline</groupId>
         <artifactId>jline</artifactId>
-        <version>2.12</version>
+        <version>2.13</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Current changes:
- XSD fix: Added missing optional 'unset' attribute to dynamic variable declaration. This has been also applied to the website: http://izpack.org/schema/5.0/izpack-types-5.0.xsd.
- [IZPACK-1307](https://izpack.atlassian.net/browse/IZPACK-1307) - New LicenceConsolePanel pagination does not work reliably for long lines
  - Fixed formatting
  - Added word breaks for license text in console mode depending on the terminal width
- Replaced commons-lang 2.6 by commons-lang3 3.4 for new framework features
- Increased JLine version to latest 2.13
- [IZPACK-1302](https://izpack.atlassian.net/browse/IZPACK-1302) - Bad message from console installer when pressing CTRL-C in TargetPanel
