### PR TITLE
IZPACK-1336: Add <consoleprefs> tag similar to the <guiprefs>

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/ConsolePrefs.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/ConsolePrefs.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.api.data;
+
+import java.io.Serializable;
+
+public class ConsolePrefs implements Serializable
+{
+    private static final long serialVersionUID = 4563261006203097483L;
+
+    /**
+     * Specifies wether the JLine should be used to use special terminal handling when reading console input.
+     */
+    public boolean enableConsoleReader = true;
+
+}

--- a/izpack-api/src/main/java/com/izforge/izpack/api/handler/AbstractPrompt.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/handler/AbstractPrompt.java
@@ -207,4 +207,38 @@ public abstract class AbstractPrompt implements Prompt
         return message;
     }
 
+    protected static String getDetails(Throwable throwable)
+    {
+        StringBuffer b = new StringBuffer();
+        int lengthOfLastTrace = 1; // initial value
+        // Start with the specified throwable and loop through the chain of
+        // causality for the throwable.
+        while (throwable != null)
+        {
+            // Output Exception name and message, and begin a list
+            b.append(throwable.getClass().getName() + ": " + throwable.getMessage());
+            // Get the stack trace and output each frame.
+            // Be careful not to repeat stack frames that were already reported
+            // for the exception that this one caused.
+            StackTraceElement[] stack = throwable.getStackTrace();
+            for (int i = stack.length - lengthOfLastTrace; i >= 0; i--)
+            {
+                b.append("- in " + stack[i].getClassName() + "." + stack[i].getMethodName()
+                        + "() at " + stack[i].getFileName() + ":"
+                        + stack[i].getLineNumber() + "\n");
+            }
+            // See if there is a cause for this exception
+            throwable = throwable.getCause();
+            if (throwable != null)
+            {
+                // If so, output a header
+                b.append("Caused by: ");
+                // And remember how many frames to skip in the stack trace
+                // of the cause exception
+                lengthOfLastTrace = stack.length;
+            }
+        }
+        return b.toString();
+    }
+
 }

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -328,6 +328,7 @@ public class CompilerConfig extends Thread
         addDynamicVariables(data);
         addDynamicInstallerRequirement(data);
         addInfo(data);
+        addConsolePrefs(data);
         addGUIPrefs(data);
         addLangpacks(data);
         addResources(data);
@@ -434,6 +435,30 @@ public class CompilerConfig extends Thread
     public boolean wasSuccessful()
     {
         return compiler.wasSuccessful();
+    }
+
+    /**
+     * Returns the ConsolePrefs.
+     *
+     * @param data The XML data.
+     * @throws CompilerException Description of the Exception
+     */
+    private void addConsolePrefs(IXMLElement data) throws CompilerException
+    {
+        notifyCompilerListener("addConsolePrefs", CompilerListener.BEGIN, data);
+        // We get the IXMLElement & the attributes
+        IXMLElement consolePrefsElement = data.getFirstChildNamed("consoleprefs");
+        ConsolePrefs prefs = new ConsolePrefs();
+        if (consolePrefsElement != null)
+        {
+            IXMLElement detectTerminalTag = consolePrefsElement.getFirstChildNamed("detectTerminal");
+            if (detectTerminalTag != null)
+            {
+                prefs.enableConsoleReader = Boolean.parseBoolean(xmlCompilerHelper.requireContent(detectTerminalTag));
+            }
+        }
+        packager.setConsolePrefs(prefs);
+        notifyCompilerListener("addConsolePrefs", CompilerListener.END, data);
     }
 
     /**

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/IPackager.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/IPackager.java
@@ -19,21 +19,16 @@
 
 package com.izforge.izpack.compiler.packager;
 
+import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.data.*;
+import com.izforge.izpack.api.rules.Condition;
+import com.izforge.izpack.data.CustomData;
+import com.izforge.izpack.data.PackInfo;
+
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
-import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.data.DynamicInstallerRequirementValidator;
-import com.izforge.izpack.api.data.DynamicVariable;
-import com.izforge.izpack.api.data.GUIPrefs;
-import com.izforge.izpack.api.data.Info;
-import com.izforge.izpack.api.data.InstallerRequirement;
-import com.izforge.izpack.api.data.Panel;
-import com.izforge.izpack.api.rules.Condition;
-import com.izforge.izpack.data.CustomData;
-import com.izforge.izpack.data.PackInfo;
 
 /**
  * Interface for all packager implementations
@@ -66,6 +61,13 @@ public interface IPackager
      * @param prefs The new gUIPrefs value
      */
     public abstract void setGUIPrefs(GUIPrefs prefs);
+
+    /**
+     * Sets the console preferences.
+     *
+     * @param prefs The new console preferences
+     */
+    public abstract void setConsolePrefs(ConsolePrefs prefs);
 
     /**
      * Allows access to add, remove and update the variables for the project, which are maintained

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -22,29 +22,7 @@
 
 package com.izforge.izpack.compiler.packager.impl;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectOutputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.jar.Manifest;
-import java.util.zip.ZipInputStream;
-
-import com.izforge.izpack.api.data.DynamicInstallerRequirementValidator;
-import com.izforge.izpack.api.data.DynamicVariable;
-import com.izforge.izpack.api.data.GUIPrefs;
-import com.izforge.izpack.api.data.Info;
-import com.izforge.izpack.api.data.InstallerRequirement;
-import com.izforge.izpack.api.data.Panel;
+import com.izforge.izpack.api.data.*;
 import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.compiler.compressor.PackCompressor;
 import com.izforge.izpack.compiler.data.CompilerData;
@@ -59,6 +37,12 @@ import com.izforge.izpack.merge.MergeManager;
 import com.izforge.izpack.merge.resolve.MergeableResolver;
 import com.izforge.izpack.util.FileUtil;
 import com.izforge.izpack.util.IoHelper;
+
+import java.io.*;
+import java.net.URL;
+import java.util.*;
+import java.util.jar.Manifest;
+import java.util.zip.ZipInputStream;
 
 /**
  * The packager base class. The packager interface <code>IPackager</code> is used by the compiler to put files into an installer, and
@@ -130,6 +114,11 @@ public abstract class PackagerBase implements IPackager
      * GUI preferences.
      */
     private GUIPrefs guiPrefs;
