### PR TITLE
IZPACK-1332: Ambiguous meaning of <native> attribute stage

### DIFF
--- a/izpack-api/src/test/resources/com/izforge/izpack/api/adaptator/partial.xml
+++ b/izpack-api/src/test/resources/com/izforge/izpack/api/adaptator/partial.xml
@@ -204,7 +204,7 @@
     <!-- The native libraries to add -->
     <natives>
         <native type="izpack" name="ShellLink.dll"/>
-        <native type="3rdparty" name="COIOSHelper.dll" stage="both">
+        <native type="3rdparty" name="COIOSHelper.dll" uninstaller="true">
             <os family="windows"/>
         </native>
     </natives>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -617,6 +617,7 @@
                     <xs:attribute name="type" type="xs:string" use="required"/>
                     <xs:attribute name="name" type="xs:string" use="required"/>
                     <xs:attribute name="src" type="xs:string" use="optional"/>
+                    <!-- remove the 'stage' attribute in future -->
                     <xs:attribute name="stage">
                         <xs:simpleType>
                             <xs:restriction base="xs:string">
@@ -625,6 +626,7 @@
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
+                    <xs:attribute name="uninstaller" type="xs:boolean" use="optional" default="false"/>
                 </xs:complexType>
             </xs:element>
         </xs:sequence>

--- a/izpack-compiler/src/test/resources/bindingTest.xml
+++ b/izpack-compiler/src/test/resources/bindingTest.xml
@@ -188,7 +188,7 @@
         <native type="izpack" name="ShellLink_x64.dll"/>
         <native type="izpack" name="WinSetupAPI.dll"/>
         <native type="izpack" name="WinSetupAPI_x64.dll"/>
-        <native type="3rdparty" name="COIOSHelper.dll" stage="both">
+        <native type="3rdparty" name="COIOSHelper.dll" uninstaller="true">
             <os family="windows"/>
         </native>
     </natives>

--- a/izpack-dist/src/main/izpack/install.xml
+++ b/izpack-dist/src/main/izpack/install.xml
@@ -176,10 +176,10 @@
         <native type="izpack" name="ShellLink_x64.dll"/>
         <native type="izpack" name="WinSetupAPI.dll"/>
         <native type="izpack" name="WinSetupAPI_x64.dll"/>
-        <native type="3rdparty" name="COIOSHelper.dll" stage="both">
+        <native type="3rdparty" name="COIOSHelper.dll" uninstaller="true">
             <os family="windows"/>
         </native>
-        <native type="3rdparty" name="COIOSHelper_x64.dll" stage="both">
+        <native type="3rdparty" name="COIOSHelper_x64.dll" uninstaller="true">
             <os family="windows"/>
         </native>
     </natives>

--- a/izpack-maven-plugin/src/examples/groovy/src/izpack/install.xml
+++ b/izpack-maven-plugin/src/examples/groovy/src/izpack/install.xml
@@ -191,7 +191,7 @@
 
     <natives>
         <native type="izpack" name="ShellLink.dll"/>
-        <native type="3rdparty" name="COIOSHelper.dll" stage="both">
+        <native type="3rdparty" name="COIOSHelper.dll" uninstaller="true">
             <os family="windows"/>
         </native>
     </natives>

--- a/izpack-test/src/test/resources/samples/natives/natives.xml
+++ b/izpack-test/src/test/resources/samples/natives/natives.xml
@@ -31,12 +31,12 @@
 
     <!-- NOTE - the following stage attributes are only applicable for testing purposes -->
     <natives>
