### PR TITLE
IZPACK-1329: Consolidate license panels functionality and translations

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
@@ -93,9 +93,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/cat.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/cat.xml
@@ -23,9 +23,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
@@ -23,9 +23,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Tato operace vyžaduje práva administrátora. Instalaci je nutno spouštět pod uživatelským účtem s oprávněním správce systému."/>
     <str id="ConsoleInstaller.inputSelection" txt="Zadejte volbu: "/>
     <str id="ConsoleInstaller.pagingMore" txt="Další"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="Byl stisknut CTRL-C"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="Licenční ujednání byly zamítnuty"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Byl zvolen konec instalace"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="Byl stisknut CTRL-C"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="Licenční ujednání byly zamítnuty"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Byl zvolen konec instalace"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="Některé operace se soubory budou dokončené po restartování systému"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Restart systému zahájen"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Konec instalace"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/chn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/chn.xml
@@ -23,9 +23,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/dan.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/dan.xml
@@ -23,9 +23,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
@@ -320,9 +320,9 @@ file we looked for -->
     <str id="ConsoleInstaller.permissionError" txt="Administratorrechte erforderlich. Bitte starten Sie das Installationsprogramm erneut unter den erforderlichen Benutzerrechten."/>
     <str id="ConsoleInstaller.inputSelection" txt="Auswahl eingeben: "/>
     <str id="ConsoleInstaller.pagingMore" txt="Mehr"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C betätigt"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="Lizenzvereinbarung abgelehnt"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Beenden betätigt"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C betätigt"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="Lizenzvereinbarung abgelehnt"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Beenden betätigt"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="Einige Dateioperationen werden erst nach einem Neustart fertiggestellt"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Automatischer Neustart erfolgt"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Textkonsolen-Installation beendet"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -342,9 +342,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
@@ -50,9 +50,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
@@ -48,9 +48,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
@@ -50,9 +50,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
@@ -293,9 +293,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
@@ -50,9 +50,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
@@ -46,9 +46,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
@@ -50,9 +50,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
@@ -50,9 +50,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
@@ -80,9 +80,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
@@ -24,9 +24,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/msa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/msa.xml
@@ -23,9 +23,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
@@ -53,9 +53,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
@@ -23,9 +23,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
@@ -115,9 +115,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
@@ -50,9 +50,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ron.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ron.xml
@@ -23,9 +23,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
@@ -24,9 +24,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
@@ -51,9 +51,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -343,9 +343,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Se requieren permisos administrativos. Por favor, arranque de nuevo el instalador con permisos administrativos."/>
     <str id="ConsoleInstaller.inputSelection" txt="Introduzca selección: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/srp.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/srp.xml
@@ -21,9 +21,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
@@ -269,9 +269,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administratörsrättigheter krävs. Väligen kör installationen med administratörsrättigheter."/>
     <str id="ConsoleInstaller.inputSelection" txt="Ditt val: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
@@ -55,9 +55,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
@@ -23,9 +23,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
@@ -51,9 +51,9 @@
     <str id="ConsoleInstaller.permissionError" txt="Administrative privileges required. Please re-run the installer with administrative privileges."/>
     <str id="ConsoleInstaller.inputSelection" txt="Input selection: "/>
     <str id="ConsoleInstaller.pagingMore" txt="More"/>
-    <str id="ConsoleInstaller.abortedPressedCTRL-C" txt="CTRL-C pressed"/>
-    <str id="ConsoleInstaller.abortedLicenseRejected" txt="License rejected"/>
-    <str id="ConsoleInstaller.abortedPressedQuit" txt="Quit pressed"/>
+    <str id="ConsoleInstaller.aborted.PressedCTRL-C" txt="CTRL-C pressed"/>
+    <str id="ConsoleInstaller.aborted.LicenseRejected" txt="License rejected"/>
+    <str id="ConsoleInstaller.aborted.PressedQuit" txt="Quit pressed"/>
     <str id="ConsoleInstaller.shutdown.pendingFileOperations" txt="There are file operations pending after reboot"/>
     <str id="ConsoleInstaller.shutdown.rebootingNow" txt="Rebooting now automatically"/>
     <str id="ConsoleInstaller.shutdown.done" txt="Console installation done"/>

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
@@ -101,7 +101,7 @@ public abstract class AbstractConsolePanel implements ConsolePanel
                 break;
 
             case 2:
-                throw new UserInterruptException(messages.get("ConsoleInstaller.abortedPressedQuit"));
+                throw new UserInterruptException(messages.get("ConsoleInstaller.aborted.PressedQuit"));
 
             default:
                 result =  run(installData, console);
@@ -131,7 +131,7 @@ public abstract class AbstractConsolePanel implements ConsolePanel
         switch (value)
         {
             case 2:
-                throw new UserInterruptException(messages.get("ConsoleInstaller.abortedPressedQuit"));
+                throw new UserInterruptException(messages.get("ConsoleInstaller.aborted.PressedQuit"));
 
             default:
                 result = run(installData, console);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicenceConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicenceConsolePanel.java
@@ -183,7 +183,7 @@ public abstract class AbstractLicenceConsolePanel extends AbstractTextConsolePan
                 break;
 
             case 2:
-                throw new UserInterruptException(messages.get("ConsoleInstaller.abortedLicenseRejected"));
+                throw new UserInterruptException(messages.get("ConsoleInstaller.aborted.LicenseRejected"));
 
             default:
                 result =  run(installData, console);

--- a/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
@@ -135,7 +135,7 @@ public class Console
             }
             catch (jline.console.UserInterruptException e)
             {
-                throw new UserInterruptException(messages.get("ConsoleInstaller.CTRL-C"), e);
+                throw new UserInterruptException(messages.get("ConsoleInstaller.aborted.PressedCTRL-C"), e);
             }
         }
     }
@@ -418,7 +418,7 @@ public class Console
         }
         catch (jline.console.UserInterruptException e)
         {
-            throw new UserInterruptException(messages.get("ConsoleInstaller.CTRL-C"), e);
+            throw new UserInterruptException(messages.get("ConsoleInstaller.aborted.PressedCTRL-C"), e);
         }
         catch (IOException e)
         {


### PR DESCRIPTION
Post- fixes for [IZPACK-1329|https://izpack.atlassian.net/browse/IZPACK-1329]:
Bad translation keys, for example _CTRL-C pressed_ has not been translated.
