### PR TITLE
IZPACK-1320: Add version comparison condition not assuming missing minor parts of one of the operands to be 0

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/rules/ComparisonOperator.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/rules/ComparisonOperator.java
@@ -1,8 +1,5 @@
 /*
- * IzPack - Copyright 2001-2012 Julien Ponge, All Rights Reserved.
- *
- * http://izpack.org/
- * http://izpack.codehaus.org/
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +22,6 @@ import java.util.Map;
 
 /**
  * Comparison operators that can be used for in conditions
- *
- * @author Rene Krell
  */
 public enum ComparisonOperator
 {

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -75,6 +75,7 @@
                     <xs:enumeration value="xor"/>
                     <xs:enumeration value="comparenumerics"/>
                     <xs:enumeration value="compareversions"/>
+                    <xs:enumeration value="compareversionsmajor"/>
                     <xs:enumeration value="empty"/>
                     <xs:enumeration value="exists"/>
                     <xs:enumeration value="java"/>

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -49,16 +49,7 @@ import com.izforge.izpack.core.rules.logic.AndCondition;
 import com.izforge.izpack.core.rules.logic.NotCondition;
 import com.izforge.izpack.core.rules.logic.OrCondition;
 import com.izforge.izpack.core.rules.logic.XorCondition;
-import com.izforge.izpack.core.rules.process.CompareNumericsCondition;
-import com.izforge.izpack.core.rules.process.CompareVersionsCondition;
-import com.izforge.izpack.core.rules.process.ContainsCondition;
-import com.izforge.izpack.core.rules.process.EmptyCondition;
-import com.izforge.izpack.core.rules.process.ExistsCondition;
-import com.izforge.izpack.core.rules.process.JavaCondition;
-import com.izforge.izpack.core.rules.process.PackSelectionCondition;
-import com.izforge.izpack.core.rules.process.RefCondition;
-import com.izforge.izpack.core.rules.process.UserCondition;
-import com.izforge.izpack.core.rules.process.VariableCondition;
+import com.izforge.izpack.core.rules.process.*;
 import com.izforge.izpack.util.Platform;
 import com.izforge.izpack.util.Platforms;
 
@@ -100,6 +91,7 @@ public class RulesEngineImpl implements RulesEngine
         TYPE_CLASS_NAMES.put("xor", XorCondition.class.getName());
         TYPE_CLASS_NAMES.put("comparenumerics", CompareNumericsCondition.class.getName());
         TYPE_CLASS_NAMES.put("compareversions", CompareVersionsCondition.class.getName());
+        TYPE_CLASS_NAMES.put("compareversionsmajor", CompareVersionsMajorCondition.class.getName());
         TYPE_CLASS_NAMES.put("empty", EmptyCondition.class.getName());
         TYPE_CLASS_NAMES.put("exists", ExistsCondition.class.getName());
         TYPE_CLASS_NAMES.put("contains", ContainsCondition.class.getName());

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/CompareVersionsMajorCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/CompareVersionsMajorCondition.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.core.rules.process;
+
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.rules.ComparisonOperator;
+import com.izforge.izpack.core.data.DefaultVariables;
+import com.izforge.izpack.util.Platform;
+
+import java.util.logging.Logger;
+
+public class CompareVersionsMajorCondition extends CompareVersionsCondition
+{
+    private static final long serialVersionUID = -8392922321054039545L;
+
+    private static final transient Logger logger = Logger.getLogger(CompareVersionsMajorCondition.class.getName());
+
+    public CompareVersionsMajorCondition()
+    {
+        super(NOT_ASSUME_MISSING_MINOR_PARTS_AS_0);
+    }
+
+    public static void main (String args[])
+    {
+        final String op1="1.8.0_72", op2="1.8";
+        final ComparisonOperator operator = ComparisonOperator.LESSEQUAL;
+        CompareVersionsMajorCondition condition = new CompareVersionsMajorCondition();
+        condition.setInstallData(new AutomatedInstallData(new DefaultVariables(), new Platform(Platform.Name.LINUX)));
+        condition.setLeftOperand(op1);
+        condition.setOperator(operator);
+        condition.setRightOperand(op2);
+        System.out.println(op1 + " " + operator.getAttribute() + " " + op2 + ": " + condition.isTrue());
+    }
+}

--- a/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/rules/RulesEngineImplTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.izforge.izpack.core.rules.process.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,15 +55,6 @@ import com.izforge.izpack.core.rules.logic.AndCondition;
 import com.izforge.izpack.core.rules.logic.NotCondition;
 import com.izforge.izpack.core.rules.logic.OrCondition;
 import com.izforge.izpack.core.rules.logic.XorCondition;
-import com.izforge.izpack.core.rules.process.CompareNumericsCondition;
-import com.izforge.izpack.core.rules.process.CompareVersionsCondition;
-import com.izforge.izpack.core.rules.process.EmptyCondition;
-import com.izforge.izpack.core.rules.process.ExistsCondition;
-import com.izforge.izpack.core.rules.process.JavaCondition;
-import com.izforge.izpack.core.rules.process.PackSelectionCondition;
-import com.izforge.izpack.core.rules.process.RefCondition;
-import com.izforge.izpack.core.rules.process.UserCondition;
-import com.izforge.izpack.core.rules.process.VariableCondition;
 import com.izforge.izpack.util.Platform;
 import com.izforge.izpack.util.Platforms;
 
@@ -523,6 +515,7 @@ public class RulesEngineImplTest
         assertTrue(rules.getCondition("variable1") instanceof VariableCondition);
         assertTrue(rules.getCondition("comparenumerics1") instanceof CompareNumericsCondition);
         assertTrue(rules.getCondition("compareversions1") instanceof CompareVersionsCondition);
+        assertTrue(rules.getCondition("compareversionsmajor1") instanceof CompareVersionsMajorCondition);
         assertTrue(rules.getCondition("empty1") instanceof EmptyCondition);
         assertTrue(rules.getCondition("exists1") instanceof ExistsCondition);
         assertTrue(rules.getCondition("java1") instanceof JavaCondition);
@@ -703,6 +696,7 @@ public class RulesEngineImplTest
 
         assertTrue(rules.isConditionTrue("comparenumerics1"));  // comparenumerics1 = 1 < 2
         assertTrue(rules.isConditionTrue("compareversions1"));  // compareversions1 = 1 < 2
+        assertTrue(rules.isConditionTrue("compareversionsmajor1"));  // compareversions1 = 1.8 eq 1.8.0_72
     }
 
     /**

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/rules/conditions.xml
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/rules/conditions.xml
@@ -44,6 +44,11 @@
         <arg2>2</arg2>
         <operator>lt</operator>
     </condition>
+    <condition type="compareversionsmajor" id="compareversionsmajor1">
+        <arg1>1.8</arg1>
+        <arg2>1.8.0_72</arg2>
+        <operator>eq</operator>
+    </condition>
     <condition type="empty" id="empty1">
         <dir>${INSTALL_PATH}/import</dir>
     </condition>


### PR DESCRIPTION
This request implements [IZPACK-1320](https://izpack.atlassian.net/browse/IZPACK-132):

Currently, there is implemented a condition of type "_compareversions_" which compares two version strings, that can have a different number of version parts, for example 1.0 and 1.0.1.
This condition assumes missing minor version parts to be 0 effectively, thus comparing 1.0 and 1.0.1 would result in comparing 1.0.0 and 1.0.1, thus evaluating 1.0 < 1.0.1.

For some use cases, this comparison behavior might be changed, there should be a second condition type comparing just the explicit major version parts of both operands and ignore the rest of the minor parts of the operand with more version parts, thus comparing 1.0 and 1.0.1 would result in comparing 1.0 and 1.0, thus evaluating 1.0 == 1.0.1.

The new condition's type is "_compareversionsmajor_".

**Example:**

Imagine a check of an explicit Java version the user enters in some input panel. There's a definition for the maximum and minimum Java version, thus min <= version <= max.
There should be further said, the Java version should be 1.7 or 1.8, ignoring the minor version parts. The minimum version should be 1.7, the maximum version 1.8. The version number to compare to should be parsed from the output of the 'java -version' command of the JRE the user entered as path. The following expressions should evaluate true in this case:
- 1.7 <= 1.8.0_72 <= 1.8
- 1.7 <= 1.7.0_20 <= 1.8

This would not be possible with the existing "compareversions" condition, because it evaluates 1.8.0_72 <= 1.8 -> false and 1.7 <= 1.7.0_20 -> false.

install.xml:
```xml
...
<variable name="java.version" value="" />
...
<condition type="compareversionsmajor" id="ValidMinJavaVersion">
    <arg1>${java.version}</arg1>
    <arg2>1.7</arg2>
    <operator>geq</operator>
</condition>
<condition type="compareversionsmajor" id="ValidMaxJavaVersion">
    <arg1>${java.version}</arg1>
    <arg2>1.8</arg2>
    <operator>leq</operator>
</condition>
...
```