-        <native type="izpack" name="ShellLink.dll" stage="install"/>
-        <native type="izpack" name="ShellLink_x64.dll" stage="install"/>
-        <native type="izpack" name="WinSetupAPI.dll" stage="both"/>
-        <native type="izpack" name="WinSetupAPI_x64.dll" stage="both"/>
-        <native type="3rdparty" name="COIOSHelper.dll" stage="uninstall"/>
-        <native type="3rdparty" name="COIOSHelper_x64.dll" stage="uninstall"/>
+        <native type="izpack" name="ShellLink.dll" uninstaller="false"/>
+        <native type="izpack" name="ShellLink_x64.dll" uninstaller="false"/>
+        <native type="izpack" name="WinSetupAPI.dll" uninstaller="true"/>
+        <native type="izpack" name="WinSetupAPI_x64.dll" uninstaller="true"/>
+        <native type="3rdparty" name="COIOSHelper.dll" uninstaller="true"/>
+        <native type="3rdparty" name="COIOSHelper_x64.dll" uninstaller="true"/>
     </natives>
 
 </izpack:installation>

--- a/izpack-test/src/test/resources/samples/windows/consoleinstall_alt_uninstall.xml
+++ b/izpack-test/src/test/resources/samples/windows/consoleinstall_alt_uninstall.xml
@@ -47,11 +47,11 @@
 
     <!-- NOTE - the following stage attributes are only applicable for testing purposes -->
     <natives>
-        <native type="izpack" name="ShellLink.dll" stage="both"/>
-        <native type="izpack" name="ShellLink_x64.dll" stage="both"/>
-        <native type="izpack" name="WinSetupAPI.dll" stage="both"/>
-        <native type="izpack" name="WinSetupAPI_x64.dll" stage="both"/>
-        <native type="3rdparty" name="COIOSHelper.dll" stage="uninstall"/>
-        <native type="3rdparty" name="COIOSHelper_x64.dll" stage="uninstall"/>
+        <native type="izpack" name="ShellLink.dll" uninstaller="true"/>
+        <native type="izpack" name="ShellLink_x64.dll" uninstaller="true"/>
+        <native type="izpack" name="WinSetupAPI.dll" uninstaller="true"/>
+        <native type="izpack" name="WinSetupAPI_x64.dll" uninstaller="true"/>
+        <native type="3rdparty" name="COIOSHelper.dll" uninstaller="true"/>
+        <native type="3rdparty" name="COIOSHelper_x64.dll" uninstaller="true"/>
     </natives>
 </izpack:installation>

--- a/izpack-test/src/test/resources/samples/windows/install.xml
+++ b/izpack-test/src/test/resources/samples/windows/install.xml
@@ -46,11 +46,11 @@
 
     <!-- NOTE - the following stage attributes are only applicable for testing purposes -->
     <natives>
-        <native type="izpack" name="ShellLink.dll" stage="both"/>
-        <native type="izpack" name="ShellLink_x64.dll" stage="both"/>
-        <native type="izpack" name="WinSetupAPI.dll" stage="both"/>
-        <native type="izpack" name="WinSetupAPI_x64.dll" stage="both"/>
-        <native type="3rdparty" name="COIOSHelper.dll" stage="uninstall"/>
-        <native type="3rdparty" name="COIOSHelper_x64.dll" stage="uninstall"/>
+        <native type="izpack" name="ShellLink.dll" uninstaller="true"/>
+        <native type="izpack" name="ShellLink_x64.dll" uninstaller="true"/>
+        <native type="izpack" name="WinSetupAPI.dll" uninstaller="true"/>
+        <native type="izpack" name="WinSetupAPI_x64.dll" uninstaller="true"/>
+        <native type="3rdparty" name="COIOSHelper.dll" uninstaller="true"/>
+        <native type="3rdparty" name="COIOSHelper_x64.dll" uninstaller="true"/>
     </natives>
 </izpack:installation>


