### PR TITLE
IZPACK-1335: NPE in "contains" condition

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
@@ -126,11 +126,11 @@ public class ContainsCondition extends Condition {
 
     if (isRegEx)
     {
+        pattern = Pattern.compile(value);
         if (isByLine)
         {
             return matchesByLine(new StringReader(content));
         }
-        pattern = Pattern.compile(value);
     }
 
     return matchesString(content);


### PR DESCRIPTION
This fixes issue [IZPACK-1335](https://izpack.atlassian.net/browse/IZPACK-1335):

The following NPE can happen using the "contains" condition:

```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
        at com.izforge.izpack.core.rules.process.ContainsCondition.matchesString(ContainsCondition.java:174)
        at com.izforge.izpack.core.rules.process.ContainsCondition.matchesByLine(ContainsCondition.java:147)
        at com.izforge.izpack.core.rules.process.ContainsCondition.isTrue(ContainsCondition.java:131)
        at com.izforge.izpack.core.rules.logic.NotCondition.isTrue(NotCondition.java:92)
        at com.izforge.izpack.core.rules.process.RefCondition.isTrue(RefCondition.java:84)
        at com.izforge.izpack.core.rules.logic.AndCondition.isTrue(AndCondition.java:73)
        at com.izforge.izpack.core.rules.process.RefCondition.isTrue(RefCondition.java:84)
        at com.izforge.izpack.core.rules.logic.OrCondition.isTrue(OrCondition.java:71)
        at com.izforge.izpack.core.rules.logic.AndCondition.isTrue(AndCondition.java:73)
        at com.izforge.izpack.core.rules.RulesEngineImpl.isConditionTrue(RulesEngineImpl.java:344)
        at com.izforge.izpack.core.rules.RulesEngineImpl.isConditionTrue(RulesEngineImpl.java:331)
        at com.izforge.izpack.core.data.DefaultVariables.refresh(DefaultVariables.java:338)
        at com.izforge.izpack.installer.panel.AbstractPanels.switchPanel(AbstractPanels.java:551)
        at com.izforge.izpack.installer.panel.AbstractPanels.next(AbstractPanels.java:254)
        at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:345)
        at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:328)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.navigate(DefaultNavigator.java:563)                                             
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.access$100(DefaultNavigator.java:526)                                           
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler$1$1.run(DefaultNavigator.java:546)                                              
        at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)                                                                                   
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)                                                                                          
        at java.awt.EventQueue.access$500(EventQueue.java:97)                                                                                                  
        at java.awt.EventQueue$3.run(EventQueue.java:709)                                                                                                      
        at java.awt.EventQueue$3.run(EventQueue.java:703)                                                                                                      
        at java.security.AccessController.doPrivileged(Native Method)                                                                                          
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```