### PR TITLE
IZPACK-1185 - Substance L&F not compatible with Java 8

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/LookAndFeels.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/LookAndFeels.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public enum LookAndFeels
 {
-    LIQUID("liquid"), LOOKS("looks"), SUBSTANCE("substance"), NIMBUS("nimbus"), KUNSTSTOFF("kunststoff");
+    LOOKS("looks"), SUBSTANCE("substance"), NIMBUS("nimbus"), KUNSTSTOFF("kunststoff");
 
     private String name;
 

--- a/izpack-compiler/pom.xml
+++ b/izpack-compiler/pom.xml
@@ -84,7 +84,7 @@
 
         <!-- lafs -->
         <dependency>
-            <groupId>org.java.net.substance</groupId>
+            <groupId>com.github.insubstantial</groupId>
             <artifactId>substance</artifactId>
         </dependency>
         <dependency>

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -511,9 +511,6 @@ public class CompilerConfig extends Thread
                     case KUNSTSTOFF:
                         mergeableList = pathResolver.getMergeableFromPackageName("com/incors/plaf");
                         break;
-                    case LIQUID:
-                        mergeableList = pathResolver.getMergeableFromPackageName("com/birosoft/liquid/");
-                        break;
                     case LOOKS:
                         mergeableList = pathResolver.getMergeableFromPackageName("com/jgoodies/looks");
                         break;

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -519,7 +519,6 @@ public class CompilerConfig extends Thread
                         break;
                     case SUBSTANCE:
                         mergeableList = pathResolver.getMergeableJarFromPackageName("org/pushingpixels");
-                        mergeableList.addAll(pathResolver.getMergeableFromPackageName("nanoxml"));
                         break;
                     case NIMBUS:
                         // Nimbus was included in JDK 6u10, and in JDK7 changed packages.

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
@@ -42,8 +42,6 @@ public class InstallerGui
     {
         final InstallerContainer applicationComponent = new GUIInstallerContainer();
         final Container installerContainer = applicationComponent.getComponent(Container.class);
-        final SplashScreen splashScreen = installerContainer.getComponent(SplashScreen.class);
-        splashScreen.displaySplashScreen();
 
         SwingUtilities.invokeLater(new Runnable()
         {
@@ -51,6 +49,8 @@ public class InstallerGui
             {
                 try
                 {
+                    final SplashScreen splashScreen = installerContainer.getComponent(SplashScreen.class);
+                    splashScreen.displaySplashScreen();
 
                     if (mediaPath != null)
                     {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/GUIInstallerContainer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/GUIInstallerContainer.java
@@ -3,9 +3,9 @@ package com.izforge.izpack.installer.container.impl;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 
-import javax.swing.ImageIcon;
-import javax.swing.JFrame;
+import javax.swing.*;
 
+import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.installer.gui.SplashScreen;
 import org.picocontainer.Characteristics;
 import org.picocontainer.MutablePicoContainer;
@@ -89,32 +89,31 @@ public class GUIInstallerContainer extends InstallerContainer
      * @param pico the container
      */
     @Override
-    protected void resolveComponents(MutablePicoContainer pico)
+    protected void resolveComponents(final MutablePicoContainer pico)
     {
         super.resolveComponents(pico);
         InstallData installdata = pico.getComponent(InstallData.class);
         pico
-                .addConfig("title", getTitle(installdata)) // Configuration of title parameter in InstallerFrame
-                .addConfig("frame", initFrame());          // Configuration of frame parameter in languageDialog
+                .addConfig("title", getTitle(installdata)); // Configuration of title parameter in InstallerFrame
 
-        InstallerFrame frame = pico.getComponent(InstallerFrame.class);
-        IUnpacker unpacker = pico.getComponent(IUnpacker.class);
-        frame.setUnpacker(unpacker);
-    }
+        try
+        {
+            SwingUtilities.invokeAndWait(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    InstallerFrame frame = pico.getComponent(InstallerFrame.class);
+                    IUnpacker unpacker = pico.getComponent(IUnpacker.class);
+                    frame.setUnpacker(unpacker);
+                }
+            });
+        }
+        catch (Exception exception)
+        {
+            throw new IzPackException(exception);
+        }
 
-    private JFrame initFrame()
-    {
-        IconsDatabase icons = getComponent(IconsDatabase.class);
-        // Dummy Frame
-        JFrame frame = new JFrame();
-        ImageIcon imageIcon = icons.get("JFrameIcon");
-        frame.setIconImage(imageIcon.getImage());
-
-        Dimension frameSize = frame.getSize();
-        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        frame.setLocation((screenSize.width - frameSize.width) / 2,
-                          (screenSize.height - frameSize.height) / 2 - 10);
-        return frame;
     }
 
     private String getTitle(InstallData installData)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
@@ -311,9 +311,9 @@ public class GUIInstallDataProvider extends AbstractInstallDataProvider
         ClassLoader classLoader = (cl != null) ? cl : JPanel.class.getClassLoader();
         Class aClass = (Class) defaults.get(uiClassName);
 
-        logger.info("PanelUI : " + uiClassName);
-        logger.info("ClassLoader : " + classLoader);
-        logger.info("Cached class : " + aClass);
+        logger.fine("PanelUI: " + uiClassName);
+        logger.fine("ClassLoader: " + classLoader);
+        logger.fine("Cached class: " + aClass);
         if (aClass != null)
         {
             return;
@@ -321,23 +321,23 @@ public class GUIInstallDataProvider extends AbstractInstallDataProvider
 
         if (classLoader == null)
         {
-            logger.info("Using system loader to load " + uiClassName);
+            logger.fine("Using system loader to load " + uiClassName);
             aClass = Class.forName(uiClassName, true, Thread.currentThread().getContextClassLoader());
-            logger.info("Done loading");
+            logger.fine("Done loading");
         }
         else
         {
-            logger.info("Using custom loader to load " + uiClassName);
+            logger.fine("Using custom loader to load " + uiClassName);
             aClass = classLoader.loadClass(uiClassName);
-            logger.info("Done loading");
+            logger.fine("Done loading");
         }
         if (aClass != null)
         {
-            logger.info("Loaded class : " + aClass.getName());
+            logger.fine("Loaded class: " + aClass.getName());
         }
         else
         {
-            logger.info("Couldn't load the class");
+            logger.fine("Couldn't load the class");
         }
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
@@ -198,32 +198,6 @@ public class GUIInstallDataProvider extends AbstractInstallDataProvider
             return;
         }
 
-        // Liquid (http://liquidlnf.sourceforge.net/)
-        if ("liquid".equals(lookAndFeelName))
-        {
-            UIManager.setLookAndFeel("com.birosoft.liquid.LiquidLookAndFeel");
-
-            Map<String, String> params = installData.guiPrefs.lookAndFeelParams.get(lookAndFeelName);
-            if (params.containsKey("decorate.frames"))
-            {
-                String value = params.get("decorate.frames");
-                if ("yes".equals(value))
-                {
-                    JFrame.setDefaultLookAndFeelDecorated(true);
-                }
-            }
-            if (params.containsKey("decorate.dialogs"))
-            {
-                String value = params.get("decorate.dialogs");
-                if ("yes".equals(value))
-                {
-                    JDialog.setDefaultLookAndFeelDecorated(true);
-                }
-            }
-
-            return;
-        }
-
         // Metouia (http://mlf.sourceforge.net/)
         if ("metouia".equals(lookAndFeelName))
         {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/language/LanguageDialog.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/language/LanguageDialog.java
@@ -18,13 +18,17 @@
  */
 package com.izforge.izpack.installer.language;
 
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.GraphicsEnvironment;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.Point;
+import com.izforge.izpack.api.GuiId;
+import com.izforge.izpack.api.exception.ResourceException;
+import com.izforge.izpack.api.resource.Locales;
+import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.gui.IconsDatabase;
+import com.izforge.izpack.installer.container.provider.AbstractInstallDataProvider;
+import com.izforge.izpack.installer.data.GUIInstallData;
+import com.izforge.izpack.installer.requirement.RequirementsChecker;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
@@ -35,28 +39,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.swing.GrayFilter;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.ListCellRenderer;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
-
-import com.izforge.izpack.api.GuiId;
-import com.izforge.izpack.api.exception.ResourceException;
-import com.izforge.izpack.api.resource.Locales;
-import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.installer.container.provider.AbstractInstallDataProvider;
-import com.izforge.izpack.installer.data.GUIInstallData;
-import com.izforge.izpack.installer.requirement.RequirementsChecker;
 
 /**
  * Used to prompt the user for the language. Languages can be displayed in iso3 or the native
@@ -70,11 +52,6 @@ import com.izforge.izpack.installer.requirement.RequirementsChecker;
 public class LanguageDialog extends JDialog
 {
     private static final long serialVersionUID = 3256443616359887667L;
-
-    /**
-     * The parent frame.
-     */
-    private final JFrame frame;
 
     /**
      * The installation data.
@@ -115,17 +92,18 @@ public class LanguageDialog extends JDialog
     /**
      * Constructs a {@code LanguageDialog}.
      *
-     * @param frame        the parent frame
+     * //@param frame        the parent frame
      * @param resources    the resources
      * @param locales      the locales
      * @param installData  the installation data
      * @param requirements the installation requirements
      */
-    public LanguageDialog(JFrame frame, Resources resources, Locales locales, GUIInstallData installData,
+    public LanguageDialog(Resources resources, Locales locales, GUIInstallData installData, IconsDatabase icons,
                           RequirementsChecker requirements)
     {
-        super(frame);
-        this.frame = frame;
+        super();
+        ImageIcon imageIcon = icons.get("JFrameIcon");
+        super.getOwner().setIconImage(imageIcon.getImage());
         this.resources = resources;
         this.locales = locales;
         this.installData = installData;
@@ -152,7 +130,7 @@ public class LanguageDialog extends JDialog
             propagateLocale(codeOfUniqueLanguage);
             break;
         default:
-            frame.setVisible(false);
+            super.getOwner().setVisible(false);
             setVisible(true);
         }
 

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/language/LanguageDialogTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/language/LanguageDialogTest.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 
 import javax.swing.JFrame;
 
+import com.izforge.izpack.gui.IconsDatabase;
 import org.fest.swing.fixture.DialogFixture;
 import org.hamcrest.core.Is;
 import org.junit.After;
@@ -69,6 +70,11 @@ public class LanguageDialogTest
     private final Locales locales;
 
     /**
+     * The locales.
+     */
+    private final IconsDatabase icons;
+
+    /**
      * The dialog fixture.
      */
     private DialogFixture fixture;
@@ -80,11 +86,12 @@ public class LanguageDialogTest
      * @param installData the installation data
      * @param locales     the locales. Must contain locales "eng" and "fra"
      */
-    public LanguageDialogTest(Resources resources, GUIInstallData installData, Locales locales)
+    public LanguageDialogTest(Resources resources, GUIInstallData installData, Locales locales, IconsDatabase icons)
     {
         this.resources = resources;
         this.installData = installData;
         this.locales = locales;
+        this.icons = icons;
     }
 
     /**
@@ -169,9 +176,7 @@ public class LanguageDialogTest
     private LanguageDialog createDialog(String langDisplayType)
     {
         installData.guiPrefs.modifier.put("langDisplayType", langDisplayType);
-        JFrame frame = new JFrame();
-        frame.setLocationRelativeTo(null);
-        return new LanguageDialog(frame, resources, locales, installData, Mockito.mock(RequirementsChecker.class));
+        return new LanguageDialog(resources, locales, installData, icons, Mockito.mock(RequirementsChecker.class));
     }
 
 }

--- a/izpack-panel/pom.xml
+++ b/izpack-panel/pom.xml
@@ -76,11 +76,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- the only maven deployment of substance? -->
-            <groupId>net.sf.squirrel-sql.thirdparty-non-maven</groupId>
+            <groupId>com.github.insubstantial</groupId>
             <artifactId>substance</artifactId>
-            <version>5.2_01</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/process/ProcessPanelTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/process/ProcessPanelTest.java
@@ -20,22 +20,6 @@
  */
 package com.izforge.izpack.panels.process;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import javax.swing.LookAndFeel;
-import javax.swing.UIManager;
-
-import org.fest.swing.fixture.DialogFixture;
-import org.fest.swing.fixture.FrameFixture;
-import org.hamcrest.text.StringContains;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.jvnet.substance.skin.SubstanceBusinessLookAndFeel;
-
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.factory.ObjectFactory;
 import com.izforge.izpack.api.resource.Locales;
@@ -48,6 +32,18 @@ import com.izforge.izpack.panels.simplefinish.SimpleFinishPanel;
 import com.izforge.izpack.panels.test.AbstractPanelTest;
 import com.izforge.izpack.panels.test.TestGUIPanelContainer;
 import com.izforge.izpack.test.Container;
+import org.fest.swing.fixture.DialogFixture;
+import org.fest.swing.fixture.FrameFixture;
+import org.hamcrest.text.StringContains;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pushingpixels.substance.api.skin.SubstanceBusinessLookAndFeel;
+
+import javax.swing.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -333,19 +333,9 @@
 
       <!-- laf -->
       <dependency>
-        <groupId>org.java.net.substance</groupId>
+        <groupId>com.github.insubstantial</groupId>
         <artifactId>substance</artifactId>
-        <version>6.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.android</groupId>
-            <artifactId>android</artifactId>
-          </exclusion>
-          <exclusion>
-            <artifactId>ant</artifactId>
-            <groupId>ant</groupId>
-          </exclusion>
-        </exclusions>
+        <version>7.3</version>
       </dependency>
       <dependency>
         <groupId>com.incors</groupId>


### PR DESCRIPTION
This request solves [IZPACK-1185](https://izpack.atlassian.net/browse/IZPACK-1185):

When install.xml includes
```xml
<laf name="substance"> 
  <os family="windows" /> 
  <os family="unix" /> 
  <param name="variant" value="creme-coffee" /> 
</laf> 
```
The installer crashes with
```
24-Nov-2014 10:47:09 PM com.izforge.izpack.installer.container.provider.GUIInstallDataProvider load 
INFO: Using laf org.pushingpixels.substance.api.skin.SubstanceMistAquaLookAndFeel 
24-Nov-2014 10:47:09 PM com.izforge.izpack.installer.bootstrap.Installer start 
SEVERE: java.lang.IllegalStateException: This method must be called on the Event Dispatch Thread 
```
When the laf section is removed, the installer runs. 

Furthermore I could not get ```<laf name="liquid">``` to compile 
Failure: ```The path 'com/birosoft/liquid//' is not present inside the classpath```. (with liquid)