### PR TITLE
IZPACK-1326: GUI installation mode - InstallerFrame initializes debug ger and thus triggers additional evaluating of all conditions

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -333,14 +333,13 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
 
         contentPane.add(navPanel, BorderLayout.SOUTH);
 
-        // always initialize debugger
-        debugger = new Debugger(installdata, getIcons(), rules);
-        // this needed to fully initialize the debugger.
-        JPanel debugpanel = debugger.getDebugPanel();
-
         // create a debug panel if TRACE is enabled
         if (Debug.isTRACE())
         {
+            debugger = new Debugger(installdata, getIcons(), rules);
+            // this needed to fully initialize the debugger
+            JPanel debugpanel = debugger.getDebugPanel();
+
             if (installdata.guiPrefs.modifier.containsKey("showDebugWindow")
                     && Boolean.valueOf(installdata.guiPrefs.modifier.get("showDebugWindow")))
             {


### PR DESCRIPTION
This fixes [IZPACK-1326](https://izpack.atlassian.net/browse/IZPACK-1326):

At the moment, during initializing an `InstallerFrame`, there is initialized the debug panel even if `-DTRACE=true` isn't set at the command line. This implies evaluating of all conditions at installer startup which cannot be prevented, because it out of the scope of the user.

This can lead to warnings and other unwanted side effects, for instance if conditions use variables, which cannot be resolved at this time.

Initialize instances of graphical debug elements only if the `-DTRACE=true` mode has been explicitly set.