+
+    /**
+     * Console preferences.
+     */
+    private ConsolePrefs consolePrefs;
 
     /**
      * The ordered panels.
@@ -305,6 +294,13 @@ public abstract class PackagerBase implements IPackager
     }
 
     @Override
+    public void setConsolePrefs(ConsolePrefs prefs)
+    {
+        sendMsg("Setting the console preferences", PackagerListener.MSG_VERBOSE);
+        consolePrefs = prefs;
+    }
+
+    @Override
     public void setInfo(Info info)
     {
         sendMsg("Setting the installer information", PackagerListener.MSG_VERBOSE);
@@ -397,6 +393,7 @@ public abstract class PackagerBase implements IPackager
 
         writeInstallerObject("info", info);
         writeInstallerObject("vars", properties);
+        writeInstallerObject("ConsolePrefs", consolePrefs);
         writeInstallerObject("GUIPrefs", guiPrefs);
         writeInstallerObject("panelsOrder", panelList);
         writeInstallerObject("customData", customDataList);

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -40,6 +40,7 @@
                 <xs:element name="conditions" type="types:conditionsType" minOccurs="0"/>
                 <xs:element name="installerrequirements" type="installerRequirementsType" minOccurs="0"/>
                 <xs:element name="dynamicinstallerrequirements" type="dynamicInstallerRequirementsType" minOccurs="0"/>
+                <xs:element name="consoleprefs" type="consolePrefsType" minOccurs="0"/>
                 <xs:element name="guiprefs" type="guiPrefsType" minOccurs="0"/>
                 <xs:element name="locale" type="localeType" minOccurs="1"/>
                 <xs:element name="resources" type="resourcesType" minOccurs="0"/>
@@ -186,6 +187,16 @@
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
+    </xs:complexType>
+
+
+    <!--                                                                                                        -->
+    <!-- Console preferences                                                                                        -->
+    <!--                                                                                                        -->
+    <xs:complexType name="consolePrefsType">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="detectTerminal" type="xs:boolean" minOccurs="0" default="true"/>
+        </xs:choice>
     </xs:complexType>
 
 

--- a/izpack-core/src/main/java/com/izforge/izpack/core/handler/AutomatedPrompt.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/handler/AutomatedPrompt.java
@@ -1,0 +1,52 @@
+/*
+ * IzPack - Copyright 2001-2013 Julien Ponge, All Rights Reserved.
+ *
+ * http://izpack.org/
+ * http://izpack.codehaus.org/
+ *
+ * Copyright 2012 Tim Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.core.handler;
+
+import com.izforge.izpack.api.handler.AbstractPrompt;
+import com.izforge.izpack.api.handler.Prompt;
+
+/**
+ * Automated implementation of {@link Prompt}.
+ */
+public class AutomatedPrompt extends AbstractPrompt
+{
+    @Override
+    public void message(Type type, String title, String message, Throwable throwable)
+    {
+        if (title != null)
+        {
+            System.out.println(title + ":");
+        }
+        System.out.println(message);
+        if (throwable != null)
+        {
+            System.out.println(getDetails(throwable));
+        }
+
+    }
+
+    @Override
+    public Option confirm(Type type, String title, String message, Options options, Option defaultOption)
+    {
+        return null;
+    }
+}

--- a/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
@@ -108,40 +108,6 @@ public class ConsolePrompt extends AbstractPrompt
         }
     }
 
