### PR TITLE
IZPACK-1324: HTMLLicenceConsolePanel not updated to support multiple instances of HTMLLicencePanel

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/htmllicence/HTMLLicenceConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/htmllicence/HTMLLicenceConsolePanel.java
@@ -21,16 +21,25 @@
 
 package com.izforge.izpack.panels.htmllicence;
 
+import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.console.ConsolePanel;
 import com.izforge.izpack.installer.panel.PanelView;
 import com.izforge.izpack.panels.licence.AbstractLicenceConsolePanel;
+
+import java.util.logging.Logger;
 
 /**
  * HTML Licence Panel console helper
  */
 public class HTMLLicenceConsolePanel extends AbstractLicenceConsolePanel
 {
+    /**
+     * The logger.
+     */
+    private static final Logger logger = Logger.getLogger(HTMLLicenceConsolePanel.class.getName());
+
+    private static final String DEFAULT_SUFFIX = ".licence";
 
     /**
      * Constructs an <tt>HTMLLicenceConsolePanel</tt>.
@@ -51,10 +60,33 @@ public class HTMLLicenceConsolePanel extends AbstractLicenceConsolePanel
     @Override
     protected String getText()
     {
-        String text = getText("HTMLLicencePanel.licence");
+        final String resNamePrefix = HTMLLicencePanel.class.getSimpleName();
+        String text = null;
+
+        Panel panel = getPanel();
+        if (panel != null)
+        {
+            String panelId = panel.getPanelId();
+            if (panelId != null)
+            {
+                String panelSpecificResName = resNamePrefix + '.' + panelId;
+                text = getText(panelSpecificResName);
+                if (text == null)
+                {
+                    text = getText(resNamePrefix + DEFAULT_SUFFIX);
+                }
+            }
+        }
+
         if (text != null)
         {
             text = removeHTML(text);
+        }
+        else
+        {
+            logger.warning("Cannot open any of both license text resources ("
+                    + resNamePrefix + '.' + panel.getPanelId() + ", " + resNamePrefix + DEFAULT_SUFFIX
+                    + ") for panel type '" + HTMLLicencePanel.class.getSimpleName() + "" );
         }
         return text;
     }


### PR DESCRIPTION
This is a fix for [IZPACK-1324](https://izpack.atlassian.net/browse/IZPACK-1324):

In [pull request #364](https://github.com/izpack/izpack/pull/364), there has been introduced the support of multiple instances of HTMLLicencePanel in one installer.

Unfortunately, there has been implemented just the Swing part, the console installation mode still lacks of this feature.

Did also some code cleanup in `HTMLLicencePanel`.