### PR TITLE
IZPACK-1338: Fix exception handling in installer during refreshing dynamic variables

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -166,7 +166,7 @@
         <xs:attribute type="xs:string" name="zipfile" use="optional"/>
         <xs:attribute type="xs:string" name="jarfile" use="optional"/>
         <xs:attribute type="xs:string" name="entry" use="optional"/>
-        <xs:attribute type="xs:boolean" name="ignorefailure" use="optional" default="false"/>
+        <xs:attribute type="xs:boolean" name="ignorefailure" use="optional" default="true"/>
         <!-- Windows registry -->
         <xs:attribute type="xs:string" name="regkey" use="optional"/>
         <xs:attribute type="xs:string" name="regroot" use="optional"/>

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DynamicVariableImpl.java
@@ -150,7 +150,7 @@ public class DynamicVariableImpl implements DynamicVariable
         }
         catch (Exception e)
         {
-            if (!ignorefailure)
+            if (!isIgnoreFailure())
             {
                 throw e;
             }


### PR DESCRIPTION
This fixes issue [ZPACK-1338](https://izpack.atlassian.net/browse/IZPACK-1338):

The following stacktrace should be avoided.

_ignorefailure_ should be _true_ by default for dynamic variables refresh.
Instead, I saw the following stacktrace (with `-DSTACKTRACE=true`):
```
Exception in thread "AWT-EventQueue-0" com.izforge.izpack.api.exception.IzPackException: Failed to refresh dynamic variable (db.file)
        at com.izforge.izpack.core.data.DefaultVariables.refresh(DefaultVariables.java:353)
        at com.izforge.izpack.installer.panel.AbstractPanelView.isValid(AbstractPanelView.java:247)
        at com.izforge.izpack.installer.panel.AbstractPanelView.isValid(AbstractPanelView.java:232)
        at com.izforge.izpack.installer.gui.IzPanelView.isValid(IzPanelView.java:61)
        at com.izforge.izpack.installer.panel.AbstractPanels.executeValidationActions(AbstractPanels.java:598)
        at com.izforge.izpack.installer.panel.AbstractPanels.isValid(AbstractPanels.java:177)
        at com.izforge.izpack.installer.panel.AbstractPanels.next(AbstractPanels.java:249)
        at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:345)
        at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:328)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.navigate(DefaultNavigator.java:563)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.access$100(DefaultNavigator.java:526)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler$1$1.run(DefaultNavigator.java:546)
        at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)                                                                                              
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)                                                                   
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)                                                                      
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)                                                                   
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)                                                                               
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)                                                                                
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)                                                                                       
Caused by: java.io.FileNotFoundException: /home/rkrell/myapp/config/resources.properties (No such file or directory)    
        at java.io.FileInputStream.open0(Native Method)                                                                                                        
        at java.io.FileInputStream.open(FileInputStream.java:195)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at java.io.FileInputStream.<init>(FileInputStream.java:93)
        at com.izforge.izpack.core.variable.PlainConfigFileValue.resolve(PlainConfigFileValue.java:79)
        at com.izforge.izpack.core.data.DynamicVariableImpl.evaluate(DynamicVariableImpl.java:142)
        at com.izforge.izpack.core.data.DefaultVariables.refresh(DefaultVariables.java:345)
        ... 25 more
```

Next one:
An unexpected exception (bug) during condition evaluation should not crash the installer.
Example (this one is already fixed):
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
    at com.izforge.izpack.core.rules.process.ContainsCondition.matchesString(ContainsCondition.java:174)
    at com.izforge.izpack.core.rules.process.ContainsCondition.matchesByLine(ContainsCondition.java:147)
    at com.izforge.izpack.core.rules.process.ContainsCondition.isTrue(ContainsCondition.java:131)
    at com.izforge.izpack.core.rules.logic.NotCondition.isTrue(NotCondition.java:92)
    at com.izforge.izpack.core.rules.process.RefCondition.isTrue(RefCondition.java:84)
    at com.izforge.izpack.core.rules.logic.AndCondition.isTrue(AndCondition.java:73)
    at com.izforge.izpack.core.rules.process.RefCondition.isTrue(RefCondition.java:84)
    at com.izforge.izpack.core.rules.logic.OrCondition.isTrue(OrCondition.java:71)
    at com.izforge.izpack.core.rules.logic.AndCondition.isTrue(AndCondition.java:73)
    at com.izforge.izpack.core.rules.RulesEngineImpl.isConditionTrue(RulesEngineImpl.java:344)
    at com.izforge.izpack.core.rules.RulesEngineImpl.isConditionTrue(RulesEngineImpl.java:331)
    at com.izforge.izpack.core.data.DefaultVariables.refresh(DefaultVariables.java:338)
    at com.izforge.izpack.installer.panel.AbstractPanels.switchPanel(AbstractPanels.java:551)
    at com.izforge.izpack.installer.panel.AbstractPanels.next(AbstractPanels.java:254)
    at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:345)
    at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:328)
    at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.navigate(DefaultNavigator.java:563)
    at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.access$100(DefaultNavigator.java:526)
    at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler$1$1.run(DefaultNavigator.java:546)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:312)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:733)
    at java.awt.EventQueue.access$200(EventQueue.java:103)
    at java.awt.EventQueue$3.run(EventQueue.java:694)
    at java.awt.EventQueue$3.run(EventQueue.java:692)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:76)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:703)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:242)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:161)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:150)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:146)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:138)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:91)
```
The `<variable ignorefailure="..."/>` attribute in `<dynamicvariables>` got a wrong default value "false" from the XSD when compiling, which is a regression in 5.0.7-SNAPSHOT. THe XSD had this bug already a longer time but before 5.0.7 this had no implication on serializing during compiling. Fix also the XSD (izpack-types.xsd).

So, this fixes a regression in 5.0.7 with the wrong `ignorefailure` attribute default and a long-standing wrong exception handling if `ignorefailure="false"`, which crashed the installer if a failure occured during refreshing.