### PR TITLE
IZPACK-1328: Various compiler and installer logging improvements

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/merge/CompilerPathResolver.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/merge/CompilerPathResolver.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 import com.izforge.izpack.api.exception.CompilerException;
 import com.izforge.izpack.api.merge.Mergeable;
@@ -50,6 +51,12 @@ import com.izforge.izpack.merge.resolve.PathResolver;
  */
 public class CompilerPathResolver extends PathResolver
 {
+
+    /**
+     * The logger.
+     */
+    private static final Logger logger = Logger.getLogger(CompilerPathResolver.class.getName());
+
 
     /**
      * The class loader.
@@ -94,10 +101,18 @@ public class CompilerPathResolver extends PathResolver
         {
             getMergeableByPackage(consoleType, mergeableByPackage);
         }
+        else
+        {
+            logger.warning("No console mode helper found for class " + className + ", panel type will be skipped in console mode installation");
+        }
         Class<PanelAutomation> automatedType = PanelHelper.getAutomatedPanel(className, loader);
         if (automatedType != null)
         {
             getMergeableByPackage(automatedType, mergeableByPackage);
+        }
+        else
+        {
+            logger.warning("No automation helper found for class " + className + ", panel type will be skipped in automated installation");
         }
         for (List<Mergeable> pkg : mergeableByPackage.values())
         {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PanelHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PanelHelper.java
@@ -20,12 +20,11 @@
  */
 package com.izforge.izpack.installer.util;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.installer.automation.PanelAutomation;
 import com.izforge.izpack.installer.console.ConsolePanel;
 import com.izforge.izpack.installer.gui.IzPanel;
+
+import java.util.logging.Logger;
 
 
 /**
@@ -53,7 +52,7 @@ public class PanelHelper
      * <br/>
      * E.g for the panel {@code HelloPanel}, the console implementation must be named {@code HelloConsolePanel}.
      * <p/>
-     * For backwards-compatibility, the sufixes <em>Console</em> and <em>ConsoleHelper</em> are also supported.
+     * For backwards-compatibility, the suffixes <em>Console</em> and <em>ConsoleHelper</em> are also supported.
      * Support for this will be removed when the {@link com.izforge.izpack.installer.console.PanelConsole} interface is
      * removed.
      *
@@ -76,7 +75,7 @@ public class PanelHelper
      * <br/>
      * E.g for the panel {@code HelloPanel}, the console implementation must be named {@code HelloConsolePanel}.
      * <p/>
-     * For backwards-compatibility, the sufixes <em>Console</em> and <em>ConsoleHelper</em> are also supported.
+     * For backwards-compatibility, the suffixes <em>Console</em> and <em>ConsoleHelper</em> are also supported.
      * Support for this will be removed when the {@link com.izforge.izpack.installer.console.PanelConsole} interface is
      * removed.
      *
@@ -158,19 +157,14 @@ public class PanelHelper
             Class type = loader.loadClass(name);
             if (!superType.isAssignableFrom(type))
             {
-                logger.warning(name + " does not implement " + superType.getName() + ", ignoring");
+                logger.fine(name + " does not implement " + superType.getName() + ", ignoring");
             }
             else
             {
                 result = (Class<T>) type;
             }
         }
-        catch (Throwable exception)
-        {
-            // ignore
-            logger.log(Level.FINE, "No " + superType.getSimpleName() + " + found for class " + name + ": "
-                    + exception.toString(), exception);
-        }
+        catch (ClassNotFoundException ignored) {}
         return result;
     }
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/LogFormatter.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/LogFormatter.java
@@ -2,8 +2,6 @@ package com.izforge.izpack.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.MessageFormat;
-import java.util.Date;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 
@@ -13,12 +11,7 @@ import java.util.logging.LogRecord;
  */
 public class LogFormatter extends Formatter
 {
-    Date date = new Date();
-    private final static String format = "{0,date} {0,time}";
     private final String lineSeparator = System.getProperty("line.separator");
-    private MessageFormat formatter;
-
-    private Object args[] = new Object[1];
 
     /**
      * Format the given LogRecord.
@@ -29,19 +22,7 @@ public class LogFormatter extends Formatter
     @Override
     public synchronized String format(LogRecord record)
     {
-        StringBuffer sb = new StringBuffer();
-        // Minimize memory allocations here.
-        date.setTime(record.getMillis());
-        args[0] = date;
-        StringBuffer text = new StringBuffer();
-        if (formatter == null)
-        {
-            formatter = new MessageFormat(format);
-        }
-        formatter.format(args, text, null);
-        sb.append(text);
-        sb.append(" ");
-
+        StringBuilder sb = new StringBuilder();
         if (Debug.isDEBUG())
         {
             if (record.getSourceClassName() != null)
@@ -59,12 +40,12 @@ public class LogFormatter extends Formatter
             }
 
             sb.append(lineSeparator);
+            sb.append(record.getLevel().getLocalizedName());
+            sb.append(": ");
         }
 
         // Append log message
         String message = formatMessage(record);
-        sb.append(record.getLevel().getLocalizedName());
-        sb.append(": ");
         sb.append(message);
 
         // Append stacktrace
@@ -79,8 +60,7 @@ public class LogFormatter extends Formatter
                 pw.close();
                 sb.append(sw.toString());
             }
-            catch (Exception ex)
-            {}
+            catch (Exception ignored) {}
         }
 
         sb.append(lineSeparator);


### PR DESCRIPTION
This is an implementation of [IZPACK-1328](https://izpack.atlassian.net/browse/IZPACK-1328):

From the mailing lists and from experience, there came several motions to improve the log output produced by the Java Util Logging system of the compiler and installer:

### Compiler:
- Use Maven log level in IzPack Maven plugin.
- Don't log added files at INFO level, move it to DEBUG level instead.
  This should help to keep the build log less messy
- As a replacement for no longer showing the single files added log a message how many files were added with each single pack.
- Shorten the log message for added files.
- Strip the `$INSTALL_PATH/` prefix from target paths logged.
- Mute meaningless log entries with stacktrace of type:
  ```
  [FINE] No PanelAutomation + found for class com.izforge.izpack.panels.install.InstallPanelAutomation: java.lang.ClassNotFoundException: com.izforge.izpack.panels.install.InstallPanelAutomation
java.lang.ClassNotFoundException: com.izforge.izpack.panels.install.InstallPanelAutomation
        at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
        at com.izforge.izpack.compiler.util.CompilerClassLoader.findClass(CompilerClassLoader.java:136)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
        at com.izforge.izpack.installer.util.PanelHelper.getClass(PanelHelper.java:158)
        at com.izforge.izpack.installer.util.PanelHelper.getPanelClass(PanelHelper.java:136)
        at com.izforge.izpack.installer.util.PanelHelper.getAutomatedPanel(PanelHelper.java:118)
        at com.izforge.izpack.compiler.merge.CompilerPathResolver.getPanelMerge(CompilerPathResolver.java:97)
        at com.izforge.izpack.compiler.packager.impl.PackagerBase.addPanel(PackagerBase.java:271)
        at com.izforge.izpack.compiler.CompilerConfig.addPanels(CompilerConfig.java:1675)
        at com.izforge.izpack.compiler.CompilerConfig.executeCompiler(CompilerConfig.java:333)
        at org.izpack.mojo.IzPackNewMojo.execute(IzPackNewMojo.java:212)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:120)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:355)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:216)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:160)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
        at java.lang.reflect.Method.invoke(Method.java:597)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
  ```
- If automation or console mode helper for a panel does not exist, log a warning that the panel will be skipped for this type of installation mode.

### Installer:
- Remove leading timestamp and log level in each log entry.
  This improves especially the readability of the output for console mode installations and makes it consistent with the non-log output of a console installation.