### PR TITLE
IZPACK-1329: Consolidate license panels functionality and translations

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
@@ -77,6 +77,31 @@
     <str id="CheckedHelloPanel.productAlreadyExist1" txt=" . Você tem certeza de que quer instalar outra cópia?"/>
     <str id="CheckedHelloPanel.infoOverUninstallKey" txt="A chave de desinstalação será chamada: "/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <str id="LicencePanel.info" txt="Por favor, leia o seguinte contrato de licença :"/>
     <str id="LicencePanel.agree" txt="Eu concordo com este contrato de licença."/>
     <str id="LicencePanel.notagree" txt="Eu não concordo com este contrato de licença."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/cat.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/cat.xml
@@ -7,6 +7,31 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Instal.lació de "/>
     <str id="installer.next" txt="Següent"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
@@ -7,6 +7,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Zvolte 1 - pokračovat, 2 - konec, 3 - opětovně zobrazit"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Zvolte 1 - přijmout, 2 - odmítnout, 3 - opětovně zobrazit"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 - opětovně zobrazit, 2 - konec"/>
+    <str id="ConsoleInstaller.permissionError" txt="Tato operace vyžaduje práva administrátora. Instalaci je nutno spouštět pod uživatelským účtem s oprávněním správce systému."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Zadejte volbu: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="Další"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="Byl stisknut CTRL-C"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="Licenční ujednání byly zamítnuty"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Byl zvolen konec instalace"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="Některé operace se soubory budou dokončené po restartování systému"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Restart systému zahájen"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Konec instalace"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Instalace byla přerušena uživatelem!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Instalace selhala!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Instalace "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/chn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/chn.xml
@@ -7,6 +7,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - °²×° "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/dan.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/dan.xml
@@ -7,6 +7,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Installation af "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
@@ -317,6 +317,17 @@ file we looked for -->
     <str id="ConsoleInstaller.continueQuitRedisplay" txt="Eingabe 1 (Weiter), 2 (Beenden), 3 (Erneut anzeigen)"/>
     <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Eingabe 1 (Bestätigen), 2 (Ablehnen), 3 (Erneut anzeigen)"/>
     <str id="ConsoleInstaller.redisplayQuit" txt="Eingabe 1 (Erneut anzeigen), 2 (Beenden)"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administratorrechte erforderlich. Bitte starten Sie das Installationsprogramm erneut unter den erforderlichen Benutzerrechten."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Auswahl eingeben: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="Mehr"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C betätigt"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="Lizenzvereinbarung abgelehnt"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Beenden betätigt"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="Einige Dateioperationen werden erst nach einem Neustart fertiggestellt"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Automatischer Neustart erfolgt"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Textkonsolen-Installation beendet"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Benutzerabbruch der Textkonsolen-Installation!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Textkonsolen-Installation fehlgeschlagen!"/>
 
     <!-- Add your own panels specific strings here if you need or use a custom
 langpack with the same syntax referred as resoure CustomLangpack.xml_[ISO3]" -->

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -7,7 +7,6 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
-
     <!-- Heading messages START -->
     <str id="CheckedHelloPanel.headline" txt="Welcome"/>
     <str id="CompilePanel.headline" txt="Compile Java Sources"/>
@@ -342,6 +341,15 @@
     <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- AutomatedInstaller Strings -->
     <str id="AutomatedInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
@@ -34,6 +34,31 @@
     <str id="UserPathPanel.headline" txt="Aukeratu Bidea"/>
     <str id="InstallationTypePanel.headline" txt="Instalazio Mota"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="Alliaria - Instaladorea: "/>
     <str id="installer.next" txt="Aurrera"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
@@ -32,6 +32,31 @@
     <str id="TreePacksPanel.headline" txt="انتخاب بسته های نصب"/>
     <str id="UserInputPanel.headline" txt="اطلاعات کاربر"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack نصب "/>
     <str id="installer.next" txt="بعدی"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
@@ -34,6 +34,31 @@
     <str id="UserPathPanel.headline" txt="Valitse polku"/>
     <str id="InstallationTypePanel.headline" txt="Asennuksen tyyppi"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Asennetaan: "/>
     <str id="installer.next" txt="Seuraava"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
@@ -290,6 +290,17 @@
     <str id="ConsoleInstaller.continueQuitRedisplay" txt="Appuyer sur 1 pour continuer, 2 pour quitter, 3 pour réafficher"/>
     <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Appuyer sur 1 pour accepter, 2 pour refuser, 3 pour réafficher"/>
     <str id="ConsoleInstaller.redisplayQuit" txt="Appuyer sur 1 pour réafficher, 2 pour quitter"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- Next Media Strings -->
     <str id="nextmedia.title" txt="Prochain media d'installation"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
@@ -34,6 +34,31 @@
     <str id="UserPathPanel.headline" txt="Ruta Seleccionada"/>
     <str id="InstallationTypePanel.headline" txt="Tipo de Instalación"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Instalación de "/>
     <str id="installer.next" txt="Seguinte"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
@@ -30,6 +30,31 @@
     <str id="UserInputPanel.headline" txt="Fölhasználói adatok"/>
     <str id="InstallationTypePanel.headline" txt="Telepítés módja"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - telepítés - "/>
     <str id="installer.next" txt="Következõ"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
@@ -34,6 +34,31 @@
     <str id="UserPathPanel.headline" txt="Pilih Lokasi"/>
     <str id="InstallationTypePanel.headline" txt="Jenis Pemasangan"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Pemasangan "/>
     <str id="installer.next" txt="Berikut"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
@@ -34,6 +34,31 @@
     <str id="UserPathPanel.headline" txt="Selezionare percorso"/>
     <str id="InstallationTypePanel.headline" txt="Tipo installazione"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Installazione di "/>
     <str id="installer.next" txt="Avanti"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
@@ -64,6 +64,31 @@
     <str id="UserPathPanel.headline" txt="パスの選択"/>
     <str id="InstallationTypePanel.headline" txt="インストールの種類"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <!-- Notice! more natural Japanese requires string after product name -->
     <str id="installer.title" txt="IzPack - インストール - "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
@@ -8,6 +8,31 @@
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - 설치: "/>
     <str id="installer.next" txt="다음"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/msa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/msa.xml
