### PR TITLE
IZPACK-1318: [HTML]LicencePanel, [HTML]InfoPanel - make paging and wordwrap for the console installation mode configurable

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
@@ -1,10 +1,5 @@
 /*
- * IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
- *
- * http://izpack.org/
- * http://izpack.codehaus.org/
- *
- * Copyright 2012 Tim Anderson
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +16,15 @@
 
 package com.izforge.izpack.installer.console;
 
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Panel;
+import com.izforge.izpack.api.rules.RulesEngine;
+import com.izforge.izpack.installer.panel.PanelView;
+import com.izforge.izpack.util.Console;
+
 import java.io.IOException;
 import java.util.Properties;
 import java.util.logging.Logger;
-
-import com.izforge.izpack.api.data.InstallData;
-import com.izforge.izpack.installer.panel.PanelView;
-import com.izforge.izpack.util.Console;
 
 /**
  * Abstract console panel for displaying paginated text.
@@ -81,13 +78,20 @@ public abstract class AbstractTextConsolePanel extends AbstractConsolePanel
         text = installData.getVariables().replace(text);
         if (text != null)
         {
+            Panel panel = getPanel();
+            RulesEngine rules = installData.getRules();
+            boolean paging = Boolean.parseBoolean(panel.getConfigurationOptionValue("console-text-paging", rules));
+            boolean wordwrap = Boolean.parseBoolean(panel.getConfigurationOptionValue("console-text-wordwrap", rules));
+            System.err.println("paging: " + paging);
+            System.err.println("wordwrap: " + wordwrap);
+
             try
             {
-                console.paginate(text);
+                console.printMultiLine(text, wordwrap, paging);
             }
             catch (IOException e)
             {
-                logger.warning("Text pagination failed: " + e.getMessage());
+                logger.warning("Displaying multiline text failed: " + e.getMessage());
             }
         }
         else

--- a/izpack-tools/src/main/java/com/izforge/izpack/util/StringTool.java
+++ b/izpack-tools/src/main/java/com/izforge/izpack/util/StringTool.java
@@ -1,17 +1,12 @@
 /*
- * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
- * 
- * http://izpack.org/
- * http://izpack.codehaus.org/
- * 
- * Copyright 2003 Marc Eppelmann
- * 
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,8 +26,6 @@ import java.util.List;
  */
 public class StringTool
 {
-    private static final String NEWLINE = System.getProperty("line.separator");
-
     // ~ Constructors
     // *********************************************************************************
 
@@ -310,36 +303,5 @@ public class StringTool
     {
         return (str != null) && (prefix != null)
                 && str.toUpperCase().startsWith(prefix.toUpperCase());
-    }
-
-    /**
-     * Performs word wrapping. Returns the input string with long lines of
-     * text cut (between words) for readability.
-     *
-     * For the original code see
-     * <a href="https://ramblingsrobert.wordpress.com/2011/04/13/java-word-wrap-algorithm/">Java Word Wrap Algorithm</a>
-     *
-     * @param in text to be word-wrapped
-     * @param length maximum number of characters in a line
-     */
-    public static String wordWrap(String in, int length) {
-        while(in.length() > 0 && (in.charAt(0) == '\t' || in.charAt(0) == ' '))
-            in = in.substring(1);
-
-        if(in.length() < length)
-            return in;
-
-        if(in.substring(0, length).contains(NEWLINE))
-            return in.substring(0, in.indexOf(NEWLINE)).trim() + NEWLINE +
-                    wordWrap(in.substring(in.indexOf(NEWLINE) + 1), length);
-
-        int spaceIndex = Math.max(Math.max( in.lastIndexOf(" ", length),
-                in.lastIndexOf("\t", length)),
-                in.lastIndexOf("-", length));
-
-        if(spaceIndex == -1)
-            spaceIndex = length;
-
-        return in.substring(0, spaceIndex).trim() + NEWLINE + wordWrap(in.substring(spaceIndex), length);
     }
 }

