### PR TITLE
IZPACK-1337: Add missing nested tag <string> to "empty" condition in XSD

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -57,6 +57,7 @@
             <xs:element name="arg1" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="arg2" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="operator" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="string" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="file" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="dir" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="java" type="javaType" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
Fix for [IZPACK-1337](https://izpack.atlassian.net/browse/IZPACK-1337):

The definition 
```xml
<condition id="IsEmpty" type="empty">
  <string>${some var}</string>
</condition>
```
is not allowed in the XSD at this time.

Allow this to not fail during compiling in 5.0.7.
Merge this fix also to the web schema definitions.