### PR TITLE
IZPACK-1301 - Ensure that installData is set on nested conditions bef…

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/AndCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/AndCondition.java
@@ -67,6 +67,9 @@ public class AndCondition extends ConditionWithMultipleOperands
         boolean result = true;
         for (Condition condition : nestedConditions)
         {
+            if (condition.getInstallData() == null) {
+                condition.setInstallData(this.getInstallData());
+            }
             result = result && condition.isTrue();
         }
         return result;

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/NotCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/NotCondition.java
@@ -85,7 +85,13 @@ public class NotCondition extends ConditionReference
     public boolean isTrue()
     {
         Condition condition = getReferencedCondition();
-        return condition != null && !condition.isTrue();
+        if (condition != null) {
+            if (condition.getInstallData() == null) {
+                condition.setInstallData(this.getInstallData());
+            }
+            return !condition.isTrue();
+        }
+        return false;
     }
 
     @Override

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/OrCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/OrCondition.java
@@ -65,6 +65,9 @@ public class OrCondition extends ConditionWithMultipleOperands
         boolean result = false;
         for (Condition condition : nestedConditions)
         {
+            if (condition.getInstallData() == null) {
+                condition.setInstallData(this.getInstallData());
+            }
             result = result || condition.isTrue();
         }
         return result;

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/XorCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/logic/XorCondition.java
@@ -65,6 +65,9 @@ public class XorCondition extends OrCondition
         boolean marked = false;
         for (Condition condition : nestedConditions)
         {
+            if (condition.getInstallData() == null) {
+                condition.setInstallData(this.getInstallData());
+            }
             boolean currentResult = condition.isTrue();
             if (!marked)
             {


### PR DESCRIPTION
…ore calling isTrue

This fixes [IZPACK-1301 NPE Exception when using compound conditions with pack selection
](https://izpack.atlassian.net/browse/IZPACK-1301)

This just follows the pattern from RulesEngineImpl of setting the install data on the condition if it has not yet been set when the condition is evaluated inside a logic condition.