--- a/izpack-tools/src/main/java/com/izforge/izpack/util/WordUtil.java
+++ b/izpack-tools/src/main/java/com/izforge/izpack/util/WordUtil.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.util;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.StringTokenizer;
+
+public class WordUtil
+{
+    private static final String NEWLINE = System.getProperty("line.separator");
+
+    public static void main(String[] args) throws FileNotFoundException
+    {
+        InputStream in = null;
+        try
+        {
+            in = new BufferedInputStream(new FileInputStream("/home/rkrell/Downloads/pentaho-eula-wrap-config-1.0.7-eula.txt"));
+            for (String line : WordUtil.wordWrap(in, 80))
+            {
+                System.out.println(line);
+            }
+        }
+        finally
+        {
+            try
+            {
+                if (in != null)
+                    in.close();
+            }
+            catch (IOException e) {}
+        }
+    }
+
+    public static String wordWrap(String text, int maxCharsPerLine)
+    {
+        StringBuffer sb = new StringBuffer();
+        for (String line : wordWrap(new ByteArrayInputStream(text.getBytes()), maxCharsPerLine))
+        {
+            sb.append(line + NEWLINE);
+        }
+        return sb.toString();
+    }
+
+    public static List<String> wordWrap(InputStream in, int maxCharsPerLine)
+    {
+        List<String> lines = new ArrayList<String>();
+        Scanner scanner = new Scanner(in);
+
+        while (scanner.hasNextLine())
+        {
+            String readLine = scanner.nextLine();
+            StringBuffer sb = new StringBuffer();
+
+            StringTokenizer tokenizer = new StringTokenizer(readLine);
+            // Add explicit line breaks from original document
+            if (tokenizer.countTokens() == 0)
+            {
+                lines.add(new String());
+            }
+
+            while (tokenizer.hasMoreTokens())
+            {
+                String word = tokenizer.nextToken();
+                int len = word.length();
+
+                // FIXME Add explicit trailing whitespace from original document
+                /*
+                if (len == 0)
+                {
+                    word = " ";
+                    len = 1;
+                }
+                */
+
+                if (sb.length() > 0)
+                {
+                    if (len + 1 > maxCharsPerLine - sb.length())
+                    {
+                        lines.add(sb.toString());
+                        sb = new StringBuffer();
+                    }
+                    else
+                    {
+                        if (len < maxCharsPerLine)
+                        {
+                            sb.append(' ');
+                        }
+                    }
+                }
+                sb.append(word);
+            }
+            if (sb.length() > 0)
+            {
+                lines.add(sb.toString());
+            }
+        }
+
+        return lines;
+    }
+}

--- a/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.izforge.izpack.util;
 
 import com.izforge.izpack.api.exception.UserInterruptException;
@@ -146,13 +162,37 @@ public class Console
         return lines;
     }
 
+    public void printMultiLine(String text, boolean wrap, boolean paging) throws IOException
+    {
+        if (wrap)
+        {
+            int width = 80;
+            if (!consoleReaderFailed)
+            {
+                Terminal terminal = consoleReader.getTerminal();
+                width = terminal.getWidth();
+            }
+
+            text = WordUtil.wordWrap(text, width);
+        }
+
+        if (paging)
+        {
+            paging(text);
+        }
+        else
+        {
+            println(text);
+        }
+    }
+
     /**
      * Pages through the supplied text.
      *
      * @param text    the text to display
      * @return <tt>true</tt> if paginated through, <tt>false</tt> if terminated
      */
-    public boolean paginate(String text) throws IOException
+    private boolean paging(String text) throws IOException
     {
         boolean result = true;
         Terminal terminal = consoleReader.getTerminal();
@@ -160,7 +200,7 @@ public class Console
         int showLines = height - 2; // the no. of lines to display at a time
         int line = 0;
 
-        StringTokenizer tokens = new StringTokenizer(StringTool.wordWrap(text, terminal.getWidth()), "\n");
+        StringTokenizer tokens = new StringTokenizer(text, "\n");
         while (tokens.hasMoreTokens())
         {
             String token = tokens.nextToken();


### PR DESCRIPTION
This request implements [IZPACK-1318](https://izpack.atlassian.net/browse/IZPACK-1318):

For all panel types inherited from ``AbstractTextConsolePanel``:
- LicencePanel,
- HTMLLicensePanel,
- InfoPanel,
- HTMLInfoPanel
we should make the paging and wordwrap configurable for displaying the multi-line text in console installation mode.

On some terminals might be problems with these features and furthermore, there might be a well-preformatted text content (for instance a license) which is messed up by automatic formatting, for example disappearing leading explicit whitespace characters at the beginning of some lines.

The definition should be made in install.xml using the optional ``<configuration>`` section as follows:
```xml
    <panel classname="LicencePanel" id="panel.license">
      <configuration>
        <param name="console-text-paging" value="true" />
        <param name="console-text-wordwrap" value="false" />
      </configuration>
    </panel>
```