### PR TITLE
IZPACK-1314 - UserInputPanel - choice fields (radio/combobox) badly handles pre-set values , difference between console and GUI installation mode

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/AutomatedInstallData.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/AutomatedInstallData.java
@@ -19,17 +19,13 @@
 
 package com.izforge.izpack.api.data;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.event.InstallerListener;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.util.Platform;
+
+import java.util.*;
 
 /**
  * Encloses information about the install process. This implementation is not thread safe.
@@ -85,11 +81,6 @@ public class AutomatedInstallData implements InstallData
      * The panels order.
      */
     private List<Panel> panelsOrder;
-
-    /**
-     * The current panel.
-     */
-    private int curPanelNumber;
 
     /**
      * Can we close the installer ?
@@ -480,30 +471,6 @@ public class AutomatedInstallData implements InstallData
         this.panelsOrder = panelsOrder;
     }
 
-    /**
-     * Returns the current panel number.
-     *
-     * @return the current panel  number
-     * @deprecated use {@code Panels#getIndex()}.
-     */
-    @Deprecated
-    public int getCurPanelNumber()
-    {
-        return curPanelNumber;
-    }
-
-    /**
-     * Sets the current panel number.
-     *
-     * @param curPanelNumber the current panel number
-     * @deprecated no replacement
-     */
-    @Deprecated
-    public void setCurPanelNumber(int curPanelNumber)
-    {
-        this.curPanelNumber = curPanelNumber;
-    }
-
     @Override
     public boolean isCanClose()
     {
@@ -562,23 +529,6 @@ public class AutomatedInstallData implements InstallData
         this.xmlData = xmlData;
     }
 
-    @Deprecated
-    public Map<String, List> getCustomData()
-    {
-        return customData;
-    }
-
-    @Deprecated
-    public void setCustomData(Map<String, List> customData)
-    {
-        this.customData = customData;
-    }
-
-    @Deprecated
-    public void setVariables(Variables variables)
-    {
-    }
-
     public Map<String, Object> getAttributes()
     {
         return attributes;
@@ -589,27 +539,9 @@ public class AutomatedInstallData implements InstallData
         this.attributes = attributes;
     }
 
-    @Deprecated
-    public Map<String, List<DynamicVariable>> getDynamicvariables()
-    {
-        return this.dynamicvariables;
-    }
-
-    @Deprecated
-    public void setDynamicvariables(Map<String, List<DynamicVariable>> dynamicvariables)
-    {
-        this.dynamicvariables = dynamicvariables;
-    }
-
     public List<DynamicInstallerRequirementValidator> getDynamicInstallerRequirements()
     {
         return this.dynamicinstallerrequirements;
-    }
-
-    @Deprecated
-    public List<DynamicInstallerRequirementValidator> getDynamicinstallerrequirements()
-    {
-        return getDynamicInstallerRequirements();
     }
 
     public void setDynamicInstallerRequirements(List<DynamicInstallerRequirementValidator> requirements)
@@ -626,23 +558,5 @@ public class AutomatedInstallData implements InstallData
     public List<InstallerRequirement> getInstallerRequirements()
     {
         return installerrequirements;
-    }
-
-    @Deprecated
-    public List<InstallerRequirement> getInstallerrequirements()
-    {
-        return getInstallerRequirements();
-    }
-
-    @Deprecated
-    public List<InstallerListener> getInstallerListener()
-    {
-        return installerListener;
-    }
-
-    @Deprecated
-    public void setInstallerListener(List<InstallerListener> installerListener)
-    {
-        this.installerListener = installerListener;
     }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -22,47 +22,6 @@
 
 package com.izforge.izpack.installer.gui;
 
-import static com.izforge.izpack.api.GuiId.BUTTON_HELP;
-
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Cursor;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GraphicsEnvironment;
-import java.awt.GridLayout;
-import java.awt.Point;
-import java.awt.Window;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.FocusAdapter;
-import java.awt.event.KeyAdapter;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseMotionAdapter;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JProgressBar;
-import javax.swing.JSeparator;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
-import javax.swing.border.TitledBorder;
-import javax.swing.text.JTextComponent;
-
 import com.izforge.izpack.api.data.Info;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.data.Variables;
@@ -85,6 +44,19 @@ import com.izforge.izpack.installer.debugger.Debugger;
 import com.izforge.izpack.installer.unpacker.IUnpacker;
 import com.izforge.izpack.util.Debug;
 import com.izforge.izpack.util.Housekeeper;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import javax.swing.text.JTextComponent;
+import java.awt.*;
+import java.awt.event.*;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.izforge.izpack.api.GuiId.BUTTON_HELP;
 
 /**
  * The IzPack installer frame.
@@ -572,7 +544,6 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
             }
 
             panelsContainer.add(newView);
-            installdata.setCurPanelNumber(newPanel.getIndex());
 
             if (newView.getInitialFocus() != null)
             {
@@ -738,7 +709,8 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
     /**
      * Writes the installation record to a file.
      *
-     * @param out  The file to write to.
+     * @param file  The file to write to.
+     * @param uninstallData  The uninstall data.
      * @throws Exception Description of the Exception
      */
     @Override
@@ -1452,43 +1424,6 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
             return;
         }
         this.helpButton.setVisible(show);
