### PR TITLE
IZPACK-1307 - New LicenceConsolePanel pagination does not work reliably for long lines

### DIFF
--- a/izpack-compiler/pom.xml
+++ b/izpack-compiler/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>picocontainer</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
         </dependency>

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -449,9 +449,6 @@ public abstract class PackagerBase implements IPackager
         mergeManager.addResourceToMerge("com/coi/tools/");
         mergeManager.addResourceToMerge("org/apache/tools/zip/");
         mergeManager.addResourceToMerge("org/apache/commons/io/FilenameUtils.class");
-        mergeManager.addResourceToMerge("org/apache/commons/lang3/JavaVersion.class");
-        mergeManager.addResourceToMerge("org/apache/commons/lang3/SystemUtils.class");
-        mergeManager.addResourceToMerge("org/apache/commons/lang3/text/WordUtils.class");
         mergeManager.addResourceToMerge("jline/");
         mergeManager.addResourceToMerge("org/fusesource/");
         mergeManager.addResourceToMerge("META-INF/native/");

--- a/izpack-tools/src/main/java/com/izforge/izpack/util/StringTool.java
+++ b/izpack-tools/src/main/java/com/izforge/izpack/util/StringTool.java
@@ -31,6 +31,7 @@ import java.util.List;
  */
 public class StringTool
 {
+    private static final String NEWLINE = System.getProperty("line.separator");
 
     // ~ Constructors
     // *********************************************************************************
@@ -311,4 +312,34 @@ public class StringTool
                 && str.toUpperCase().startsWith(prefix.toUpperCase());
     }
 
+    /**
+     * Performs word wrapping. Returns the input string with long lines of
+     * text cut (between words) for readability.
+     *
+     * For the original code see
+     * <a href="https://ramblingsrobert.wordpress.com/2011/04/13/java-word-wrap-algorithm/">Java Word Wrap Algorithm</a>
+     *
+     * @param in text to be word-wrapped
+     * @param length maximum number of characters in a line
+     */
+    public static String wordWrap(String in, int length) {
+        while(in.length() > 0 && (in.charAt(0) == '\t' || in.charAt(0) == ' '))
+            in = in.substring(1);
+
+        if(in.length() < length)
+            return in;
+
+        if(in.substring(0, length).contains(NEWLINE))
+            return in.substring(0, in.indexOf(NEWLINE)).trim() + NEWLINE +
+                    wordWrap(in.substring(in.indexOf(NEWLINE) + 1), length);
+
+        int spaceIndex = Math.max(Math.max( in.lastIndexOf(" ", length),
+                in.lastIndexOf("\t", length)),
+                in.lastIndexOf("-", length));
+
+        if(spaceIndex == -1)
+            spaceIndex = length;
+
+        return in.substring(0, spaceIndex).trim() + NEWLINE + wordWrap(in.substring(spaceIndex), length);
+    }
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
@@ -6,11 +6,13 @@ import jline.UnsupportedTerminal;
 import jline.console.ConsoleReader;
 import jline.console.completer.FileNameCompleter;
 import jline.internal.Log;
-import org.apache.commons.lang3.text.WordUtils;
 
 import java.awt.event.KeyEvent;
 import java.io.*;
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -158,7 +160,7 @@ public class Console
         int showLines = height - 2; // the no. of lines to display at a time
         int line = 0;
 
-        StringTokenizer tokens = new StringTokenizer(WordUtils.wrap(text, terminal.getWidth(), null, true), "\n");
+        StringTokenizer tokens = new StringTokenizer(StringTool.wordWrap(text, terminal.getWidth()), "\n");
         while (tokens.hasMoreTokens())
         {
             String token = tokens.nextToken();


### PR DESCRIPTION
Post-fix for [IZPACK-1307](https://izpack.atlassian.net/browse/IZPACK-1307):
 - Do not use WordUtils (commons-lang3) for word wrapping any longer - function does not work as expected in the LicenseConsolePanel in several tests on Linux and Windows
 - Use a built-in utility method for word wrapping