### PR TITLE
IZPACK-1339: Variables not resolved in static text fields and field labels of UserInputConsolePanel

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanel.java
@@ -328,7 +328,6 @@ public class UserInputPanel extends IzPanel
                 view.setDisplayed(false);
             }
 
-            updated |= view.translateStaticText();
             updated |= view.updateView();
         }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -558,7 +558,12 @@ public abstract class Field
      */
     public String getLabel()
     {
-        return label;
+        String result = null;
+        if (label != null)
+        {
+            result = replaceVariables(label);
+        }
+        return result;
     }
 
     /**
@@ -568,7 +573,12 @@ public abstract class Field
      */
     public String getDescription()
     {
-        return description;
+        String result = null;
+        if (description != null)
+        {
+            result = replaceVariables(description);
+        }
+        return result;
     }
 
     /**
@@ -576,7 +586,14 @@ public abstract class Field
      *
      * @return the field tooltip. May be {@code null}
      */
-    public String getTooltip() { return tooltip; }
+    public String getTooltip() {
+        String result = null;
+        if (tooltip != null)
+        {
+            result = replaceVariables(tooltip);
+        }
+        return result;
+    }
 
     /**
      * Determines if the condition associated with the field is true.

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
@@ -100,7 +100,7 @@ public abstract class GUIField extends AbstractFieldView
      */
     public boolean updateView()
     {
-        return false;
+        return translateStaticText();
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/combo/GUIComboField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/combo/GUIComboField.java
@@ -99,7 +99,7 @@ public class GUIComboField extends GUIField
     {
         refreshChoices();
 
-        boolean result = false;
+        boolean result = super.updateView();
         ComboField field = (ComboField)getField();
         String value = field.getInitialValue();
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/AbstractGUIFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/AbstractGUIFileField.java
@@ -94,7 +94,7 @@ public abstract class AbstractGUIFileField extends GUIField
     @Override
     public boolean updateView()
     {
-        boolean result = false;
+        boolean result = super.updateView();
         // Set default value here for getting current variable values replaced
         Field field = getField();
         String value = field.getInitialValue();

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/GUIMultipleFileField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/GUIMultipleFileField.java
@@ -100,7 +100,7 @@ public class GUIMultipleFileField extends GUIField
     @Override
     public boolean updateView()
     {
-        boolean result = false;
+        boolean result = super.updateView();
         String value = getField().getInitialValue();
 
         if (value != null)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/password/GUIPasswordGroupField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/password/GUIPasswordGroupField.java
@@ -115,7 +115,7 @@ public class GUIPasswordGroupField extends GUIField
     @Override
     public boolean updateView()
     {
-        boolean result = false;
+        boolean result = super.updateView();
         String value = getField().getInitialValue();
 
         if (value != null)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/radio/GUIRadioField.java
@@ -162,7 +162,7 @@ public class GUIRadioField extends GUIField implements ActionListener
     {
         refreshChoices();
 
-        boolean result = false;
+        boolean result = super.updateView();
         RadioField field = getField();
         String value = field.getInitialValue();
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/rule/GUIRuleField.java
@@ -131,7 +131,7 @@ public class GUIRuleField extends GUIField
     @Override
     public boolean updateView()
     {
-        boolean changed = false;
+        boolean changed = super.updateView();
         Field f = getField();
         String value = f.getInitialValue();
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/text/GUITextField.java
@@ -108,7 +108,7 @@ public class GUITextField extends GUIField implements FocusListener, DocumentLis
     @Override
     public boolean updateView()
     {
-        boolean result = false;
+        boolean result = super.updateView();
         Field f = getField();
         String value = f.getInitialValue();
 


### PR DESCRIPTION
Implementation of a fix for [IZPACK-1339](https://izpack.atlassian.net/browse/IZPACK-1339):

Variable placeholders are not resolved in static text fields and field labels of the UserInputConsolePanel.

Added also replacement of variables in tooltips.