### PR TITLE
Revert "IZPACK-1330: Fix for test errors under windows with JDK8"

### DIFF
--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/target/TargetPanelHelperTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/target/TargetPanelHelperTest.java
@@ -155,7 +155,7 @@ public class TargetPanelHelperTest
     @Test
     public void testIsIncompatibleInstallation() throws IOException
     {
-        File dir = FileUtils.createTempDir("junit");
+        File dir = File.createTempFile("junit", "");
         FileUtils.delete(dir);
 
         // verify that the method returns false for non-existent directory

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/FileUtils.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/FileUtils.java
@@ -122,17 +122,6 @@ public class FileUtils
             return File.createTempFile(prefix, suffix);
         }
     }
-    
-    /**
-     * Method to create a directory in the temp directory.
-     * @param directory the directory name
-     * @return the temporary directory
-     */
-    public static File createTempDir(String directory) {
-        File dir = new File(new File(System.getProperty("java.io.tmpdir")), directory);
-    	dir.mkdir();
-        return dir;
-    }
 
     /**
      * Method to retrieve The FileUtils, which is shared by all users of this


### PR DESCRIPTION
Reverts izpack/izpack#430

Reason:
- Lets 'mvn deploy' fail on Linux:
  `java.lang.AssertionError
        at com.izforge.izpack.panels.target.TargetPanelHelperTest.testIsIncompatibleInstallation(TargetPanelHelperTest.java:162)`
- The new method FileUtils.createTempDir(String directory) isn't used by anone else, just by this test.

I believe this should be solved in a different way, like in https://github.com/oblac/jodd/issues/34.
Just make sure the default directory is an absolute path by using `File.getCanonicalPath()`.
