### PR TITLE
IZPACK-1327: Print headline for all built-in console-mode panels

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
@@ -21,12 +21,12 @@
 
 package com.izforge.izpack.core.handler;
 
-import jline.TerminalFactory;
-
 import com.izforge.izpack.api.handler.AbstractPrompt;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.util.Console;
+
+import java.util.Arrays;
 
 /**
  * Console implementation of {@link Prompt}.
@@ -156,8 +156,12 @@ public class ConsolePrompt extends AbstractPrompt
     public Option confirm(Type type, String title, String message, Options options, Option defaultOption)
     {
         Option result;
-        final int maxlength = TerminalFactory.get().getWidth();
-        final String hline = new String(new char[maxlength]).replace("\0", "\u2500");
+
+        int length = Math.max((title!=null ? title.length() : 0), message.length());
+        char[] chars = new char[length];
+        Arrays.fill(chars, '*');
+        final String hline = new String(chars);
+
         console.println(hline);
         if (title != null)
         {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
@@ -74,6 +74,8 @@ public abstract class AbstractTextConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         String text = getText();
         text = installData.getVariables().replace(text);
         if (text != null)

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PanelHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PanelHelper.java
@@ -41,6 +41,61 @@ public class PanelHelper
      */
     private static final Logger logger = Logger.getLogger(PanelHelper.class.getName());
 
+    /**
+     * Returns the IzPanel implementation of an {@link ConsolePanel}.
+     * <p/>
+     * Console implementations must use the naming convention:
+     * <p>
+     * {@code <prefix>ConsolePanel}
+     * </p>
+     * where <em>{@code <prefix>}</em> is the IzPanel name, minus <em>Panel</em>.
+     * <br/>
+     * E.g for the panel {@code HelloPanel}, the console implementation must be named {@code HelloConsolePanel}.
+     * <p/>
+     * For backwards-compatibility, the sufixes <em>Console</em> and <em>ConsoleHelper</em> are also supported.
+     * Support for this will be removed when the {@link com.izforge.izpack.installer.console.PanelConsole} interface is
+     * removed.
+     *
+     * @param className the ConsolePanel class name
+     * @return the corresponding IzPanel implementation, or {@code null} if none is found
+     */
+    public static Class<IzPanel> getIzPanel(String className)
+    {
+        return getIzPanel(className, PanelHelper.class.getClassLoader());
+    }
+
+    /**
+     * Returns the IzPanel implementation of an {@link ConsolePanel}.
+     * <p/>
+     * Console implementations must use the naming convention:
+     * <p>
+     * {@code <prefix>ConsolePanel}
+     * </p>
+     * where <em>{@code <prefix>}</em> is the IzPanel name, minus <em>Panel</em>.
+     * <br/>
+     * E.g for the panel {@code HelloPanel}, the console implementation must be named {@code HelloConsolePanel}.
+     * <p/>
+     * For backwards-compatibility, the sufixes <em>Console</em> and <em>ConsoleHelper</em> are also supported.
+     * Support for this will be removed when the {@link com.izforge.izpack.installer.console.PanelConsole} interface is
+     * removed.
+     *
+     * @param className the ConsolePanel class name
+     * @param loader    the class loader to use
+     * @return the corresponding IzPanel implementation, or {@code null} if none is found
+     */
+    public static Class<IzPanel> getIzPanel(String className, ClassLoader loader)
+    {
+        Class<IzPanel> result = getClass(className.replaceAll("ConsolePanel$", "Panel"), IzPanel.class, loader);
+        if (result == null)
+        {
+            result = getClass(className.replaceAll("ConsoleHelper$", ""), IzPanel.class, loader);
+            if (result == null)
+            {
+                result = getClass(className.replaceFirst("Console", ""), IzPanel.class, loader);
+            }
+        }
+        return result;
+    }
 
     /**
      * Returns the console implementation of an {@link IzPanel}.

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloConsolePanel.java
@@ -96,6 +96,8 @@ public class CheckedHelloConsolePanel extends HelloConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         boolean result = true;
         if (registered)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetConsolePanel.java
@@ -92,6 +92,8 @@ public class DefaultTargetConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         String path = TargetPanelHelper.getPath(installData);
         installData.setInstallPath(path);
         return true;

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishConsolePanel.java
@@ -105,6 +105,8 @@ public class FinishConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         if (doGenerateAutoInstallScript())
         {
             generateAutoInstallScript(installData, uninstallData, console);
@@ -113,11 +115,11 @@ public class FinishConsolePanel extends AbstractConsolePanel
         if (installData.isInstallSuccess())
         {
             console.println("Installation was successful");
-            console.println("application installed on " + installData.getInstallPath());
+            console.println("Application installed on " + installData.getInstallPath());
         }
         else
         {
-            console.println("Install Failed!!!");
+            console.println("Installation failed!");
         }
         return true;
     }
@@ -160,7 +162,7 @@ public class FinishConsolePanel extends AbstractConsolePanel
                  * (e.g. with launch4j), the autoInstall script is generated in the /tmp directory
                  * of the installer
                  */