@@ -7,6 +7,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Pemasangan untuk "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
@@ -37,6 +37,31 @@
     <str id="UserPathPanel.headline" txt="Selekteer pad"/>
     <str id="InstallationTypePanel.headline" txt="Installatietype"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Installatie van "/>
     <str id="installer.next" txt="Verder"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
@@ -7,6 +7,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- Heading messages START -->
     <str id="CheckedHelloPanel.headline" txt="Velkommen"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
@@ -99,6 +99,31 @@
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <str id="InstallPanel.begin" txt=" "/>
     <str id="InstallPanel.finished" txt="[Zakończono]"/>
     <str id="InstallPanel.headline" txt="Instalacja"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
@@ -34,6 +34,31 @@
     <str id="UserPathPanel.headline" txt="Seleccione a Localização"/>
     <str id="InstallationTypePanel.headline" txt="Tipo de Instalação"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Instalação de "/>
     <str id="installer.next" txt="Seguinte"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ron.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ron.xml
@@ -7,6 +7,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Instalare "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
@@ -8,6 +8,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Установка "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
@@ -35,6 +35,30 @@
     <str id="InstallationTypePanel.headline" txt="Typ inštalácie"/>
     <str id="DefaultTargetPanel.summaryCaption" txt="Inštalačný priečinok"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Inštalácia "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -342,6 +342,15 @@
     <str id="ConsoleInstaller.redisplayQuit" txt="Presione 1 para volver a mostrar, 2 para salir"/>
     <str id="ConsoleInstaller.permissionError" txt="Se requieren permisos administrativos. Por favor, arranque de nuevo el instalador con permisos administrativos."/>
     <str id="ConsoleInstaller.inputSelection" txt="Introduzca selección: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- AutomatedInstaller Strings -->
     <str id="AutomatedInstaller.permissionError" txt="Se requieren permisos administrativos. Por favor, arranque de nuevo el instalador con permisos administrativos."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/srp.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/srp.xml
@@ -5,6 +5,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Инсталација "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
@@ -268,6 +268,15 @@
     <str id="ConsoleInstaller.redisplayQuit" txt="Tryck 1 för att repetera, 2 för att avsluta"/>
     <str id="ConsoleInstaller.permissionError" txt="Administratörsrättigheter krävs. Väligen kör installationen med administratörsrättigheter."/>
     <str id="ConsoleInstaller.inputSelection" txt="Ditt val: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- AutomatedInstaller Strings -->
     <str id="AutomatedInstaller.permissionError" txt="Administratörsrättigheter krävs. Väligen kör installationen med administratörsrättigheter."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
@@ -39,6 +39,31 @@
     <str id="TreePacksPanel.headline" txt="Kurmak İstediğiniz Paketleri Seçiniz"/>
     <str id="UserInputPanel.headline" txt="Kullanıcı Bilgileri"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- Genel kurulum karakter dizileri -->
     <str id="installer.title" txt="IzPack - Kurulum "/>
     <str id="installer.next" txt="Sonraki"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
@@ -7,6 +7,30 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
 
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - 安裝部署 "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
@@ -35,6 +35,31 @@
     <str id="UserPathPanel.headline" txt="Виберіть шлях"/>
     <str id="InstallationTypePanel.headline" txt="Тип встановлення"/>
 
+    <!-- ConsolePrompt strings -->
+    <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>
+    <str id="ConsolePrompt.yesNo" txt="Enter Y for Yes, N for No: "/>
+    <str id="ConsolePrompt.yesNoCancel" txt="Enter Y for Yes, N for No, or C to Cancel: "/>
+    <str id="ConsolePrompt.ok" txt="O"/>
+    <str id="ConsolePrompt.cancel" txt="C"/>
+    <str id="ConsolePrompt.yes" txt="Y"/>
+    <str id="ConsolePrompt.no" txt="N"/>
+
+    <!-- ConsoleInstaller strings -->
+    <str id="ConsoleInstaller.continueQuitRedisplay" txt="Press 1 to continue, 2 to quit, 3 to redisplay"/>
+    <str id="ConsoleInstaller.acceptRejectRedisplay" txt="Press 1 to accept, 2 to reject, 3 to redisplay"/>
+    <str id="ConsoleInstaller.redisplayQuit" txt="Press 1 to redisplay, 2 to quit"/>
+    <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
+    <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
+    <str id="ConsoleInstaller.pagingMore" txt="More"/>
+    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
+    <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
+    <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>
+    <str id="ConsoleInstaller.shutdown.aborted" txt="Console installation ABORTED by the user!"/>
+    <str id="ConsoleInstaller.shutdown.failed" txt="Console installation FAILED!"/>
+
     <!-- General installer strings -->
     <str id="installer.title" txt="IzPack - Встановлення "/>
     <str id="installer.next" txt="Далі"/>

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
@@ -25,6 +25,7 @@ import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.exception.UserInterruptException;
+import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.installer.panel.PanelView;
 import com.izforge.izpack.installer.util.PanelHelper;
 import com.izforge.izpack.util.Console;