### PR DESCRIPTION
This request implements [IZPACK-1332](https://izpack.atlassian.net/browse/IZPACK-1332):

I stumbled upon this while reviewing and discussing issue IZPACK-1331:

There is an inaccuracy in the definition of the optional attribute stage of the <native> tag:

See https://github.com/izpack/izpack/blob/master/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java#L666-L682:
```java
            // Additionals for mark a native lib also used in the uninstaller
            // The lib will be copied from the installer into the uninstaller if
            // needed.
            // Therefore the lib should be in the installer also it is used only
            // from
            // the uninstaller. This is the reason why the stage wiil be only
            // observed
            // for the uninstaller.
            String stage = ixmlElement.getAttribute("stage");
            List<OsModel> constraints = OsConstraintHelper.getOsList(ixmlElement);
            if ("both".equalsIgnoreCase(stage) || "uninstall".equalsIgnoreCase(stage))
            {
                List<String> contents = new ArrayList<String>();
                contents.add(destination);
                CustomData customData = new CustomData(null, contents, constraints, CustomData.UNINSTALLER_LIB);
                packager.addNativeUninstallerLibrary(customData);
            }
```
The _<native>_ tag in install.xml accepts a _stage_ attribute. In IzPack 4, from what I remember, there were 3 possible values: _install_ | _both_ | _uninstall_ (default: _install_), to define whether the native library should land in the installer, uninstaller or both.

According to the comment in the mentioned lines, due to the implementation in IzPack 5, a native library must be always added to the installer, to be able to make it optionally available in the uninstaller. Thus, this _stage_ attribute doesn't make sense this way. The current XSD allows the values _both_ | _uninstall_, which is even more messy, because not defining the attribute means the same as if it was set to "_install_" and the values "_both_" and "_uninstall_" mean actually exactly the same.

An implication of this can be seen in another error in [{{WindowsConsoleInstallationTest}}|https://github.com/izpack/izpack/blob/master/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsConsoleInstallationTest.java], which doesn't actually fail although it functionally should:
There is an install descriptor for this test here: https://github.com/izpack/izpack/blob/master/izpack-test/src/test/resources/samples/windows/install.xml with the following contents (mentioned just the relevant parts):
```xml
    <listeners>
        ...
        <listener classname="RegistryInstallerListener" stage="install">
            <os family="windows"/>
        </listener>
        <listener classname="RegistryUninstallerListener" stage="uninstall">
            <os family="windows"/>
        </listener>
    </listeners>
    ...
    <natives>
        ...
        <native type="3rdparty" name="COIOSHelper.dll" stage="uninstall"/>
        <native type="3rdparty" name="COIOSHelper_x64.dll" stage="uninstall"/>
    </natives>
```
Normally this should fail, because both, RegistryInstallerListener and RegistryUninstallerListener, require the proper COIOSHelper DLL to be loaded. From the definition of the term _stage="uninstall"_ the DLL should be available just to the uninstaller, but internally it is available also in the installer, therefore the test doesn't fail. But it doesn't anyway fit the meaning of this attribute.

Suggestion:
- Just allow "_install_" and "_both_" as possible values of the _stage_ attribute (default: "_install_"). The value "_uninstall_" should be no longer accepted. Or we'll replace the attribute by a new boolean attribute __uninstaller__ with the possible values "_true_"|"_false_" (default: "_false_"). The last one would be even better, both changes break existing environments, but this should be easy to fix, though.
- Fix te [izpack-installation-5.0.xsd|https://github.com/izpack/izpack/blob/master/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd] according to the implementation chosen.
- Fix the https://github.com/izpack/izpack/blob/master/izpack-test/src/test/resources/samples/windows/install.xml by using
 ```xml
    <natives>
        ...
        <native type="3rdparty" name="COIOSHelper.dll" stage="both"/>
        <native type="3rdparty" name="COIOSHelper_x64.dll" stage="both"/>
    </natives>
  ```
  or better after a changed implementation:
  ```xml
    <natives>
        ...
        <native type="3rdparty" name="COIOSHelper.dll" uninstaller="true"/>
        <native type="3rdparty" name="COIOSHelper_x64.dll" uninstaller="true"/>
    </natives>
  ```
- There should be updated the documentation after a fix: https://izpack.atlassian.net/wiki/x/mYAH.
  
There might be affected more Windows-specific integration tests, don't forget to verify them all after an implementation.