-                console.println("path of the installation script must be absolute");
+                console.println("Path of the installation script must be absolute");
                 promptRerunPanel(installData, console);
             }
             else
@@ -179,7 +181,7 @@ public class FinishConsolePanel extends AbstractConsolePanel
         }
         catch (Exception err)
         {
-            console.println("failed to save the installation into file [" + file.getAbsolutePath() + "]");
+            console.println("Failed to save the installation into file [" + file.getAbsolutePath() + "]");
         }
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/hello/HelloConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/hello/HelloConsolePanel.java
@@ -65,6 +65,8 @@ public class HelloConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         display(installData, console);
         return promptEndPanel(installData, console);
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/htmlinfo/HTMLInfoConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/htmlinfo/HTMLInfoConsolePanel.java
@@ -64,8 +64,9 @@ public class HTMLInfoConsolePanel extends AbstractTextConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
         console.println(installData.getMessages().get("InfoPanel.info"));
-        return super.run(installData, console);
+        return true;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallConsolePanel.java
@@ -66,6 +66,7 @@ public class InstallConsolePanel extends AbstractConsolePanel implements Progres
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
         return run();
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupConsolePanel.java
@@ -69,6 +69,8 @@ public class InstallationGroupConsolePanel extends AbstractConsolePanel implemen
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         // Set/restore availablePacks from allPacks; consider OS constraints
         this.automatedInstallData.setAvailablePacks(new ArrayList<Pack>());
         for (Pack pack : this.automatedInstallData.getAllPacks())

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathConsolePanel.java
@@ -96,6 +96,8 @@ public class JDKPathConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         String detectedJavaVersion = "";
         String defaultValue = JDKPathPanelHelper.getDefaultJavaPath(installData, handler);
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksConsolePanel.java
@@ -101,7 +101,8 @@ public class PacksConsolePanel extends AbstractConsolePanel implements ConsolePa
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        out(Type.INFORMATION, "");
+        super.run(installData, console);
+
         out(Type.INFORMATION, installData.getMessages().get("PacksPanel.info"));
         out(Type.INFORMATION, "");
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessConsolePanel.java
@@ -131,6 +131,7 @@ public class ProcessConsolePanel extends AbstractConsolePanel implements Console
 
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
         return run(installData);
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConsolePanel.java
@@ -126,6 +126,8 @@ public class ShortcutConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         boolean result = true;
         try
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetConsolePanel.java
@@ -90,6 +90,8 @@ public class TargetConsolePanel extends AbstractConsolePanel implements ConsoleP
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         File pathFile;
         String normalizedPath;
         String defaultPath = TargetPanelHelper.getPath(installData);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksConsolePanel.java
@@ -103,6 +103,8 @@ public class TreePacksConsolePanel extends AbstractConsolePanel implements Conso
      */
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         List<Pack> selectedPacks;
         packsModel = new PacksModel(installData);
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
@@ -215,6 +215,8 @@ public class UserInputConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         boolean result = true;
         if (fields != null && !fields.isEmpty())
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathConsolePanel.java
@@ -101,6 +101,8 @@ public class UserPathConsolePanel extends AbstractConsolePanel
 
     public boolean run(InstallData installData, Console console)
     {
+        super.run(installData, console);
+
         loadLangpack(installData);
 
         String userPathPanel;

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/process/ProcessConsolePanelTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/process/ProcessConsolePanelTest.java
@@ -134,8 +134,8 @@ public class ProcessConsolePanelTest
         ProcessConsolePanel panel = new ProcessConsolePanel(rules, resources, prompt, matcher, null);
         assertFalse(panel.run(installData, console));
 
-        assertEquals(4, console.getOutput().size());
-        assertTrue(console.getOutput().get(3).equals(
+        assertEquals(7, console.getOutput().size());
+        assertTrue(console.getOutput().get(6).equals(
                 "Invocation Problem calling: com.izforge.izpack.panels.process.Executable, Executable exception"));
 
         // verify Executable was run the expected no. of times, with the expected arguments


### PR DESCRIPTION
This request implements [IZPACK-1327](https://izpack.atlassian.net/browse/IZPACK-1327):

Currently, no implementation of the built-in console mode panels doesn't show the panel headline like in GUI mode. In console mode, after activating a new panel, the headline should be printed to the terminal:

**Example: TargetPanel**

```
──────────────────────────────────────────────────────────
Target Path
──────────────────────────────────────────────────────────
Select the installation path:  [/home/rkrell/myapp] 
```

The _useHeadingPanel_ modifier in the `<guiprefs>` section of install.xml is ignored here, since guiprefs are not available to console panels.