### PR TITLE
IZPACK-1325: NullPointerException in PacksPanelBase

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModelGUI.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksModelGUI.java
@@ -44,7 +44,7 @@ public class PacksModelGUI extends PacksModel
     @Override
     public void setValueAt(Object checkValue, int rowIndex, int columnIndex)
     {
-        if (columnIndex != 0 || !(checkValue instanceof Integer))
+        if (columnIndex != 0 || !(checkValue instanceof CbSelectionState))
         {
             return;
         }
@@ -64,7 +64,7 @@ public class PacksModelGUI extends PacksModel
         long bytes = 0;
         for (int q = 0; q < packs.size(); q++)
         {
-            if (Math.abs(checkValues[q]) == 1)
+            if (checkValues.get(q).isSelectedOrRequiredSelected())
             {
                 Pack pack = packs.get(q);
                 bytes += pack.getSize();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -1,35 +1,5 @@
 package com.izforge.izpack.panels.treepacks;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.io.File;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import javax.swing.JTree;
-import javax.swing.tree.TreeModel;
-import javax.swing.tree.TreeNode;
-import javax.swing.tree.TreePath;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.data.Pack;
@@ -48,6 +18,20 @@ import com.izforge.izpack.panels.packs.PacksModel;
 import com.izforge.izpack.panels.packs.PacksPanelAutomationHelper;
 import com.izforge.izpack.util.IoHelper;
 import com.izforge.izpack.util.file.FileUtils;
+
+import javax.swing.*;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.InputStream;
+import java.util.*;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Created by IntelliJ IDEA.
@@ -419,8 +403,8 @@ public class TreePacksPanel extends IzPanel
             int childRowIndex = getRowIndex((Pack) nodePack);
             if (childRowIndex >= 0)
             {
-                Integer state = (Integer) packsModel.getValueAt(childRowIndex, 0);
-                node.setEnabled(state >= 0);
+                PacksModel.CbSelectionState state = (PacksModel.CbSelectionState) packsModel.getValueAt(childRowIndex, 0);
+                node.setEnabled(state.isSelectable());
 
                 node.setPartial(packsModel.isPartiallyChecked(childRowIndex));
                 node.setSelected(packsModel.isChecked(childRowIndex));


### PR DESCRIPTION
This is a fix for [IZPACK-1325](https://izpack.atlassian.net/browse/IZPACK-1325):

The installedPacks field is initialized only in constructor. While it is used before initialization in removeAlreadyInstalledPacks():

```
java.lang.NullPointerException
at com.izforge.izpack.panels.packs.PacksModel.removeAlreadyInstalledPacks(PacksModel.java:877)
at com.izforge.izpack.panels.packs.PacksModel.loadInstallationInformation(PacksModel.java:910)
at com.izforge.izpack.panels.packs.PacksModel.<init>(PacksModel.java:90)
at com.izforge.izpack.panels.packs.PacksModelGUI.<init>(PacksModelGUI.java:38)
at com.izforge.izpack.panels.packs.PacksPanelBase$5.<init>(PacksPanelBase.java:656)
at com.izforge.izpack.panels.packs.PacksPanelBase.panelActivate(PacksPanelBase.java:655)
at com.izforge.izpack.installer.gui.InstallerFrame.switchPanel(InstallerFrame.java:613)
at com.izforge.izpack.installer.gui.InstallerFrame$5.switchPanel(InstallerFrame.java:410)
at com.izforge.izpack.installer.gui.IzPanels.switchPanel(IzPanels.java:128)
at com.izforge.izpack.installer.gui.IzPanels.switchPanel(IzPanels.java:36)
at com.izforge.izpack.installer.panel.AbstractPanels.switchPanel(AbstractPanels.java:504)
at com.izforge.izpack.installer.panel.AbstractPanels.next(AbstractPanels.java:251)
at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:345)
at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:328)
at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.navigate(DefaultNavigator.java:563)
at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.access$100(DefaultNavigator.java:526)
at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler$1$1.run(DefaultNavigator.java:546)
at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:312)
at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:733)
at java.awt.EventQueue.access$200(EventQueue.java:103)
at java.awt.EventQueue$3.run(EventQueue.java:694)
at java.awt.EventQueue$3.run(EventQueue.java:692)
at java.security.AccessController.doPrivileged(Native Method)
at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:76)
at java.awt.EventQueue.dispatchEvent(EventQueue.java:703)
at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:242)
at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:161)
at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:150)
at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:146)
at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:138)
at java.awt.EventDispatchThread.run(EventDispatchThread.java:91)
```

Contains also some code refactory of PacksModel and depending classes