-    }
-
-    public void refreshDynamicVariables()
-    {
-        try
-        {
-            installdata.refreshVariables();
-        }
-        catch (Exception e)
-        {
-            logger.log(Level.SEVERE, "Error when refreshing variable", e);
-            logger.fine("Refreshing dynamic variables failed, asking user whether to proceed.");
-            StringBuilder msg = new StringBuilder();
-            msg.append("<html>");
-            msg.append("The following error occured during refreshing panel contents:<br>");
-            msg.append("<i>").append(e.getMessage()).append("</i><br>");
-            msg.append("Are you sure you want to continue with this installation?");
-            msg.append("</html>");
-            JLabel label = new JLabel(msg.toString());
-            label.setFont(new Font("Sans Serif", Font.PLAIN, 12));
-            Object[] optionValues = {"Continue", "Exit"};
-            int selectedOption = JOptionPane.showOptionDialog(null, label, "Warning",
-                                                              JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
-                                                              null, optionValues,
-                                                              optionValues[1]);
-            logger.fine("Selected option: " + selectedOption);
-            if (selectedOption == 0)
-            {
-                logger.fine("Continuing installation");
-            }
-            else
-            {
-                // TODO - shouldn't do this. Should try and clean up the installation
-                logger.fine("Exiting");
-                System.exit(1);
-            }
-        }
     }
 
     /**

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
@@ -176,7 +176,6 @@ public abstract class IzPanel extends JPanel implements AbstractUIHandler, Layou
      * @param parent      the parent IzPack installer frame
      * @param installData the installation data
      * @param iconName    the Headline icon name
-     * @param instance    an instance counter
      * @param resources   the resources
      */
     @Deprecated
@@ -195,7 +194,6 @@ public abstract class IzPanel extends JPanel implements AbstractUIHandler, Layou
      * one of these Candidates. <p/> by marc.eppelmann&#064;gmx.de
      *
      * @param imageIconName  an Iconname
-     * @param instanceNumber an panel instance
      * @return true if successful build
      */
     @Deprecated

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleChoiceField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleChoiceField.java
@@ -100,7 +100,7 @@ public abstract class ConsoleChoiceField<T extends Choice> extends ConsoleField
      * Displays the choices.
      *
      * @param choices  the choices
-     * @param selected the selected choice, or {@code -1} if no choice is selected
+     * @param selectedRealIndex the selected choice, or {@code -1} if no choice is selected
      */
     private MappedSelection listChoices(List<Choice> choices, int selectedRealIndex)
     {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
@@ -206,7 +206,7 @@ public class Config
     public String getString(IXMLElement element, String name, String defaultValue)
     {
         String value = element.getAttribute(name);
-        if (value != null && !value.equals(""))
+        if (value != null && !value.isEmpty())
         {
             value = installData.getVariables().replace(value);
         }
@@ -286,7 +286,7 @@ public class Config
     {
         boolean result = defaultValue;
         String value = getString(element, name, null);
-        if (value != null && !value.equals(""))
+        if (value != null && !value.isEmpty())
         {
             // support "yes" for backwards compatibility, but don't encourage its use...
             result = value.equals("yes") || Boolean.valueOf(value);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/SimpleChoiceReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/SimpleChoiceReader.java
@@ -150,12 +150,13 @@ public class SimpleChoiceReader extends FieldReader implements ChoiceFieldConfig
         {
             String value = config.getAttribute(choice, "value");
             String conditionId = config.getString(choice, "conditionid", null);
-            String set = config.getAttribute(choice, "set", true);
+            boolean isSet = config.getBoolean(choice, "set", false);
             if(variableValue == null)
             {
-                if(set != null && set.equalsIgnoreCase("true"))
+                if (isSet)
                 {
                     result = selected;
+                    break;
                 }
             }
             else

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
@@ -190,7 +190,6 @@ public class GUIRadioField extends GUIField implements ActionListener
             if (value.equals(view.choice.getTrueValue()))
             {
                 view.button.setSelected(true);
-                notifyUpdateListener();
                 return true;
             }
             else


### PR DESCRIPTION
This pull request fixes [IZPACK-1314](https://izpack.atlassian.net/browse/IZPACK-1314):

UserInputPanel choice fields (radio, combo) partly badly handle pre-set values according to the documentation. In this case there are also slight differences in handling between GUI and console mode installations.

Provided a definition like this (there is some noise, but it has been my test case):

**install.xml**:
```xml

  <variables>
    <variable name="enabled" value="true"/>
  </variables>

  <conditions>
    <condition type="and" id="showDataPanel">
        <condition type="packselection">
          <name>Pack 1</name>
        </condition>
        <condition type="packselection">
          <name>Pack 2</name>
        </condition>
    </condition>
  </conditions>

  <resources>
    <res id="userInputSpec.xml" src="@{izpack.build.directory}/userInputSpec.xml" />
  </resources>

  <panels>
    <panel classname="TargetPanel" id="panel.target"/>
    <panel classname="PacksPanel" id="panel.packs"/>
    <panel classname="UserInputPanel" id="user_scope" condition="showDataPanel" />
    <panel classname="SummaryPanel"/>
    <panel classname="FinishPanel"/>
  </panels>

  <packs>
    <pack name="Pack 1" required="no" id="pack.1">
      <description>Pack 1</description>
    </pack>
    <pack name="Pack 2" required="no" id="pack.2">
      <description>Pack 2</description>
    </pack>
  </packs>
```

**userInputSpec.xml**:
```xml
  <panel id="user_scope">
    <field type="radio" variable="userScopeSelection">
      <description txt="Install for All users or only for you?" id="description.userScope" />
      <spec>
        <choice txt="Install for all users" id="userScope.all" value="all" />
        <choice txt="Install for only you" id="userScope.single" value="single" set="${enabled}"/>
      </spec>
    </field>
  </panel>
```

- Console mode: The ``set`` attribute for the *userScope.single* choice is ignored, there is initially preselected the first choice instead unless the user changes this selection.
- GUI mode: The _userScopeSelection_ variable is set with some initial value before the panel *user_scope* appears at all. This should not happen, the variable has to left unset unless the UserInputPanel containing and setting it is reached, in case the variable isn't explicitly defined in a ``<variables>`` or ``<dynamicvariables>`` section.