-    private static String getDetails(Throwable throwable)
-    {
-        StringBuffer b = new StringBuffer();
-        int lengthOfLastTrace = 1; // initial value
-        // Start with the specified throwable and loop through the chain of
-        // causality for the throwable.
-        while (throwable != null)
-        {
-            // Output Exception name and message, and begin a list
-            b.append(throwable.getClass().getName() + ": " + throwable.getMessage());
-            // Get the stack trace and output each frame.
-            // Be careful not to repeat stack frames that were already reported
-            // for the exception that this one caused.
-            StackTraceElement[] stack = throwable.getStackTrace();
-            for (int i = stack.length - lengthOfLastTrace; i >= 0; i--)
-            {
-                b.append("- in " + stack[i].getClassName() + "." + stack[i].getMethodName()
-                        + "() at " + stack[i].getFileName() + ":"
-                        + stack[i].getLineNumber() + "\n");
-            }
-            // See if there is a cause for this exception
-            throwable = throwable.getCause();
-            if (throwable != null)
-            {
-                // If so, output a header
-                b.append("Caused by: ");
-                // And remember how many frames to skip in the stack trace
-                // of the cause exception
-                lengthOfLastTrace = stack.length;
-            }
-        }
-        return b.toString();
-    }
-
     /**
      * Displays a confirmation message.
      *

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -21,7 +21,15 @@
 
 package com.izforge.izpack.installer.bootstrap;
 
-import java.awt.GraphicsEnvironment;
+import com.izforge.izpack.installer.automation.AutomatedInstaller;
+import com.izforge.izpack.installer.console.ConsoleInstaller;
+import com.izforge.izpack.installer.container.impl.AutomatedInstallerContainer;
+import com.izforge.izpack.installer.container.impl.ConsoleInstallerContainer;
+import com.izforge.izpack.installer.container.impl.InstallerContainer;
+import com.izforge.izpack.util.Debug;
+import com.izforge.izpack.util.StringTool;
+
+import java.awt.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -30,13 +38,6 @@ import java.util.NoSuchElementException;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
-
-import com.izforge.izpack.installer.automation.AutomatedInstaller;
-import com.izforge.izpack.installer.console.ConsoleInstaller;
-import com.izforge.izpack.installer.container.impl.ConsoleInstallerContainer;
-import com.izforge.izpack.installer.container.impl.InstallerContainer;
-import com.izforge.izpack.util.Debug;
-import com.izforge.izpack.util.StringTool;
 
 /**
  * The program entry point. Selects between GUI and text install modes.
@@ -236,7 +237,7 @@ public class Installer
      */
     private void launchAutomatedInstaller(String path, String mediaDir, String[] args) throws Exception
     {
-        InstallerContainer container = new ConsoleInstallerContainer();
+        InstallerContainer container = new AutomatedInstallerContainer();
         AutomatedInstaller automatedInstaller = container.getComponent(AutomatedInstaller.class);
         automatedInstaller.init(path, mediaDir, args);
         automatedInstaller.doInstall();

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
@@ -21,20 +21,13 @@
 
 package com.izforge.izpack.installer.console;
 
-import java.io.*;
-import java.util.Enumeration;
-import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.Info;
-import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.exception.UserInterruptException;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.installer.base.InstallerBase;
 import com.izforge.izpack.installer.bootstrap.Installer;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
 import com.izforge.izpack.installer.data.UninstallData;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.installer.requirement.RequirementsChecker;
@@ -42,6 +35,14 @@ import com.izforge.izpack.util.Console;
 import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.PrivilegedRunner;
 import com.izforge.izpack.util.file.FileUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Runs the console installer.
@@ -64,7 +65,7 @@ public class ConsoleInstaller implements InstallerBase
     /**
      * The installation data.
      */
-    private InstallData installData;
+    private ConsoleInstallData installData;
 
     /**
      * Verifies the installation requirements.
@@ -103,7 +104,7 @@ public class ConsoleInstaller implements InstallerBase
      * @param housekeeper         the house-keeper
      * @throws IzPackException for any IzPack error
      */
-    public ConsoleInstaller(ConsolePanels panels, AutomatedInstallData installData, RequirementsChecker requirements,
+    public ConsoleInstaller(ConsolePanels panels, ConsoleInstallData installData, RequirementsChecker requirements,
                             UninstallDataWriter uninstallDataWriter, Console console, Housekeeper housekeeper)
     {
         this.panels = panels;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/PanelConsoleHelper.java
@@ -21,12 +21,12 @@
 
 package com.izforge.izpack.installer.console;
 
-import java.io.PrintWriter;
-import java.util.Properties;
-
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.installer.panel.PanelView;
 import com.izforge.izpack.util.Console;
+
+import java.io.PrintWriter;
+import java.util.Properties;
 
 /**
  * Abstract class implementing basic functions needed by all panel console helpers.
@@ -95,32 +95,6 @@ abstract public class PanelConsoleHelper extends AbstractConsolePanel implements
     public boolean run(InstallData installData, Console console)
     {
         return runConsole(installData, console);
-    }
-
-    /**
-     * Runs the panel in interactive console mode.
-     *
-     * @param installData the installation data
-     * @deprecated use {@link #run(InstallData, Console)}
-     */
-    @Override
-    @Deprecated
-    public boolean runConsole(InstallData installData)
-    {
-        return runConsole(installData, new Console(installData.getMessages()));
-    }
-
-    /**
-     * Prompts to end the console panel.
-     *
-     * @return <tt>1</tt> to continue, <tt>2</tt> to quit, <tt>3</tt> to redisplay
-     * @see {@link #promptEndPanel(InstallData, Console)}
-     * @deprecated
-     */
-    @Deprecated
-    public int askEndOfConsolePanel(InstallData installData)
-    {
-        return new Console(installData.getMessages()).prompt("press 1 to continue, 2 to quit, 3 to redisplay", 1, 3, 2);
     }
 
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/AutomatedInstallerContainer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/impl/AutomatedInstallerContainer.java
@@ -23,44 +23,43 @@ package com.izforge.izpack.installer.container.impl;
 
 
 import com.izforge.izpack.api.exception.ContainerException;
-import com.izforge.izpack.core.handler.ConsolePrompt;
+import com.izforge.izpack.core.handler.AutomatedPrompt;
 import com.izforge.izpack.installer.automation.AutomatedInstaller;
-import com.izforge.izpack.installer.console.ConsoleInstaller;
 import com.izforge.izpack.installer.console.ConsolePanelAutomationHelper;
-import com.izforge.izpack.installer.container.provider.*;
+import com.izforge.izpack.installer.container.provider.AutomatedInstallDataProvider;
+import com.izforge.izpack.installer.container.provider.AutomatedPanelsProvider;
 import com.izforge.izpack.installer.multiunpacker.MultiVolumeUnpackerAutomationHelper;
 import com.izforge.izpack.installer.unpacker.ConsolePackResources;
-import com.izforge.izpack.util.Console;
 import org.picocontainer.MutablePicoContainer;
 import org.picocontainer.injectors.ProviderAdapter;
 
 /**
- * Installer container for console installation mode.
+ * Installer container for automated installation mode.
  *
  * @author Tim Anderson
  */
-public class ConsoleInstallerContainer extends InstallerContainer
+public class AutomatedInstallerContainer extends InstallerContainer
 {
 
     /**
-     * Constructs a <tt>ConsoleInstallerContainer</tt>.
+     * Constructs a <tt>AutomatedInstallerContainer</tt>.
      *
      * @throws ContainerException if initialisation fails
      */
-    public ConsoleInstallerContainer()
+    public AutomatedInstallerContainer()
     {
         initialise();
     }
 
     /**
-     * Constructs a <tt>ConsoleInstallerContainer</tt>.
+     * Constructs a <tt>AutomatedInstallerContainer</tt>.
      * <p/>
      * This constructor is provided for testing purposes.
      *
      * @param container the underlying container
      * @throws ContainerException if initialisation fails
      */
-    protected ConsoleInstallerContainer(MutablePicoContainer container)
+    protected AutomatedInstallerContainer(MutablePicoContainer container)
     {
         initialise(container);
     }
@@ -76,16 +75,12 @@ public class ConsoleInstallerContainer extends InstallerContainer
         super.registerComponents(container);
 
         container
-                .addAdapter(new ProviderAdapter(new ConsoleInstallDataProvider()))
-                .addAdapter(new ProviderAdapter(new ConsolePanelsProvider()))
-                //.addAdapter(new ProviderAdapter(new AutomatedPanelsProvider()))
-                .addAdapter(new ProviderAdapter(new MessagesProvider())) // required by ConsolePrompt and Console
-                .addAdapter(new ProviderAdapter(new ConsolePrefsProvider())); // required by Console
+                .addAdapter(new ProviderAdapter(new AutomatedInstallDataProvider()))
+                .addAdapter(new ProviderAdapter(new AutomatedPanelsProvider()));
 
         container
-                .addComponent(Console.class)
-                .addComponent(ConsolePrompt.class)
-                .addComponent(ConsoleInstaller.class)
+                .addComponent(AutomatedPrompt.class)
+                .addComponent(AutomatedInstaller.class)
                 .addComponent(ConsolePanelAutomationHelper.class)
                 .addComponent(ConsolePackResources.class)
                 .addComponent(MultiVolumeUnpackerAutomationHelper.class);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AutomatedInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AutomatedInstallDataProvider.java
@@ -24,13 +24,12 @@ public class AutomatedInstallDataProvider extends AbstractInstallDataProvider
         AutomatedInstallData automatedInstallData = new InstallData(variables, matcher.getCurrentPlatform());
         // Loads the installation data
         loadInstallData(automatedInstallData, resources, matcher, housekeeper);
-
+        loadInstallerRequirements(automatedInstallData, resources);
+        loadDynamicVariables(variables, automatedInstallData, resources);
+        loadDynamicConditions(automatedInstallData, resources);
         loadDefaultLocale(automatedInstallData, locales);
         // Load custom langpack if exist.
         AbstractInstallDataProvider.addCustomLangpack(automatedInstallData, locales);
-        loadDynamicVariables(variables, automatedInstallData, resources);
-        loadDynamicConditions(automatedInstallData, resources);
-        loadInstallerRequirements(automatedInstallData, resources);
         return automatedInstallData;
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/ConsoleInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/ConsoleInstallDataProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.installer.container.provider;
+
+import com.izforge.izpack.api.data.ConsolePrefs;
+import com.izforge.izpack.api.resource.Locales;
+import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.core.data.DefaultVariables;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
+import com.izforge.izpack.util.Housekeeper;
+import com.izforge.izpack.util.PlatformModelMatcher;
+
+public class ConsoleInstallDataProvider extends AbstractInstallDataProvider
+{
+
+    public ConsoleInstallData provide(Resources resources, Locales locales, DefaultVariables variables,
+                                      Housekeeper housekeeper, PlatformModelMatcher matcher)
+            throws Exception
+    {
+        final ConsoleInstallData consoleInstallData = new ConsoleInstallData(variables, matcher.getCurrentPlatform());
+        loadInstallData(consoleInstallData, resources, matcher, housekeeper);
+        loadConsoleInstallData(consoleInstallData, resources);
+        loadInstallerRequirements(consoleInstallData, resources);
+        loadDynamicVariables(variables, consoleInstallData, resources);
+        loadDynamicConditions(consoleInstallData, resources);
+        loadDefaultLocale(consoleInstallData, locales);
+        // Load custom langpack if exist.
+        AbstractInstallDataProvider.addCustomLangpack(consoleInstallData, locales);
+        return consoleInstallData;
+    }
+
+    /**
+     * Load GUI preference information.
+     *
+     * @param installData the console installation data
+     * @throws Exception
+     */
+    private void loadConsoleInstallData(ConsoleInstallData installData, Resources resources) throws Exception
+    {
+        installData.consolePrefs = (ConsolePrefs) resources.getObject("ConsolePrefs");
+    }
+
+}

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/ConsolePrefsProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/ConsolePrefsProvider.java
@@ -1,0 +1,48 @@
+/*
+ * IzPack - Copyright 2001-2013 Julien Ponge, All Rights Reserved.
+ *
+ * http://izpack.org/
+ * http://izpack.codehaus.org/
+ *
+ * Copyright 2013 Tim Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.installer.container.provider;
+
+import com.izforge.izpack.api.data.ConsolePrefs;
+import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
+import org.picocontainer.injectors.Provider;
+
+
+/**
+ * Provides an {@link Messages} from the current locale.
+ *
+ * @author Tim Anderson
+ */
+public class ConsolePrefsProvider implements Provider
+{
+
+    /**
+     * Provides an {@link ConsolePrefs}.
+     *
+     * @param installData the console installation data
+     * @return the console preferences
+     */
+    public ConsolePrefs provide(ConsoleInstallData installData)
+    {
+        return installData.consolePrefs;
+    }
+}

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/GUIInstallDataProvider.java
@@ -1,22 +1,5 @@
 package com.izforge.izpack.installer.container.provider;
 
-import java.awt.Color;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.LookAndFeel;
-import javax.swing.SwingUtilities;
-import javax.swing.UIDefaults;
-import javax.swing.UIManager;
-import javax.swing.plaf.metal.MetalLookAndFeel;
-import javax.swing.plaf.metal.MetalTheme;
-
 import com.izforge.izpack.api.data.GUIPrefs;
 import com.izforge.izpack.api.resource.Locales;
 import com.izforge.izpack.api.resource.Resources;
@@ -27,6 +10,16 @@ import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.OsVersion;
 import com.izforge.izpack.util.PlatformModelMatcher;
+
+import javax.swing.*;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import javax.swing.plaf.metal.MetalTheme;
+import java.awt.*;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Provide installData for GUI :
@@ -318,13 +311,12 @@ public class GUIInstallDataProvider extends AbstractInstallDataProvider
     /**
      * Load GUI preference information.
      *
-     * @param installData the installation data
+     * @param installData the GUI installation data
      * @throws Exception
      */
     private void loadGUIInstallData(GUIInstallData installData, Resources resources) throws Exception
     {
         installData.guiPrefs = (GUIPrefs) resources.getObject("GUIPrefs");
     }
-
 
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/data/ConsoleInstallData.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/data/ConsoleInstallData.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.installer.data;
+
+import com.izforge.izpack.api.data.ConsolePrefs;
+import com.izforge.izpack.api.data.Variables;
+import com.izforge.izpack.util.Platform;
+
+import java.io.Serializable;
+
+public class ConsoleInstallData extends InstallData implements Serializable
+{
+    private static final long serialVersionUID = -4272255846202671405L;
+
+    /**
+     * The console preferences.
+     */
+    public ConsolePrefs consolePrefs;
+
+    public ConsoleInstallData(Variables variables, Platform platform)
+    {
+        super(variables, platform);
+    }
+}

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/AbstractRequirementCheckerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/AbstractRequirementCheckerTest.java
@@ -20,12 +20,7 @@
  */
 package com.izforge.izpack.installer.requirement;
 
-import static org.junit.Assert.assertNotNull;
-
-import java.io.InputStream;
-
-import org.mockito.Mockito;
-
+import com.izforge.izpack.api.data.ConsolePrefs;
 import com.izforge.izpack.api.data.Info;
 import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.handler.Prompt;
@@ -33,9 +28,14 @@ import com.izforge.izpack.api.installer.RequirementChecker;
 import com.izforge.izpack.api.resource.Locales;
 import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.core.handler.ConsolePrompt;
-import com.izforge.izpack.installer.data.InstallData;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
 import com.izforge.izpack.test.util.TestConsole;
 import com.izforge.izpack.util.Platforms;
+import org.mockito.Mockito;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Base class for {@link RequirementChecker} tests.
@@ -48,7 +48,7 @@ public abstract class AbstractRequirementCheckerTest
     /**
      * The installation data.
      */
-    protected final InstallData installData;
+    protected final ConsoleInstallData installData;
 
     /**
      * The console.
@@ -65,7 +65,12 @@ public abstract class AbstractRequirementCheckerTest
      */
     public AbstractRequirementCheckerTest()
     {
-        installData = new InstallData(new DefaultVariables(), Platforms.FEDORA_LINUX);
+        installData = new ConsoleInstallData(new DefaultVariables(), Platforms.FEDORA_LINUX);
+
+        ConsolePrefs prefs = new ConsolePrefs();
+        prefs.enableConsoleReader = false;
+        installData.consolePrefs = prefs;
+
         Info info = new Info();
         installData.setInfo(info);
 
@@ -73,7 +78,7 @@ public abstract class AbstractRequirementCheckerTest
         assertNotNull(langPack);
         installData.setMessages(new LocaleDatabase(langPack, Mockito.mock(Locales.class)));
 
-        console = new TestConsole(installData.getMessages());
+        console = new TestConsole(installData.getMessages(), prefs);
         prompt = new ConsolePrompt(console, installData.getMessages());
     }
 }

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/JDKCheckerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/requirement/JDKCheckerTest.java
@@ -21,17 +21,15 @@
 
 package com.izforge.izpack.installer.requirement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
 import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.ConsolePrefs;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.core.handler.ConsolePrompt;
 import com.izforge.izpack.test.util.TestConsole;
 import com.izforge.izpack.util.FileExecutor;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests the {@link JDKChecker} class.
@@ -88,7 +86,11 @@ public class JDKCheckerTest extends AbstractRequirementCheckerTest
         boolean exists = (code == 0); // exists if javac is in the path
         installData.getInfo().setJdkRequired(true);
 
-        TestConsole console = new TestConsole(installData.getMessages());
+        ConsolePrefs prefs = new ConsolePrefs();
+        prefs.enableConsoleReader = false;
+        installData.consolePrefs = prefs;
+
+        TestConsole console = new TestConsole(installData.getMessages(), prefs);
         ConsolePrompt prompt = new ConsolePrompt(console, installData.getMessages());
         JDKChecker checker = new JDKChecker(installData, prompt);
         assertEquals(exists, checker.check());

--- a/izpack-installer/src/test/java/com/izforge/izpack/test/provider/ConsoleInstallDataMockProvider.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/test/provider/ConsoleInstallDataMockProvider.java
@@ -20,33 +20,52 @@
  */
 package com.izforge.izpack.test.provider;
 
-import java.io.IOException;
-
-import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.ConsolePrefs;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.resource.Locales;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
+import com.izforge.izpack.util.Platforms;
+
+import java.io.IOException;
 
 /**
- * Test provider for {@link InstallData}.
+ * Test provider for {@link ConsoleInstallData}.
  *
  * @author Tim Anderson
  */
-public class InstallDataMockProvider extends AbstractInstallDataMockProvider
+public class ConsoleInstallDataMockProvider extends AbstractInstallDataMockProvider
 {
 
     /**
-     * Provides an {@link AutomatedInstallData}.
+     * Provides an {@link ConsoleInstallData}.
      *
      * @param variables the variables
      * @param locales   the locales
-     * @return an {@link AutomatedInstallData}
+     * @return an {@link ConsoleInstallData}
      * @throws IOException if the default messages cannot be found
      */
-    public AutomatedInstallData provide(Variables variables, Locales locales) throws IOException
+    public ConsoleInstallData provide(Variables variables, Locales locales) throws IOException
     {
-        AutomatedInstallData result = createInstallData(variables);
+        ConsoleInstallData result = createInstallData(variables);
         populate(result, locales);
+        return result;
+    }
+
+    /**
+     * Creates a new {@link ConsoleInstallData}.
+     *
+     * @param variables the variables
+     * @return a new {@link ConsoleInstallData}
+     */
+    @Override
+    protected ConsoleInstallData createInstallData(Variables variables)
+    {
+        ConsoleInstallData result = new ConsoleInstallData(variables, Platforms.MAC_OSX);
+
+        ConsolePrefs consolePrefs = new ConsolePrefs();
+        consolePrefs.enableConsoleReader = false;
+        result.consolePrefs = consolePrefs;
+
         return result;
     }
 

--- a/izpack-installer/src/test/java/com/izforge/izpack/test/provider/GUIInstallDataMockProvider.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/test/provider/GUIInstallDataMockProvider.java
@@ -18,15 +18,14 @@
  */
 package com.izforge.izpack.test.provider;
 
-import java.io.IOException;
-
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.GUIPrefs;
-import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.resource.Locales;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.util.Platforms;
+
+import java.io.IOException;
 
 /**
  * Mock provider for guiInstallData
@@ -35,11 +34,11 @@ public class GUIInstallDataMockProvider extends AbstractInstallDataMockProvider
 {
 
     /**
-     * Provides an {@link InstallData}.
+     * Provides an {@link GUIInstallData}.
      *
      * @param variables the variables
      * @param locales   the locales
-     * @return an {@link InstallData}
+     * @return an {@link GUIInstallData}
      * @throws IOException if the default messages cannot be found
      */
     public GUIInstallData provide(Variables variables, Locales locales) throws IOException

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/test/TestConsolePanelContainer.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/test/TestConsolePanelContainer.java
@@ -20,17 +20,18 @@
  */
 package com.izforge.izpack.panels.test;
 
-import org.mockito.Mockito;
-import org.picocontainer.MutablePicoContainer;
-import org.picocontainer.PicoException;
-import org.picocontainer.injectors.ProviderAdapter;
-
+import com.izforge.izpack.api.data.ConsolePrefs;
 import com.izforge.izpack.api.exception.ContainerException;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.core.handler.ConsolePrompt;
-import com.izforge.izpack.test.provider.InstallDataMockProvider;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
+import com.izforge.izpack.test.provider.ConsoleInstallDataMockProvider;
 import com.izforge.izpack.test.util.TestConsole;
+import org.mockito.Mockito;
+import org.picocontainer.MutablePicoContainer;
+import org.picocontainer.PicoException;
+import org.picocontainer.injectors.ProviderAdapter;
 
 /**
  * Container for testing console panels.
@@ -56,10 +57,12 @@ public class TestConsolePanelContainer extends AbstractTestPanelContainer
     protected void fillContainer(MutablePicoContainer container)
     {
         super.fillContainer(container);
+        container.addAdapter(new ProviderAdapter(new ConsoleInstallDataMockProvider()));
+        ConsoleInstallData installData = container.getComponent(ConsoleInstallData.class);
+        addComponent(ConsolePrefs.class, installData.consolePrefs);
         addComponent(TestConsole.class);
         addComponent(Messages.class, Mockito.mock(Messages.class));
         addComponent(ConsolePrompt.class);
-        container.addAdapter(new ProviderAdapter(new InstallDataMockProvider()));
 
         getComponent(RulesEngine.class); // force creation of the rules
     }

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/AbstractConsoleFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/AbstractConsoleFieldTest.java
@@ -1,14 +1,6 @@
 package com.izforge.izpack.panels.userinput.console;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.InputStream;
-
-import org.mockito.Mockito;
-
-import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.ConsolePrefs;
 import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.resource.Locales;
@@ -17,8 +9,14 @@ import com.izforge.izpack.core.container.DefaultContainer;
 import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.core.rules.ConditionContainer;
 import com.izforge.izpack.core.rules.RulesEngineImpl;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
 import com.izforge.izpack.test.util.TestConsole;
 import com.izforge.izpack.util.Platforms;
+import org.mockito.Mockito;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
 
 /**
  * Base class for console-based user-input fields.
@@ -31,7 +29,7 @@ public abstract class AbstractConsoleFieldTest
     /**
      * The install data.
      */
-    protected final AutomatedInstallData installData;
+    protected final ConsoleInstallData installData;
 
     /**
      * The console.
@@ -49,13 +47,18 @@ public abstract class AbstractConsoleFieldTest
      */
     public AbstractConsoleFieldTest()
     {
-        installData = new AutomatedInstallData(new DefaultVariables(), Platforms.LINUX);
+        installData = new ConsoleInstallData(new DefaultVariables(), Platforms.LINUX);
         InputStream langPack = getClass().getResourceAsStream("/com/izforge/izpack/bin/langpacks/installer/eng.xml");
         assertNotNull(langPack);
         installData.setMessages(new LocaleDatabase(langPack, Mockito.mock(Locales.class)));
         RulesEngine rules = new RulesEngineImpl(new ConditionContainer(new DefaultContainer()),
                                                 installData.getPlatform());
-        console = new TestConsole(installData.getMessages());
+
+        ConsolePrefs prefs = new ConsolePrefs();
+        prefs.enableConsoleReader = false;
+        installData.consolePrefs = prefs;
+
+        console = new TestConsole(installData.getMessages(), prefs);
         prompt = Mockito.mock(Prompt.class);
         installData.setRules(rules);
     }

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/check/ConsoleCheckFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/check/ConsoleCheckFieldTest.java
@@ -21,7 +21,7 @@
 
 package com.izforge.izpack.panels.userinput.console.check;
 
-import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.ConsolePrefs;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.api.rules.RulesEngine;
@@ -30,6 +30,7 @@ import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.core.handler.ConsolePrompt;
 import com.izforge.izpack.core.rules.ConditionContainer;
 import com.izforge.izpack.core.rules.RulesEngineImpl;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
 import com.izforge.izpack.panels.userinput.console.AbstractConsoleFieldTest;
 import com.izforge.izpack.panels.userinput.field.check.CheckField;
 import com.izforge.izpack.panels.userinput.field.check.TestCheckFieldConfig;
@@ -53,7 +54,7 @@ public class ConsoleCheckFieldTest extends AbstractConsoleFieldTest
     /**
      * The install data.
      */
-    private final AutomatedInstallData installData;
+    private final ConsoleInstallData installData;
 
     /**
      * The console.
@@ -70,10 +71,15 @@ public class ConsoleCheckFieldTest extends AbstractConsoleFieldTest
      */
     public ConsoleCheckFieldTest()
     {
-        installData = new AutomatedInstallData(new DefaultVariables(), Platforms.HP_UX);
+        installData = new ConsoleInstallData(new DefaultVariables(), Platforms.HP_UX);
         RulesEngine rules = new RulesEngineImpl(new ConditionContainer(new DefaultContainer()),
                                                 installData.getPlatform());
-        console = new TestConsole(installData.getMessages());
+
+        ConsolePrefs prefs = new ConsolePrefs();
+        prefs.enableConsoleReader = false;
+        installData.consolePrefs = prefs;
+
+        console = new TestConsole(installData.getMessages(), prefs);
         prompt = new ConsolePrompt(console, Mockito.mock(Messages.class));
         installData.setRules(rules);
     }

--- a/izpack-test-common/src/main/java/com/izforge/izpack/test/util/TestConsole.java
+++ b/izpack-test-common/src/main/java/com/izforge/izpack/test/util/TestConsole.java
@@ -22,13 +22,14 @@
 package com.izforge.izpack.test.util;
 
 
+import com.izforge.izpack.api.data.ConsolePrefs;
+import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.util.Console;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import com.izforge.izpack.api.resource.Messages;
-import com.izforge.izpack.util.Console;
 
 
 /**
@@ -71,10 +72,9 @@ public class TestConsole extends Console
     /**
      * Constructs a <tt>TestConsole</tt>.
      */
-    public TestConsole(Messages messages)
+    public TestConsole(Messages messages, ConsolePrefs prefs)
     {
-        super(messages);
-        super.useDefaultInput();
+        super(messages, prefs);
     }
 
     /**

--- a/izpack-test/src/test/java/com/izforge/izpack/compiler/container/TestAutomatedInstallationContainer.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/compiler/container/TestAutomatedInstallationContainer.java
@@ -1,0 +1,26 @@
+package com.izforge.izpack.compiler.container;
+
+import com.izforge.izpack.installer.container.impl.InstallerContainer;
+import org.junit.runners.model.FrameworkMethod;
+import org.picocontainer.MutablePicoContainer;
+
+
+/**
+ * Container for integration testing
+ */
+public class TestAutomatedInstallationContainer extends AbstractTestInstallationContainer
+{
+    public TestAutomatedInstallationContainer(Class<?> klass, FrameworkMethod frameworkMethod)
+    {
+        super(klass, frameworkMethod);
+        initialise();
+    }
+
+
+    @Override
+    protected InstallerContainer fillInstallerContainer(MutablePicoContainer container)
+    {
+        return new TestAutomatedInstallerContainer(container);
+    }
+
+}

--- a/izpack-test/src/test/java/com/izforge/izpack/compiler/container/TestAutomatedInstallerContainer.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/compiler/container/TestAutomatedInstallerContainer.java
@@ -22,38 +22,34 @@
 package com.izforge.izpack.compiler.container;
 
 import com.izforge.izpack.api.data.ConsolePrefs;
-import com.izforge.izpack.installer.console.ConsoleInstaller;
-import com.izforge.izpack.installer.console.TestConsoleInstaller;
-import com.izforge.izpack.installer.container.impl.ConsoleInstallerContainer;
 import com.izforge.izpack.installer.console.TestConsolePrefsProvider;
-import com.izforge.izpack.test.util.TestConsole;
+import com.izforge.izpack.installer.container.impl.AutomatedInstallerContainer;
 import com.izforge.izpack.test.util.TestHousekeeper;
-import com.izforge.izpack.util.Console;
 import com.izforge.izpack.util.Housekeeper;
 import org.picocontainer.MutablePicoContainer;
 import org.picocontainer.injectors.ProviderAdapter;
 
 
 /**
- * Test installer container for console based installers.
- * <p/>
- * This returns:
- * <ul>
- * <li>a {@link TestConsoleInstaller} instead of a {@link ConsoleInstaller}</li>
- * <li>a {@link TestConsole} instead of a {@link Console}</li>
- * <li>a {@link TestHousekeeper} instead of a {@link Housekeeper}</li>
- * </ul>
- *
- * @author Tim Anderson
+ * Test installer container for automated installation mode.
  */
-public class TestConsoleInstallerContainer extends ConsoleInstallerContainer
+public class TestAutomatedInstallerContainer extends AutomatedInstallerContainer
 {
 
-    public TestConsoleInstallerContainer()
+    /**
+     * Default constructor.
+     */
+    public TestAutomatedInstallerContainer()
     {
+        super();
     }
 
-    public TestConsoleInstallerContainer(MutablePicoContainer container)
+    /**
+     * Constructs a <tt>TestAutomatedInstallerContainer</tt>.
+     *
+     * @param container the container to use
+     */
+    public TestAutomatedInstallerContainer(MutablePicoContainer container)
     {
         super(container);
     }
@@ -67,12 +63,8 @@ public class TestConsoleInstallerContainer extends ConsoleInstallerContainer
     protected void registerComponents(MutablePicoContainer container)
     {
         super.registerComponents(container);
-        container.removeComponent(ConsoleInstaller.class);
-        container.addComponent(TestConsoleInstaller.class);
         container.removeComponent(ConsolePrefs.class);
-        container.removeComponent(Console.class);
-        container.addAdapter(new ProviderAdapter(new TestConsolePrefsProvider())); // required by TestConsole
-        container.addComponent(TestConsole.class);
+        container.addAdapter(new ProviderAdapter(new TestConsolePrefsProvider()));
         container.removeComponent(Housekeeper.class);
         container.addComponent(TestHousekeeper.class);
     }

--- a/izpack-test/src/test/java/com/izforge/izpack/compiler/container/TestGUIInstallationContainer.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/compiler/container/TestGUIInstallationContainer.java
@@ -10,10 +10,10 @@ import com.izforge.izpack.installer.container.impl.InstallerContainer;
  *
  * @author Anthonin Bonnefoy
  */
-public class TestInstallationContainer extends AbstractTestInstallationContainer
+public class TestGUIInstallationContainer extends AbstractTestInstallationContainer
 {
 
-    public TestInstallationContainer(Class klass, FrameworkMethod frameworkMethod)
+    public TestGUIInstallationContainer(Class klass, FrameworkMethod frameworkMethod)
     {
         super(klass, frameworkMethod);
         initialise();

--- a/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsoleInstaller.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsoleInstaller.java
@@ -21,7 +21,7 @@
 
 package com.izforge.izpack.installer.console;
 
-import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.installer.requirement.RequirementsChecker;
 import com.izforge.izpack.test.util.TestConsole;
@@ -48,7 +48,7 @@ public class TestConsoleInstaller extends ConsoleInstaller
      * @param housekeeper  the house-keeper
      * @throws Exception for any error
      */
-    public TestConsoleInstaller(ConsolePanels panels, AutomatedInstallData installData,
+    public TestConsoleInstaller(ConsolePanels panels, ConsoleInstallData installData,
                                 RequirementsChecker requirements, UninstallDataWriter writer,
                                 TestConsole console, Housekeeper housekeeper)
             throws Exception

--- a/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsolePrefsProvider.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsolePrefsProvider.java
@@ -1,0 +1,48 @@
+/*
+ * IzPack - Copyright 2001-2013 Julien Ponge, All Rights Reserved.
+ *
+ * http://izpack.org/
+ * http://izpack.codehaus.org/
+ *
+ * Copyright 2013 Tim Anderson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.installer.console;
+
+import com.izforge.izpack.api.data.ConsolePrefs;
+import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.installer.data.ConsoleInstallData;
+import org.picocontainer.injectors.Provider;
+
+
+/**
+ * Provides an {@link Messages} from the current locale.
+ */
+public class TestConsolePrefsProvider implements Provider
+{
+
+    /**
+     * Provides an {@link ConsolePrefs}.
+     *
+     * @param installData the console installation data
+     * @return the console preferences
+     */
+    public ConsolePrefs provide(ConsoleInstallData installData)
+    {
+        ConsolePrefs prefs = installData.consolePrefs;
+        prefs.enableConsoleReader = false;
+        return prefs;
+    }
+}

--- a/izpack-test/src/test/java/com/izforge/izpack/installer/language/ConditionCheckTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/installer/language/ConditionCheckTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mockito;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.installer.InstallerRequirementDisplay;
 import com.izforge.izpack.api.rules.RulesEngine;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.core.resource.ResourceManager;
 import com.izforge.izpack.test.Container;
 import com.izforge.izpack.test.InstallFile;
@@ -22,7 +22,7 @@ import com.izforge.izpack.test.junit.PicoRunner;
  * @author Anthonin Bonnefoy
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class ConditionCheckTest
 {
 

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/EventTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/EventTest.java
@@ -11,7 +11,7 @@ import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.data.CustomData;
 import com.izforge.izpack.event.RegistryInstallerListener;
 import com.izforge.izpack.event.RegistryUninstallerListener;
@@ -29,7 +29,7 @@ import com.izforge.izpack.test.junit.PicoRunner;
  * @see com.izforge.izpack.installer.container.impl.CustomDataLoader
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class EventTest
 {
     private final InstallerListeners listeners;

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/ExecutableFileTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/ExecutableFileTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.handler.AbstractUIProgressHandler;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.installer.unpacker.Unpacker;
 import com.izforge.izpack.test.Container;
@@ -55,7 +55,7 @@ import com.izforge.izpack.util.Platform.Name;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class ExecutableFileTest extends AbstractDestroyerTest
 {
     /**

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/InstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/InstallationTest.java
@@ -18,7 +18,7 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import com.izforge.izpack.api.GuiId;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.gui.IconsDatabase;
 import com.izforge.izpack.installer.container.impl.InstallerContainer;
 import com.izforge.izpack.installer.data.GUIInstallData;
@@ -35,7 +35,7 @@ import com.izforge.izpack.test.junit.PicoRunner;
  */
 
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class InstallationTest
 {
     @Rule

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/InstallerListenerTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/InstallerListenerTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.event.InstallerListener;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.installer.event.InstallerListeners;
 import com.izforge.izpack.installer.gui.InstallerController;
 import com.izforge.izpack.installer.gui.InstallerFrame;
@@ -47,7 +47,7 @@ import com.izforge.izpack.test.listener.TestInstallerListener;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class InstallerListenerTest extends AbstractInstallationTest
 {
 

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/IzpackInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/IzpackInstallationTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.exception.NativeLibException;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.installer.data.GUIInstallData;
@@ -52,7 +52,7 @@ import com.izforge.izpack.util.Platforms;
  * installation.
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class IzpackInstallationTest
 {
     @Rule

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/UninstallDataWriterTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/UninstallDataWriterTest.java
@@ -46,7 +46,7 @@ import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.Info;
 import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.api.rules.RulesEngine;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.matcher.ZipMatcher;
 import com.izforge.izpack.test.Container;
@@ -61,7 +61,7 @@ import com.izforge.izpack.util.IoHelper;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class UninstallDataWriterTest
 {
     /**

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/UninstallerListenerTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/UninstallerListenerTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.installer.data.UninstallData;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.matcher.ZipMatcher;
@@ -52,7 +52,7 @@ import com.izforge.izpack.uninstaller.Destroyer;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class UninstallerListenerTest extends AbstractDestroyerTest
 {
     /**

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/automation/AutomatedInstallerTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/automation/AutomatedInstallerTest.java
@@ -21,12 +21,21 @@
 
 package com.izforge.izpack.integration.automation;
 
-import static com.izforge.izpack.test.util.TestHelper.assertFileExists;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.File;
-import java.net.URL;
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.compiler.container.TestAutomatedInstallationContainer;
+import com.izforge.izpack.installer.automation.AutomatedInstaller;
+import com.izforge.izpack.integration.AbstractInstallationTest;
+import com.izforge.izpack.integration.UninstallHelper;
+import com.izforge.izpack.test.Container;
+import com.izforge.izpack.test.InstallFile;
+import com.izforge.izpack.test.junit.PicoRunner;
+import com.izforge.izpack.util.FileUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -36,23 +45,12 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.net.URL;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.xml.sax.InputSource;
-
-import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.api.data.InstallData;
-import com.izforge.izpack.compiler.container.TestConsoleInstallationContainer;
-import com.izforge.izpack.installer.automation.AutomatedInstaller;
-import com.izforge.izpack.integration.AbstractInstallationTest;
-import com.izforge.izpack.integration.UninstallHelper;
-import com.izforge.izpack.test.Container;
-import com.izforge.izpack.test.InstallFile;
-import com.izforge.izpack.test.junit.PicoRunner;
-import com.izforge.izpack.util.FileUtil;
+import static com.izforge.izpack.test.util.TestHelper.assertFileExists;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 
 /**
@@ -61,7 +59,7 @@ import com.izforge.izpack.util.FileUtil;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestConsoleInstallationContainer.class)
+@Container(TestAutomatedInstallationContainer.class)
 public class AutomatedInstallerTest extends AbstractInstallationTest
 {
 

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/console/ConsoleInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/console/ConsoleInstallationTest.java
@@ -21,18 +21,6 @@
 
 package com.izforge.izpack.integration.console;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.util.Properties;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.IzPackException;
@@ -45,6 +33,15 @@ import com.izforge.izpack.test.Container;
 import com.izforge.izpack.test.InstallFile;
 import com.izforge.izpack.test.junit.PicoRunner;
 import com.izforge.izpack.test.util.TestConsole;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
 
 
 /**
@@ -148,8 +145,8 @@ public class ConsoleInstallationTest extends AbstractConsoleInstallationTest
         TestConsole console = installer.getConsole();
         console.addScript("HelloPanel", "1");
         console.addScript("InfoPanel", "1");
-        console.addScript("LicensePanel", "\n", "3", "\n", "1");
-        console.addScript("TargetPanel", "\n", "1");
+        console.addScript("LicensePanel", "\n", "3", "1");
+        console.addScript("TargetPanel", "\n", "\n", "1");
 
         checkInstall(installer, getInstallData());
     }

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/datavalidator/DataValidatorTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/datavalidator/DataValidatorTest.java
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith;
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.installer.DataValidator;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerController;
 import com.izforge.izpack.installer.gui.InstallerFrame;
@@ -64,7 +64,7 @@ import com.izforge.izpack.test.util.TestHousekeeper;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class DataValidatorTest
 {
     /**

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/packaging/PackagingTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/packaging/PackagingTest.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
 
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.compiler.data.CompilerData;
 import com.izforge.izpack.compiler.packager.impl.Packager;
 import com.izforge.izpack.installer.gui.InstallerController;
@@ -61,7 +61,7 @@ import com.izforge.izpack.test.junit.PicoRunner;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class PackagingTest extends AbstractInstallationTest
 {
     /**

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/packvalidator/PackValidatorTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/packvalidator/PackValidatorTest.java
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith;
 
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.Panel;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerController;
 import com.izforge.izpack.installer.gui.InstallerFrame;
@@ -61,7 +61,7 @@ import com.izforge.izpack.test.util.TestHousekeeper;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class PackValidatorTest
 {
     /**

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/panelaction/PanelActionTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/panelaction/PanelActionTest.java
@@ -46,7 +46,7 @@ import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.data.PanelActionConfiguration;
 import com.izforge.izpack.api.data.binding.ActionStage;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.data.PanelAction;
 import com.izforge.izpack.installer.gui.InstallerController;
 import com.izforge.izpack.installer.gui.InstallerFrame;
@@ -67,7 +67,7 @@ import com.izforge.izpack.test.util.TestHousekeeper;
  * @author Tim Anderson
  */
 @RunWith(PicoRunner.class)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class PanelActionTest
 {
     /**

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsInstallationTest.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.exception.NativeLibException;
-import com.izforge.izpack.compiler.container.TestInstallationContainer;
+import com.izforge.izpack.compiler.container.TestGUIInstallationContainer;
 import com.izforge.izpack.core.os.RegistryDefaultHandler;
 import com.izforge.izpack.core.os.RegistryHandler;
 import com.izforge.izpack.event.RegistryInstallerListener;
@@ -79,7 +79,7 @@ import com.izforge.izpack.util.os.ShellLink;
  */
 @RunWith(PicoRunner.class)
 @RunOn(Platform.Name.WINDOWS)
-@Container(TestInstallationContainer.class)
+@Container(TestGUIInstallationContainer.class)
 public class WindowsInstallationTest extends AbstractDestroyerTest
 {
 

--- a/izpack-uninstaller/src/main/java/com/izforge/izpack/uninstaller/console/ConsoleUninstallerContainer.java
+++ b/izpack-uninstaller/src/main/java/com/izforge/izpack/uninstaller/console/ConsoleUninstallerContainer.java
@@ -21,13 +21,13 @@
 
 package com.izforge.izpack.uninstaller.console;
 
-import org.picocontainer.MutablePicoContainer;
-import org.picocontainer.PicoException;
-
+import com.izforge.izpack.api.data.ConsolePrefs;
 import com.izforge.izpack.api.exception.ContainerException;
 import com.izforge.izpack.core.handler.ConsolePrompt;
 import com.izforge.izpack.uninstaller.container.UninstallerContainer;
 import com.izforge.izpack.util.Console;
+import org.picocontainer.MutablePicoContainer;
+import org.picocontainer.PicoException;
 
 
 /**
@@ -58,6 +58,11 @@ public class ConsoleUninstallerContainer extends UninstallerContainer
     protected void fillContainer(MutablePicoContainer container)
     {
         super.fillContainer(container);
+
+        ConsolePrefs consolePrefs = new ConsolePrefs();
+        consolePrefs.enableConsoleReader = false;
+        addComponent(ConsolePrefs.class, consolePrefs);
+
         addComponent(Console.class);
         addComponent(ConsolePrompt.class);
         addComponent(ConsoleDestroyerListener.class);


### PR DESCRIPTION
This is an implementation of [IZPACK-1336](https://izpack.atlassian.net/browse/IZPACK-1336):

For several reasons we'd need to configure the console installation mode in advance in the installation description. This should be extensible in future, extend also the API.

For instance, there should be an option to determine whether the JLine  terminal detection should be done. On some exotic terminals this doesn't work, the user should be allowed to force the fallback.

This implementation does also a code cleanup regarding console and automation installation mode, which have been mixed in code too much.