@@ -89,8 +90,8 @@ public abstract class AbstractConsolePanel implements ConsolePanel
     protected boolean promptEndPanel(InstallData installData, Console console)
     {
         boolean result;
-
-        String prompt = installData.getMessages().get("ConsoleInstaller.continueQuitRedisplay");
+        final Messages messages = installData.getMessages();
+        String prompt = messages.get("ConsoleInstaller.continueQuitRedisplay");
         console.println();
         int value = console.prompt(prompt, 1, 3, 2);
         switch (value)
@@ -100,7 +101,7 @@ public abstract class AbstractConsolePanel implements ConsolePanel
                 break;
 
             case 2:
-                throw new UserInterruptException("Quit pressed");
+                throw new UserInterruptException(messages.get("ConsoleInstaller.abortedPressedQuit"));
 
             default:
                 result =  run(installData, console);
@@ -123,13 +124,14 @@ public abstract class AbstractConsolePanel implements ConsolePanel
     protected boolean promptRerunPanel(InstallData installData, Console console)
     {
         boolean result;
-        String prompt = installData.getMessages().get("ConsoleInstaller.redisplayQuit");
+        final Messages messages = installData.getMessages();
+        String prompt = messages.get("ConsoleInstaller.redisplayQuit");
         console.println();
         int value = console.prompt(prompt, 1, 2, 2);
         switch (value)
         {
             case 2:
-                throw new UserInterruptException("Quit pressed");
+                throw new UserInterruptException(messages.get("ConsoleInstaller.abortedPressedQuit"));
 
             default:
                 result = run(installData, console);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
@@ -32,6 +32,7 @@ import com.izforge.izpack.api.data.Info;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.exception.UserInterruptException;
+import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.installer.base.InstallerBase;
 import com.izforge.izpack.installer.bootstrap.Installer;
 import com.izforge.izpack.installer.data.UninstallData;
@@ -214,9 +215,10 @@ public class ConsoleInstaller implements InstallerBase
     {
         // TODO - fix reboot handling
         boolean reboot = false;
+        final Messages messages = installData.getMessages();
         if (installData.isRebootNecessary())
         {
-            console.println("[ There are file operations pending after reboot ]");
+            console.println("[ " + messages.get("ConsoleInstaller.shutdown.pendingFileOperations") + " ]");
             switch (installData.getInfo().getRebootAction())
             {
                 case Info.REBOOT_ACTION_ALWAYS:
@@ -224,7 +226,7 @@ public class ConsoleInstaller implements InstallerBase
             }
             if (reboot)
             {
-                console.println("[ Rebooting now automatically ]");
+                console.println("[ " + messages.get("ConsoleInstaller.shutdown.rebootingNow") + " ]");
             }
         }
         shutdown(exitSuccess, reboot);
@@ -238,6 +240,7 @@ public class ConsoleInstaller implements InstallerBase
      */
     protected void shutdown(boolean exitSuccess, boolean reboot)
     {
+        final Messages messages = installData.getMessages();
         if (exitSuccess && !installData.isInstallSuccess())
         {
             logger.severe("Expected successful exit status, but installation data is reporting failure");
@@ -246,17 +249,17 @@ public class ConsoleInstaller implements InstallerBase
         installData.setInstallSuccess(exitSuccess);
         if (exitSuccess)
         {
-            console.println("[ Console installation done ]");
+            console.println("[ " + messages.get("ConsoleInstaller.shutdown.done") + " ]");
         }
         else
         {
             if (interrupted)
             {
-                console.println("[ Console installation ABORTED by the user! ]");
+                console.println("[ " + messages.get("ConsoleInstaller.shutdown.aborted") + " ]");
             }
             else
             {
-                console.println("[ Console installation FAILED! ]");
+                console.println("[ " + messages.get("ConsoleInstaller.shutdown.failed") + " ]");
             }
         }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
@@ -107,7 +107,7 @@ abstract public class PanelConsoleHelper extends AbstractConsolePanel implements
     @Deprecated
     public boolean runConsole(InstallData installData)
     {
-        return runConsole(installData, new Console());
+        return runConsole(installData, new Console(installData.getMessages()));
     }
 
     /**
@@ -118,9 +118,9 @@ abstract public class PanelConsoleHelper extends AbstractConsolePanel implements
      * @deprecated
      */
     @Deprecated
-    public int askEndOfConsolePanel()
+    public int askEndOfConsolePanel(InstallData installData)
     {
-        return new Console().prompt("press 1 to continue, 2 to quit, 3 to redisplay", 1, 3, 2);
+        return new Console(installData.getMessages()).prompt("press 1 to continue, 2 to quit, 3 to redisplay", 1, 3, 2);
     }
 
 }

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/AbstractRequirementCheckerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/AbstractRequirementCheckerTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractRequirementCheckerTest
         assertNotNull(langPack);
         installData.setMessages(new LocaleDatabase(langPack, Mockito.mock(Locales.class)));
 
-        console = new TestConsole();
+        console = new TestConsole(installData.getMessages());
         prompt = new ConsolePrompt(console, installData.getMessages());
     }
 }

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/JDKCheckerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/JDKCheckerTest.java
@@ -88,7 +88,7 @@ public class JDKCheckerTest extends AbstractRequirementCheckerTest
         boolean exists = (code == 0); // exists if javac is in the path
         installData.getInfo().setJdkRequired(true);
 
-        TestConsole console = new TestConsole();
+        TestConsole console = new TestConsole(installData.getMessages());
         ConsolePrompt prompt = new ConsolePrompt(console, installData.getMessages());
         JDKChecker checker = new JDKChecker(installData, prompt);
         assertEquals(exists, checker.check());

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/htmllicence/HTMLLicenceConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/htmllicence/HTMLLicenceConsolePanel.java
@@ -1,16 +1,14 @@
 /*
- * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
+ * IzPack - Copyright 2001-2016 The IzPack project team.
+ * All Rights Reserved.
  *
  * http://izpack.org/
- * http://izpack.codehaus.org/
- *
- * Copyright 2002 Jan Blok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,26 +19,16 @@
 
 package com.izforge.izpack.panels.htmllicence;
 
-import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.console.ConsolePanel;
 import com.izforge.izpack.installer.panel.PanelView;
 import com.izforge.izpack.panels.licence.AbstractLicenceConsolePanel;
-
-import java.util.logging.Logger;
 
 /**
  * HTML Licence Panel console helper
  */
 public class HTMLLicenceConsolePanel extends AbstractLicenceConsolePanel
 {
-    /**
-     * The logger.
-     */
-    private static final Logger logger = Logger.getLogger(HTMLLicenceConsolePanel.class.getName());
-
-    private static final String DEFAULT_SUFFIX = ".licence";
-
     /**
      * Constructs an <tt>HTMLLicenceConsolePanel</tt>.
      *
@@ -60,35 +48,7 @@ public class HTMLLicenceConsolePanel extends AbstractLicenceConsolePanel
     @Override
     protected String getText()
     {
-        final String resNamePrefix = HTMLLicencePanel.class.getSimpleName();
-        String text = null;
-
-        Panel panel = getPanel();
-        if (panel != null)
-        {
-            String panelId = panel.getPanelId();
-            if (panelId != null)
-            {
-                String panelSpecificResName = resNamePrefix + '.' + panelId;
-                text = getText(panelSpecificResName);
-                if (text == null)
-                {
-                    text = getText(resNamePrefix + DEFAULT_SUFFIX);
-                }
-            }
-        }
-
-        if (text != null)
-        {
-            text = removeHTML(text);
-        }
-        else
-        {
-            logger.warning("Cannot open any of both license text resources ("
-                    + resNamePrefix + '.' + panel.getPanelId() + ", " + resNamePrefix + DEFAULT_SUFFIX
-                    + ") for panel type '" + HTMLLicencePanel.class.getSimpleName() + "" );
-        }
-        return text;
+        return removeHTML(loadLicenceAsString());
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/htmllicence/HTMLLicencePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/htmllicence/HTMLLicencePanel.java
@@ -21,14 +21,13 @@ package com.izforge.izpack.panels.htmllicence;
 
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.Panel;
-import com.izforge.izpack.api.exception.ResourceNotFoundException;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.gui.IzPanelLayout;
 import com.izforge.izpack.gui.LabelFactory;
 import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
-import com.izforge.izpack.installer.gui.IzPanel;
+import com.izforge.izpack.panels.licence.AbstractLicencePanel;
 
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
@@ -37,27 +36,15 @@ import javax.swing.text.Document;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.net.URL;
-import java.util.logging.Logger;
 
 /**
  * The IzPack HTML license panel.
  *
  * @author Julien Ponge
  */
-public class HTMLLicencePanel extends IzPanel implements HyperlinkListener, ActionListener
+public class HTMLLicencePanel extends AbstractLicencePanel implements HyperlinkListener, ActionListener
 {
-    /**
-     * The logger.
-     */
-    private static final Logger logger = Logger.getLogger(HTMLLicencePanel.class.getName());
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 3256728385458746416L;
-
-    private static final String DEFAULT_SUFFIX = ".licence";
 
     /**
      * The text area.
@@ -67,8 +54,8 @@ public class HTMLLicencePanel extends IzPanel implements HyperlinkListener, Acti
     /**
      * The radio buttons.
      */
-    private JRadioButton yesRadio;
-    private JRadioButton noRadio;
+    private final JRadioButton yesRadio;
+    private final JRadioButton noRadio;
 
     /**
      * Constructs an <tt>HTMLLicencePanel</tt>.
@@ -83,11 +70,8 @@ public class HTMLLicencePanel extends IzPanel implements HyperlinkListener, Acti
                             Log log)
     {
         super(panel, parent, installData, new IzPanelLayout(log), resources);
-        // We load the licence
-        loadLicence();
 
         // We put our components
-
         add(LabelFactory.create(getString("LicencePanel.info"), parent.getIcons().get("history"), LEADING), NEXT_LINE);
         try
         {
@@ -135,53 +119,6 @@ public class HTMLLicencePanel extends IzPanel implements HyperlinkListener, Acti
         noRadio.addActionListener(this);
         setInitialFocus(textArea);
         getLayoutHelper().completeLayout();
-    }
-
-    /**
-     * Loads the license text.
-     *
-     * @return The license text URL.
-     */
-    protected URL loadLicence()
-    {
-        final String resNamePrefix = HTMLLicencePanel.class.getSimpleName();
-        String resNameStr = resNamePrefix + DEFAULT_SUFFIX;
-
-        Panel panel = getMetadata();
-        Resources resources = getResources();
-        if (panel != null)
-        {
-            String panelId = panel.getPanelId();
-            if (panelId != null)
-            {
-                try
-                {
-                    String panelSpecificResName = resNamePrefix + '.' + panelId;
-                    String panelspecificResContent = resources.getString(panelSpecificResName, null);
-                    if (panelspecificResContent != null)
-                    {
-                        resNameStr = panelSpecificResName;
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Those ones can be skipped
-                }
-            }
-
-            try
-            {
-                return resources.getURL(resNameStr);
-            }
-            catch (ResourceNotFoundException ex)
-            {
-                logger.warning("Cannot open any of both license text resources ("
-                        + resNamePrefix + '.' + panel.getPanelId() + ", " + resNamePrefix + DEFAULT_SUFFIX
-                        + ") for panel type '" + HTMLLicencePanel.class.getSimpleName() + "" );
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicenceConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicenceConsolePanel.java
@@ -1,16 +1,14 @@
 /*
- * IzPack - Copyright 2001-2013 Julien Ponge, All Rights Reserved.
+ * IzPack - Copyright 2001-2016 The IzPack project team.
+ * All Rights Reserved.
  *
  * http://izpack.org/
- * http://izpack.codehaus.org/
- *
- * Copyright 2012 Tim Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,16 +19,25 @@
 
 package com.izforge.izpack.panels.licence;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Panel;
+import com.izforge.izpack.api.exception.ResourceNotFoundException;
 import com.izforge.izpack.api.exception.UserInterruptException;
+import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.console.AbstractTextConsolePanel;
 import com.izforge.izpack.installer.console.ConsolePanel;
+import com.izforge.izpack.installer.gui.IzPanel;
 import com.izforge.izpack.installer.panel.PanelView;
+import com.izforge.izpack.installer.util.PanelHelper;
 import com.izforge.izpack.util.Console;
+import com.izforge.izpack.util.file.FileUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.logging.Logger;
 
 /**
  * Abstract panel for displaying license text to the console.
@@ -39,6 +46,7 @@ import com.izforge.izpack.util.Console;
  */
 public abstract class AbstractLicenceConsolePanel extends AbstractTextConsolePanel
 {
+    private static final String DEFAULT_SUFFIX = ".licence";
 
     /**
      * The resources.
@@ -63,17 +71,88 @@ public abstract class AbstractLicenceConsolePanel extends AbstractTextConsolePan
     }
 
     /**
-     * Returns the named text resource
+     * Loads the license document URL.
      *
-     * @param resourceName the resource name
-     * @return the text resource, or {@code null} if it cannot be found
+     * @return The license text URL.
      */
-    protected String getText(String resourceName)
+    protected URL loadLicence()
     {
-        String result = resources.getString(resourceName, null, null);
-        if (result == null)
+        URL url = null;
+        final Class<? extends AbstractLicenceConsolePanel> thisClazz = getClass();
+        final Class<IzPanel> izClass = PanelHelper.getIzPanel(thisClazz.getName());
+        if (izClass != null)
         {
-            logger.log(Level.WARNING, "No licence text for resource: " + resourceName);
+            final String resNamePrefix = izClass.getSimpleName();
+            String resNameStr = resNamePrefix + DEFAULT_SUFFIX;
+            Panel panel = getPanel();
+            if (panel != null)
+            {
+                String panelId = panel.getPanelId();
+                if (panelId != null)
+                {
+                    String panelSpecificResName = resNamePrefix + '.' + panelId;
+                    try
+                    {
+                        url = resources.getURL(panelSpecificResName);
+                    }
+                    catch (ResourceNotFoundException e)
+                    {
+                        try
+                        {
+                            url = resources.getURL(resNameStr);
+                        }
+                        catch (Exception ignored)
+                        {
+                        }
+                    }
+                }
+            }
+            if (url == null)
+            {
+                String panelId = panel != null ? panel.getPanelId() : null;
+                logger.warning("Cannot open any of the possible license document resources ("
+                        + (panelId != null ? resNamePrefix + '.' + panelId + ", " : "")
+                        + resNamePrefix + DEFAULT_SUFFIX
+                        + ") for panel type '" + resNamePrefix + "" );
+            }
+        }
+        else
+        {
+            logger.warning("No IzPanel implementation found for " + thisClazz.getSimpleName());
+        }
+
+        return url;
+    }
+
+    protected String loadLicenceAsString()
+    {
+        return loadLicenceAsString("UTF-8");
+    }
+
+    protected String loadLicenceAsString(final String encoding)
+    {
+        URL url = null;
+        String result = null;
+        try
+        {
+            url = loadLicence();
+
+            InputStream in = url.openStream();
+            InputStreamReader reader = null;
+            try
+            {
+                reader = (encoding != null) ? new InputStreamReader(in, encoding) : new InputStreamReader(in);
+                result = FileUtils.readFully(reader);
+            }
+            finally
+            {
+                FileUtils.close(reader);
+                FileUtils.close(in);
+            }
+        }
+        catch (IOException e)
+        {
+            logger.warning("Cannot convert license document from resource " + url.getFile() + " to text: " + e.getMessage());
         }
         return result;
     }
@@ -86,14 +165,15 @@ public abstract class AbstractLicenceConsolePanel extends AbstractTextConsolePan
      *
      * @param installData the installation date
      * @param console     the console to use
-     * @return {@code true} to accept, {@code false} to reject. If redisplaying the panel, the result of
+     * @return {@code true} to accept, {@code false} to reject. If the panel is displayed again, the result of
      *         {@link #run(InstallData, Console)} is returned
      */
     @Override
     protected boolean promptEndPanel(InstallData installData, Console console)
     {
         boolean result;
-        String prompt = installData.getMessages().get("ConsoleInstaller.acceptRejectRedisplay");
+        final Messages messages = installData.getMessages();
+        String prompt = messages.get("ConsoleInstaller.acceptRejectRedisplay");
         console.println();
         int value = console.prompt(prompt, 1, 3, 2);
         switch (value)
@@ -103,7 +183,7 @@ public abstract class AbstractLicenceConsolePanel extends AbstractTextConsolePan
                 break;
 
             case 2:
-                throw new UserInterruptException("License rejected");
+                throw new UserInterruptException(messages.get("ConsoleInstaller.abortedLicenseRejected"));
 
             default:
                 result =  run(installData, console);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicencePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicencePanel.java
@@ -1,0 +1,131 @@
+/*
+ * IzPack - Copyright 2001-2016 The IzPack project team.
+ * All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.panels.licence;
+
+import com.izforge.izpack.api.data.Panel;
+import com.izforge.izpack.api.exception.ResourceNotFoundException;
+import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.installer.data.GUIInstallData;
+import com.izforge.izpack.installer.gui.InstallerFrame;
+import com.izforge.izpack.installer.gui.IzPanel;
+import com.izforge.izpack.util.file.FileUtils;
+
+import java.awt.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.logging.Logger;
+
+public abstract class AbstractLicencePanel extends IzPanel
+{
+    /**
+     * The logger.
+     */
+    private static final Logger logger = Logger.getLogger(AbstractLicencePanel.class.getName());
+
+    private static final String DEFAULT_SUFFIX = ".licence";
+    private static final long serialVersionUID = 1483930095144726447L;
+
+    public AbstractLicencePanel(Panel panel, InstallerFrame parent, GUIInstallData installData, LayoutManager2 layoutManager, Resources resources)
+    {
+        super(panel, parent, installData, layoutManager, resources);
+    }
+
+    /**
+     * Loads the license document URL.
+     *
+     * @return The license text URL.
+     */
+    protected URL loadLicence()
+    {
+        final String resNamePrefix = getClass().getSimpleName();
+        String resNameStr = resNamePrefix + DEFAULT_SUFFIX;
+
+        Panel panel = getMetadata();
+        Resources resources = getResources();
+        URL url = null;
+        if (panel != null)
+        {
+            String panelId = panel.getPanelId();
+            if (panelId != null)
+            {
+                String panelSpecificResName = resNamePrefix + '.' + panelId;
+                try
+                {
+                    url = resources.getURL(panelSpecificResName);
+                }
+                catch (ResourceNotFoundException e)
+                {
+                    try
+                    {
+                        url = resources.getURL(resNameStr);
+                    }
+                    catch (Exception ignored)
+                    {
+                    }
+                }
+            }
+        }
+
+        if (url == null)
+        {
+            String panelId = panel != null ? panel.getPanelId() : null;
+            logger.warning("Cannot open any of the possible license document resources ("
+                    + (panelId != null ? resNamePrefix + '.' + panelId + ", " : "")
+                    + resNamePrefix + DEFAULT_SUFFIX
+                    + ") for panel type '" + resNamePrefix + "" );
+        }
+        return url;
+    }
+
+    protected String loadLicenceAsString()
+    {
+        return loadLicenceAsString("UTF-8");
+    }
+
+    protected String loadLicenceAsString(final String encoding)
+    {
+        URL url = null;
+        String result = null;
+        try
+        {
+            url = loadLicence();
+
+            InputStream in = url.openStream();
+            InputStreamReader reader = null;
+            try
+            {
+                reader = (encoding != null) ? new InputStreamReader(in, encoding) : new InputStreamReader(in);
+                result = FileUtils.readFully(reader);
+            }
+            finally
+            {
+                FileUtils.close(reader);
+                FileUtils.close(in);
+            }
+        }
+        catch (IOException e)
+        {
+            logger.warning("Cannot convert license document from resource " + url.getFile() + " to text: " + e.getMessage());
+        }
+        return result;
+    }
+}

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/LicenceConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/LicenceConsolePanel.java
@@ -1,16 +1,14 @@
 /*
- * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
+ * IzPack - Copyright 2001-2016 The IzPack project team.
+ * All Rights Reserved.
  *
  * http://izpack.org/
- * http://izpack.codehaus.org/
- *
- * Copyright 2002 Jan Blok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +22,6 @@ package com.izforge.izpack.panels.licence;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.console.ConsolePanel;
 import com.izforge.izpack.installer.panel.PanelView;
-
 
 /**
  * Console based Licence Panel.
@@ -50,7 +47,7 @@ public class LicenceConsolePanel extends AbstractLicenceConsolePanel
     @Override
     protected String getText()
     {
-        return getText("LicencePanel.licence");
+        return loadLicenceAsString();
     }
 
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/LicencePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/LicencePanel.java
@@ -1,16 +1,14 @@
 /*
- * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
+ * IzPack - Copyright 2001-2016 The IzPack project team.
+ * All Rights Reserved.
  *
  * http://izpack.org/
- * http://izpack.codehaus.org/
- *
- * Copyright 2002 Jan Blok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,18 +19,6 @@
 
 package com.izforge.izpack.panels.licence;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-
-import javax.swing.ButtonGroup;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import javax.swing.KeyStroke;
-
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Resources;
@@ -41,31 +27,26 @@ import com.izforge.izpack.gui.LabelFactory;
 import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
-import com.izforge.izpack.installer.gui.IzPanel;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 
 /**
  * The license panel.
  *
  * @author Julien Ponge
  */
-public class LicencePanel extends IzPanel implements ActionListener
+public class LicencePanel extends AbstractLicencePanel implements ActionListener
 {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 3691043187997552948L;
-
-    /**
-     * The license text.
-     */
-    private String licence;
 
     /**
      * The radio buttons.
      */
-    private JRadioButton yesRadio;
-    private JRadioButton noRadio;
+    private final JRadioButton yesRadio;
+    private final JRadioButton noRadio;
 
     /**
      * Constructs a <tt>LicencePanel</tt>.
@@ -80,14 +61,12 @@ public class LicencePanel extends IzPanel implements ActionListener
                         Log log)
     {
         super(panel, parent, installData, new IzPanelLayout(log), resources);
-        // We load the licence
-        loadLicence();
 
         // We put our components
-
         add(LabelFactory.create(getString("LicencePanel.info"),
                                 parent.getIcons().get("history"), LEADING), NEXT_LINE);
-        JTextArea textArea = new JTextArea(licence);
+
+        JTextArea textArea = new JTextArea(loadLicenceAsString());
         textArea.setName(GuiId.LICENCE_TEXT_AREA.id);
         textArea.setCaretPosition(0);
         textArea.setEditable(false);
@@ -129,14 +108,6 @@ public class LicencePanel extends IzPanel implements ActionListener
 
         setInitialFocus(noRadio);
         getLayoutHelper().completeLayout();
-    }
-
-    /**
-     * Loads the licence text.
-     */
-    private void loadLicence()
-    {
-        licence = getResources().getString("LicencePanel.licence", null, "Error : could not load the licence text !");
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/pdflicence/PDFLicenceConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/pdflicence/PDFLicenceConsolePanel.java
@@ -1,16 +1,14 @@
 /*
- * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
+ * IzPack - Copyright 2001-2016 The IzPack project team.
+ * All Rights Reserved.
  *
  * http://izpack.org/
- * http://izpack.codehaus.org/
- *
- * Copyright 2002 Jan Blok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,27 +19,24 @@
 
 package com.izforge.izpack.panels.pdflicence;
 
+import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.installer.console.ConsolePanel;
+import com.izforge.izpack.installer.panel.PanelView;
+import com.izforge.izpack.panels.licence.AbstractLicenceConsolePanel;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.util.PDFTextStripper;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.util.PDFTextStripper;
-
-import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.installer.console.ConsolePanel;
-import com.izforge.izpack.installer.panel.PanelView;
-import com.izforge.izpack.panels.licence.AbstractLicenceConsolePanel;
-
 /**
- * HTML Licence Panel console helper
+ * PDF Licence Panel console helper
  */
 public class PDFLicenceConsolePanel extends AbstractLicenceConsolePanel {
 
 	private static final Logger logger = Logger.getLogger(AbstractLicenceConsolePanel.class.getName());
-	private static final String RESOURCE_NAME = "PDFLicencePanel.licence";
-	private final URL licenceURL;
 
 	/**
 	 * Constructs an <tt>PDFLicenceConsolePanel</tt>.
@@ -53,7 +48,6 @@ public class PDFLicenceConsolePanel extends AbstractLicenceConsolePanel {
 	 */
 	public PDFLicenceConsolePanel(PanelView<ConsolePanel> panel, Resources resources) {
 		super(panel, resources);
-		this.licenceURL = resources.getURL(RESOURCE_NAME);
 	}
 
 	/**
@@ -62,12 +56,17 @@ public class PDFLicenceConsolePanel extends AbstractLicenceConsolePanel {
 	 * @return the text. A <tt>null</tt> indicates failure
 	 */
 	@Override
-	protected String getText() {
+	protected String getText()
+	{
+		URL url = null;
 		try {
 			PDFTextStripper stripper = new PDFTextStripper();
-			return stripper.getText(PDDocument.load(licenceURL));
-		} catch (IOException e) {
-			logger.log(Level.WARNING, "No licence text for resource: " + RESOURCE_NAME);
+			url = loadLicence();
+			return stripper.getText(PDDocument.load(url));
+		}
+		catch (IOException e) {
+			logger.log(Level.WARNING, "Error opening PDF license document from resource" +
+					(url != null ? " " + url.getFile() : ""), e);
 			return null;
 		}
 	}

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/pdflicence/PDFLicencePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/pdflicence/PDFLicencePanel.java
@@ -1,14 +1,14 @@
 /*
- * IzPack - Copyright 2001-2008 Julien Ponge, All Rights Reserved.
+ * IzPack - Copyright 2001-2016 The IzPack project team.
+ * All Rights Reserved.
  *
  * http://izpack.org/
- * http://izpack.codehaus.org/
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,58 +19,6 @@
 
 package com.izforge.izpack.panels.pdflicence;
 
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_DEFAULT_PAGEFIT;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_DEFAULT_ZOOM_LEVEL;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_HIDE_UTILITYPANE;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_KEYBOARD_SHORTCUTS;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_STATUSBAR;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_STATUSBAR_STATUSLABEL;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_STATUSBAR_VIEWMODE;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_TOOLBAR_ANNOTATION;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_TOOLBAR_FIT;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_TOOLBAR_FORMS;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_TOOLBAR_PAGENAV;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_TOOLBAR_ROTATE;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_TOOLBAR_TOOL;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_TOOLBAR_UTILITY;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_TOOLBAR_ZOOM;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITYPANE_ANNOTATION;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITYPANE_ANNOTATION_FLAGS;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITYPANE_BOOKMARKS;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITYPANE_LAYERS;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITYPANE_SEARCH;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITYPANE_THUMBNAILS;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITY_OPEN;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITY_PRINT;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITY_SAVE;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITY_SEARCH;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_SHOW_UTILITY_UPANE;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_VIEWPREF_FITWINDOW;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_VIEWPREF_FORM_HIGHLIGHT;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_VIEWPREF_HIDEMENUBAR;
-import static org.icepdf.ri.util.PropertiesManager.PROPERTY_VIEWPREF_HIDETOOLBAR;
-
-import java.awt.FlowLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.net.URL;
-import java.util.Properties;
-import java.util.ResourceBundle;
-
-import javax.swing.ButtonGroup;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.KeyStroke;
-
-import org.icepdf.ri.common.ComponentKeyBinding;
-import org.icepdf.ri.common.SwingController;
-import org.icepdf.ri.common.SwingViewBuilder;
-import org.icepdf.ri.common.views.DocumentViewController;
-import org.icepdf.ri.util.PropertiesManager;
-
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Resources;
@@ -79,22 +27,35 @@ import com.izforge.izpack.gui.LabelFactory;
 import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
-import com.izforge.izpack.installer.gui.IzPanel;
+import com.izforge.izpack.panels.licence.AbstractLicencePanel;
+import org.icepdf.ri.common.ComponentKeyBinding;
+import org.icepdf.ri.common.SwingController;
+import org.icepdf.ri.common.SwingViewBuilder;
+import org.icepdf.ri.common.views.DocumentViewController;
+import org.icepdf.ri.util.PropertiesManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.util.Properties;
+import java.util.ResourceBundle;
+
+import static org.icepdf.ri.util.PropertiesManager.*;
 
 /**
- * The IzPack HTML license panel.
- *
- * @author Julien Ponge
+ * The IzPack PDF license panel.
  */
-public class PDFLicencePanel extends IzPanel implements ActionListener {
+public class PDFLicencePanel extends AbstractLicencePanel implements ActionListener {
 
-	private static final long serialVersionUID = 3256728385458746416L;
+	private static final long serialVersionUID = 1907880984181722205L;
 
 	/**
 	 * The radio buttons.
 	 */
-	private JRadioButton yesRadio;
-	private JRadioButton noRadio;
+	private final JRadioButton yesRadio;
+	private final JRadioButton noRadio;
 
 	/**
 	 * Constructs an <tt>PDFLicencePanel</tt>.
@@ -111,7 +72,8 @@ public class PDFLicencePanel extends IzPanel implements ActionListener {
 	 *            the log
 	 */
 	public PDFLicencePanel(Panel panel, final InstallerFrame parent, GUIInstallData installData, Resources resources,
-			Log log) {
+			Log log)
+	{
 		super(panel, parent, installData, new IzPanelLayout(log), resources);
 
 		// We put our components
@@ -168,35 +130,6 @@ public class PDFLicencePanel extends IzPanel implements ActionListener {
 	}
 
 	/**
-	 * Loads the license text.
-	 *
-	 * @return The license text URL.
-	 */
-	protected URL loadLicence() {
-		String resNamePrefix = "PDFLicencePanel";
-		String resNameStr = resNamePrefix + ".licence";
-
-		if (getMetadata() != null && getMetadata().getPanelId() != null) {
-			try {
-				String panelSpecificResName = resNamePrefix + '.' + this.getMetadata().getPanelId();
-				String panelspecificResContent = getResources().getString(panelSpecificResName, null);
-				if (panelspecificResContent != null) {
-					resNameStr = panelSpecificResName;
-				}
-			} catch (Exception e) {
-				// Those ones can be skipped
-			}
-		}
-
-		try {
-			return getResources().getURL(resNameStr);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
-		return null;
-	}
-
-	/**
 	 * Actions-handling method (here it launches the installation).
 	 *
 	 * @param e
@@ -211,7 +144,7 @@ public class PDFLicencePanel extends IzPanel implements ActionListener {
 	}
 
 	/**
-	 * Indicates wether the panel has been validated or not.
+	 * Indicates whether the panel has been validated or not.
 	 *
 	 * @return true if the user agrees with the license, false otherwise.
 	 */
@@ -240,7 +173,7 @@ public class PDFLicencePanel extends IzPanel implements ActionListener {
 		result.setProperty(PROPERTY_DEFAULT_PAGEFIT, Integer.toString(DocumentViewController.PAGE_FIT_WINDOW_WIDTH));
 
 		result.setProperty(PROPERTY_VIEWPREF_HIDEMENUBAR, "false");
-		// Hides the menubar. Default value false.
+		// Hides the menu bar. Default value false.
 		result.setProperty(PROPERTY_VIEWPREF_HIDETOOLBAR, "false");
 		// Hides the top toolbar. Default value false.
 		result.setProperty(PROPERTY_VIEWPREF_FORM_HIGHLIGHT, "false");
@@ -248,7 +181,7 @@ public class PDFLicencePanel extends IzPanel implements ActionListener {
 		// When enabled shows the document with fit to width if the document
 		// does not already specify a default view. Default value, true.
 		result.setProperty(PROPERTY_SHOW_KEYBOARD_SHORTCUTS, "false");
-		// Enables/disables menubar key events, default is true.
+		// Enables/disables menu bar key events, default is true.
 		result.setProperty("application.alwaysShowImageSplashWindow", "no");
 		// Enables/disables the splash window, default is no
 		result.setProperty("application.chromeOnStartup", "no");
@@ -263,7 +196,7 @@ public class PDFLicencePanel extends IzPanel implements ActionListener {
 		// Show page navigation controls; first, previous, next and last.
 		// Default is true.
 		result.setProperty(PROPERTY_SHOW_TOOLBAR_FIT, "false");
-		// Shows page fit controls; normal, hight and width. Default is true.
+		// Shows page fit controls; normal, height and width. Default is true.
 		result.setProperty(PROPERTY_SHOW_TOOLBAR_ZOOM, "false");
 		// Shows page zoom controls. Default is true.
 		result.setProperty(PROPERTY_SHOW_TOOLBAR_ROTATE, "false");

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/AbstractConsoleFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/AbstractConsoleFieldTest.java
@@ -55,7 +55,7 @@ public abstract class AbstractConsoleFieldTest
         installData.setMessages(new LocaleDatabase(langPack, Mockito.mock(Locales.class)));
         RulesEngine rules = new RulesEngineImpl(new ConditionContainer(new DefaultContainer()),
                                                 installData.getPlatform());
-        console = new TestConsole();
+        console = new TestConsole(installData.getMessages());
         prompt = Mockito.mock(Prompt.class);
         installData.setRules(rules);
     }

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/check/ConsoleCheckFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/check/ConsoleCheckFieldTest.java
@@ -73,7 +73,7 @@ public class ConsoleCheckFieldTest extends AbstractConsoleFieldTest
         installData = new AutomatedInstallData(new DefaultVariables(), Platforms.HP_UX);
         RulesEngine rules = new RulesEngineImpl(new ConditionContainer(new DefaultContainer()),
                                                 installData.getPlatform());
-        console = new TestConsole();
+        console = new TestConsole(installData.getMessages());
         prompt = new ConsolePrompt(console, Mockito.mock(Messages.class));
         installData.setRules(rules);
     }

--- a/izpack-test-common/src/main/java/com/izforge/izpack/test/util/TestConsole.java
+++ b/izpack-test-common/src/main/java/com/izforge/izpack/test/util/TestConsole.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.util.Console;
 
 
@@ -70,8 +71,9 @@ public class TestConsole extends Console
     /**
      * Constructs a <tt>TestConsole</tt>.
      */
-    public TestConsole()
+    public TestConsole(Messages messages)
     {
+        super(messages);
         super.useDefaultInput();
     }
 

--- a/izpack-tools/src/main/java/com/izforge/izpack/util/WordUtil.java
+++ b/izpack-tools/src/main/java/com/izforge/izpack/util/WordUtil.java
@@ -42,7 +42,7 @@ public class WordUtil
                 if (in != null)
                     in.close();
             }
-            catch (IOException e) {}
+            catch (IOException ignored) {}
         }
     }
 
@@ -64,7 +64,7 @@ public class WordUtil
      */
     public static String wordWrap(String text, int maxCharsPerLine, boolean wrapLineFull)
     {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (String line : wordWrap(new ByteArrayInputStream(text.getBytes()), maxCharsPerLine))
         {
             sb.append(line);
@@ -84,35 +84,25 @@ public class WordUtil
         while (scanner.hasNextLine())
         {
             String readLine = scanner.nextLine();
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
 
             StringTokenizer tokenizer = new StringTokenizer(readLine);
             // Add explicit line breaks from original document
             if (tokenizer.countTokens() == 0)
             {
-                lines.add(new String());
+                lines.add(" ");
             }
 
             while (tokenizer.hasMoreTokens())
             {
                 String word = tokenizer.nextToken();
                 int len = word.length();
-
-                // FIXME Add explicit trailing whitespace from original document
-                /*
-                if (len == 0)
-                {
-                    word = " ";
-                    len = 1;
-                }
-                */
-
                 if (sb.length() > 0)
                 {
                     if (len + 1 > maxCharsPerLine - sb.length())
                     {
                         lines.add(sb.toString());
-                        sb = new StringBuffer();
+                        sb = new StringBuilder();
                     }
                     else
                     {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
@@ -17,6 +17,7 @@
 package com.izforge.izpack.util;
 
 import com.izforge.izpack.api.exception.UserInterruptException;
+import com.izforge.izpack.api.resource.Messages;
 import jline.Terminal;
 import jline.UnsupportedTerminal;
 import jline.console.ConsoleReader;
@@ -59,9 +60,14 @@ public class Console
     private final FileNameCompleter fileNameCompleter = new FileNameCompleter();
 
     /**
+     * Translations
+     */
+    private Messages messages;
+
+    /**
      * Constructs a <tt>Console</tt> with <tt>System.in</tt> and <tt>System.out</tt> as the I/O streams.
      */
-    public Console()
+    public Console(Messages messages)
     {
         try
         {
@@ -83,9 +89,10 @@ public class Console
         catch (Throwable t)
         {
             consoleReaderFailed = true;
-            logger.log(Level.WARNING, "Cannot initialize the console reader. Default to regular input stream.", t);
+            logger.log(Level.WARNING, "Cannot initialize the console reader. Falling back to default console.", t);
         }
 
+        this.messages = messages;
     }
 
     /**
@@ -128,7 +135,7 @@ public class Console
             }
             catch (jline.console.UserInterruptException e)
             {
-                throw new UserInterruptException("CTRL-C pressed", e);
+                throw new UserInterruptException(messages.get("ConsoleInstaller.CTRL-C"), e);
             }
         }
     }
@@ -211,7 +218,7 @@ public class Console
             if (line >= showLines && tokens.hasMoreTokens())
             {
                 // Overflow
-                println("--More--");
+                println("--" + messages.get("ConsoleInstaller.pagingMore") + "--");
                 flush();
                 int c = read();
                 if (c == '\r' || c == '\n')
@@ -411,7 +418,7 @@ public class Console
         }
         catch (jline.console.UserInterruptException e)
         {
-            throw new UserInterruptException("CTRL-C pressed", e);
+            throw new UserInterruptException(messages.get("ConsoleInstaller.CTRL-C"), e);
         }
         catch (IOException e)
         {


### PR DESCRIPTION
This request implements issue [IZPACK-1329](https://izpack.atlassian.net/browse/IZPACK-1329):

At this time, there are three types of license panels including their console mode helpers:
- _LicencePanel_ - text files
- _HTMLLicencePanel_ - HTML files
- _PDFLicencePanel_ - PDF files
They are still configured in a different manner and have different behavior in GUI and console mode.

There should be more abstraction about common functionality, like allowing to define multiple instances for both installation mode types.

There should be also added missing translations for all depending console mode code, like --More-- (for paging), abortion reasons and all the start and shutdown messages printed during a console mode installation.

By this way, add also missing translations for the console mode to all available language pack files (the unknown for me in english, to be translated by someone who knows this).