### PR TITLE
IZPACK-1316 - UserInputPanel "check" field - initial value not consistent in several combinations of true/false/set attributes in spec

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
@@ -90,6 +90,8 @@ public class UserInputConsolePanel extends AbstractConsolePanel
      */
     private final Prompt prompt;
 
+    private final Panel panel;
+
     /**
      * The fields.
      */
@@ -123,7 +125,7 @@ public class UserInputConsolePanel extends AbstractConsolePanel
         this.prompt = prompt;
 
         UserInputPanelSpec model = new UserInputPanelSpec(resources, installData, factory, matcher);
-        Panel panel = getPanel();
+        this.panel = getPanel();
         IXMLElement spec = model.getPanelSpec(panel);
 
         boolean isDisplayingHidden = false;
@@ -167,12 +169,13 @@ public class UserInputConsolePanel extends AbstractConsolePanel
         {
             panel.setReadonlyCondition(condition);
         }
+
+        collectInputs(installData);
     }
 
     @Override
     public boolean run(InstallData installData, Properties properties)
     {
-        collectInputs(installData);
         for (ConsoleField field : fields)
         {
             String name = field.getVariable();
@@ -191,7 +194,6 @@ public class UserInputConsolePanel extends AbstractConsolePanel
     @Override
     public boolean generateProperties(InstallData installData, PrintWriter printWriter)
     {
-        collectInputs(installData);
         for (ConsoleField field : fields)
         {
             String name = field.getVariable();
@@ -213,16 +215,10 @@ public class UserInputConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        boolean result;
-        if (!collectInputs(installData))
-        {
-            // no inputs
-            result = true;
-        }
-        else
+        boolean result = true;
+        if (fields != null && !fields.isEmpty())
         {
             boolean rerun = false;
-            Panel panel = getPanel();
             Set<String> variables = new HashSet<String>();
             for (ConsoleField field : fields)
             {
@@ -288,7 +284,7 @@ public class UserInputConsolePanel extends AbstractConsolePanel
         return result;
     }
 
-    private boolean collectInputs(InstallData installData)
+    private void collectInputs(InstallData installData)
     {
         UserInputPanelSpec model = new UserInputPanelSpec(resources, installData, factory, matcher);
         Panel panel = getPanel();
@@ -302,7 +298,6 @@ public class UserInputConsolePanel extends AbstractConsolePanel
             ConsoleField consoleField = factory.create(fieldDefinition, model, spec);
             fields.add(consoleField);
         }
-        return true;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -21,19 +21,19 @@
 
 package com.izforge.izpack.panels.userinput.field;
 
-import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.binding.OsModel;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.core.rules.process.ExistsCondition;
 import com.izforge.izpack.panels.userinput.processorclient.ValuesProcessingClient;
+
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Describes a user input field.
@@ -343,9 +343,10 @@ public abstract class Field
      */
     public String getDefaultValue()
     {
-        if (defaultValue != null)
+        String value = wrapDefaultValue(defaultValue);
+        if (value != null)
         {
-            return replaceVariables(defaultValue);
+            return replaceVariables(value);
         }
         return null;
     }
@@ -357,9 +358,10 @@ public abstract class Field
      */
     private String getForcedValue()
     {
-        if (initialValue != null)
+        String value = wrapInitialValue(initialValue);
+        if (value != null)
         {
-            return replaceVariables(initialValue);
+            return replaceVariables(value);
         }
         return null;
     }
@@ -417,6 +419,47 @@ public abstract class Field
             logger.fine("Field setting variable=" + variable + " to value=" + value);
         }
         installData.setVariable(variable, value);
+    }
+
+
+    /**
+     * Wrap the initial value of a field, which is the value of the <code>set</code> attribute in the field's spec to
+     * the effective value to be assigned to the variable. This can be used for enumeration type conversions.
+     * <br><br>
+     * This method can be optionally overridden by several user input field types.
+     * <br><br>
+     * Example: The <code>set</code> attribute in the checkbox user input field has a boolean value, the value should
+     * be wrapped to the value of the <code>true</code> attribute in case of <code>set="true"</code> or to the value of
+     * the <code>false</code> attribute in case of <code>set="false"</code>.
+     *
+     * @param originalValue the original value of the <code>set</code> attribute
+     * @return the wrapped value
+     * @see com.izforge.izpack.panels.userinput.field.check.CheckField
+     */
+    public String wrapInitialValue(String originalValue)
+    {
+        return originalValue;
+    }
+
+    /**
+     * Wrap the default value of a field, which is the value of the <code>default</code> attribute in the field's spec
+     * to the effective value to be assigned to the variable. This can be used for enumeration type conversions.
+     * To be overridden by several user input field types.
+     * <br><br>
+     * This method can be optionally overridden by several user input field types.
+     * <br><br>
+     * Example: The <code>set</code> attribute in the checkbox user input field has a boolean value, the value should
+     * be wrapped to the value of the <code>true</code> attribute in case of <code>default="true"</code> or to the
+     * value of the <code>false</code> attribute in case of <code>default="false"</code>.
+     * @see com.izforge.izpack.panels.userinput.field.check.CheckField
+     *
+     * @param originalValue the original value of the <code>default</code> attribute
+     * @return the wrapped value
+     * @see com.izforge.izpack.panels.userinput.field.check.CheckField
+     */
+    public String wrapDefaultValue(String originalValue)
+    {
+        return originalValue;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/check/CheckField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/check/CheckField.java
@@ -88,12 +88,36 @@ public class CheckField extends Field
      */
     public boolean getInitialSelection()
     {
-        String value = getInitialValue();
         boolean result = false;
+        String value = getInitialValue();
         if (value != null)
         {
-            result = value.equals(trueValue) || Boolean.valueOf(value);
+            result = value.equals(trueValue);
         }
         return result;
+    }
+
+    @Override
+    public String wrapInitialValue(String originalValue)
+    {
+        if (originalValue != null)
+        {
+            return Boolean.parseBoolean(originalValue)
+                    ? replaceVariables(trueValue)
+                    : replaceVariables(falseValue);
+        }
+        return null;
+    }
+
+    @Override
+    public String wrapDefaultValue(String originalValue)
+    {
+        if (originalValue != null)
+        {
+            return Boolean.parseBoolean(originalValue)
+                    ? replaceVariables(trueValue)
+                    : replaceVariables(falseValue);
+        }
+        return null;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/check/CheckFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/check/CheckFieldReader.java
@@ -52,7 +52,7 @@ public class CheckFieldReader extends FieldReader implements CheckFieldConfig
      */
     public String getTrueValue()
     {
-        return getConfig().getString(getSpec(), "true", null);
+        return getConfig().getString(getSpec(), "true", Boolean.TRUE.toString());
     }
 
     /**
@@ -62,6 +62,6 @@ public class CheckFieldReader extends FieldReader implements CheckFieldConfig
      */
     public String getFalseValue()
     {
-        return getConfig().getString(getSpec(), "false", null);
+        return getConfig().getString(getSpec(), "false", Boolean.FALSE.toString());
     }
 }

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/check/ConsoleCheckFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/check/ConsoleCheckFieldTest.java
@@ -21,12 +21,6 @@
 
 package com.izforge.izpack.panels.userinput.console.check;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.resource.Messages;
@@ -36,10 +30,16 @@ import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.core.handler.ConsolePrompt;
 import com.izforge.izpack.core.rules.ConditionContainer;
 import com.izforge.izpack.core.rules.RulesEngineImpl;
+import com.izforge.izpack.panels.userinput.console.AbstractConsoleFieldTest;
 import com.izforge.izpack.panels.userinput.field.check.CheckField;
 import com.izforge.izpack.panels.userinput.field.check.TestCheckFieldConfig;
 import com.izforge.izpack.test.util.TestConsole;
 import com.izforge.izpack.util.Platforms;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -47,7 +47,7 @@ import com.izforge.izpack.util.Platforms;
  *
  * @author Tim Anderson
  */
-public class ConsoleCheckFieldTest
+public class ConsoleCheckFieldTest extends AbstractConsoleFieldTest
 {
 
     /**
@@ -133,7 +133,7 @@ public class ConsoleCheckFieldTest
         assertEquals("unselected", installData.getVariable(variable));
     }
 
-    /**
+        /**
      * Tests setting the state from selected to deselected.
      */
     @Test
@@ -151,5 +151,4 @@ public class ConsoleCheckFieldTest
 
         assertEquals("unselected", installData.getVariable(variable));
     }
-
 }

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/field/check/TestCheckFieldConfig.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/field/check/TestCheckFieldConfig.java
@@ -65,7 +65,7 @@ public class TestCheckFieldConfig extends TestFieldConfig implements CheckFieldC
     @Override
     public String getTrueValue()
     {
-        return trueValue;
+        return trueValue != null ? trueValue : Boolean.TRUE.toString();
     }
 
     /**
@@ -76,6 +76,6 @@ public class TestCheckFieldConfig extends TestFieldConfig implements CheckFieldC
     @Override
     public String getFalseValue()
     {
-        return falseValue;
+        return falseValue != null ? falseValue : Boolean.FALSE.toString();
     }
 }


### PR DESCRIPTION
This pull request fixes [IZPACK-1316](https://izpack.atlassian.net/browse/IZPACK-1316):

Provided something like this in *UserInputSpec.xml*:

```xml
    <field type="check" variable="allow">
      <spec txt="Allow something" true="false" false="true" set="true" id="text.allow" />
    </field>
```
compared to

```xml
    <field type="check" variable="allow">
      <spec txt="Allow something" true="false" false="true" set="false" id="text.allow" />
    </field>
```

For both cases, the checkbox is initially checked.

This due to the ambiguous check in the code (```value``` is the value of the *set* attribute):
```java
value.equals(trueValue) || Boolean.valueOf(value)
```

With the current implementation, there's currently no way out of this combination, because the value of set is considered as String and as Boolean type in one and the same expression.

The code for checking this should just compare the value of the *set* attribute as String, like this:
```java
value.equals(trueValue)
```

The *set* attribute should receive a boolean value if used and applied according to the documentation:
https://izpack.atlassian.net/wiki/x/S4AH

Added also some ```UserInputConsolePanel``` optimizations.