### PR TITLE
IZPACK-1342: Console installer regressions

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/handler/ConsolePrompt.java
@@ -26,8 +26,6 @@ import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.util.Console;
 
-import java.util.Arrays;
-
 /**
  * Console implementation of {@link Prompt}.
  *
@@ -123,18 +121,7 @@ public class ConsolePrompt extends AbstractPrompt
     {
         Option result;
 
-        int length = Math.max((title!=null ? title.length() : 0), message.length());
-        char[] chars = new char[length];
-        Arrays.fill(chars, '*');
-        final String hline = new String(chars);
-
-        console.println(hline);
-        if (title != null)
-        {
-            console.println(title);
-        }
-        console.println(message);
-        console.println(hline);
+        console.printMessageBox(title, message);
         if (options == Options.OK_CANCEL)
         {
             String defaultValue = (defaultOption != null && defaultOption == Option.OK) ? ok : cancel;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
@@ -29,7 +29,6 @@ import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.installer.panel.PanelView;
 import com.izforge.izpack.installer.util.PanelHelper;
 import com.izforge.izpack.util.Console;
-import jline.TerminalFactory;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -162,14 +161,13 @@ public abstract class AbstractConsolePanel implements ConsolePanel
         final String headline = getI18nStringForClass("headline", installData);
         if (headline != null)
         {
-            final int maxlength = TerminalFactory.get().getWidth();
-            final String hline = new String(new char[maxlength]).replace("\0", "\u2500");
             console.println();
-            console.println(hline);
+            console.printFilledLine('\u2500');
             console.println(headline);
-            console.println(hline);
+            console.printFilledLine('\u2500');
             console.println();
         }
+
         return true;
     }
 

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/test/AbstractTestPanelContainer.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/test/AbstractTestPanelContainer.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.util.Locale;
 import java.util.Properties;
 
+import com.izforge.izpack.test.util.TestHousekeeper;
 import org.mockito.Mockito;
 import org.picocontainer.MutablePicoContainer;
 import org.picocontainer.PicoException;
@@ -51,7 +52,6 @@ import com.izforge.izpack.installer.container.provider.RulesProvider;
 import com.izforge.izpack.installer.data.UninstallData;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.installer.unpacker.IUnpacker;
-import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.PlatformModelMatcher;
 import com.izforge.izpack.util.Platforms;
 
@@ -94,7 +94,7 @@ public abstract class AbstractTestPanelContainer extends AbstractContainer
 
         container.addComponent(new DefaultObjectFactory(this));
         addComponent(IUnpacker.class, Mockito.mock(IUnpacker.class));
-        addComponent(Housekeeper.class, Mockito.mock(Housekeeper.class));
+        addComponent(TestHousekeeper.class, Mockito.mock(TestHousekeeper.class));
         addComponent(Platforms.class);
         addComponent(Container.class, this);
         addComponent(PlatformModelMatcher.class);

--- a/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsoleInstaller.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsoleInstaller.java
@@ -61,6 +61,7 @@ public class TestConsoleInstaller extends ConsoleInstaller
      *
      * @return the console
      */
+    @Override
     public TestConsole getConsole()
     {
         return (TestConsole) super.getConsole();


### PR DESCRIPTION
This request contains fixes for [IZPACK-1342](https://izpack.atlassian.net/browse/IZPACK-1342):

There is a few regressions within the latest console mode enhancements:
- In the fallback console installation mode (without JLine initialization using the standard Java Console), text input fields are skipped on first keystroke.
  This way it is not possible to override their values, for instance the path in TargetConsolePanel.
- There are NullPointer exceptions in console fallback mode (if JLine cannot initialize the terminal).
- Panel console tests use Housekeeper instead of TestHousekeeper and let the VM crash during Maven builds with tests.
- Text lines of asterisks in console mode prompts do not adapt to the terminal width and are thus broken into multiple lines if the message is longer than the terminal width.
- The title is not displayed in console prompts. if there is one.