### PR TITLE
IZPACK-1342: Console installer regressions (post-fixes)

### DIFF
--- a/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsoleInstaller.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsoleInstaller.java
@@ -25,7 +25,7 @@ import com.izforge.izpack.installer.data.ConsoleInstallData;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.installer.requirement.RequirementsChecker;
 import com.izforge.izpack.test.util.TestConsole;
-import com.izforge.izpack.util.Housekeeper;
+import com.izforge.izpack.test.util.TestHousekeeper;
 
 /**
  * Test implementation of the {@link ConsoleInstaller}.
@@ -50,7 +50,7 @@ public class TestConsoleInstaller extends ConsoleInstaller
      */
     public TestConsoleInstaller(ConsolePanels panels, ConsoleInstallData installData,
                                 RequirementsChecker requirements, UninstallDataWriter writer,
-                                TestConsole console, Housekeeper housekeeper)
+                                TestConsole console, TestHousekeeper housekeeper)
             throws Exception
     {
         super(panels, installData, requirements, writer, console, housekeeper);

--- a/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
@@ -83,11 +83,6 @@ public class Console
         {
             console = System.console();
         }
-
-        if (console == null)
-        {
-            logger.severe("Could not initialize a fallback console");
-        }
     }
 
     private void initConsoleReader()


### PR DESCRIPTION
- Removed the nasty message "Could not initialize a fallback console" during console installations.
- Added forgotten commit - use TestHousekeeper to not crash tests during the build.