### PR TITLE
IZPACK-1327: Print headline for all built-in console-mode panels (post-fixes)

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractConsolePanel.java
@@ -158,6 +158,12 @@ public abstract class AbstractConsolePanel implements ConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
+        printHeadLine(installData, console);
+        return true;
+    }
+
+    protected void printHeadLine(InstallData installData, Console console)
+    {
         final String headline = getI18nStringForClass("headline", installData);
         if (headline != null)
         {
@@ -167,8 +173,6 @@ public abstract class AbstractConsolePanel implements ConsolePanel
             console.printFilledLine('\u2500');
             console.println();
         }
-
-        return true;
     }
 
     @Override

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
@@ -74,7 +74,7 @@ public abstract class AbstractTextConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         String text = getText();
         text = installData.getVariables().replace(text);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/checkedhello/CheckedHelloConsolePanel.java
@@ -96,7 +96,7 @@ public class CheckedHelloConsolePanel extends HelloConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         boolean result = true;
         if (registered)
@@ -122,6 +122,7 @@ public class CheckedHelloConsolePanel extends HelloConsolePanel
             display(installData, console);
             result = promptEndPanel(installData, console);
         }
+
         return result;
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetConsolePanel.java
@@ -92,7 +92,7 @@ public class DefaultTargetConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         String path = TargetPanelHelper.getPath(installData);
         installData.setInstallPath(path);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishConsolePanel.java
@@ -105,7 +105,7 @@ public class FinishConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         if (doGenerateAutoInstallScript())
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/hello/HelloConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/hello/HelloConsolePanel.java
@@ -65,7 +65,7 @@ public class HelloConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         display(installData, console);
         return promptEndPanel(installData, console);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallConsolePanel.java
@@ -66,7 +66,8 @@ public class InstallConsolePanel extends AbstractConsolePanel implements Progres
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
+
         return run();
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupConsolePanel.java
@@ -69,7 +69,7 @@ public class InstallationGroupConsolePanel extends AbstractConsolePanel implemen
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         // Set/restore availablePacks from allPacks; consider OS constraints
         this.automatedInstallData.setAvailablePacks(new ArrayList<Pack>());

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathConsolePanel.java
@@ -96,7 +96,7 @@ public class JDKPathConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         String detectedJavaVersion = "";
         String defaultValue = JDKPathPanelHelper.getDefaultJavaPath(installData, handler);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksConsolePanel.java
@@ -101,7 +101,7 @@ public class PacksConsolePanel extends AbstractConsolePanel implements ConsolePa
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         out(Type.INFORMATION, installData.getMessages().get("PacksPanel.info"));
         out(Type.INFORMATION, "");

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessConsolePanel.java
@@ -131,7 +131,8 @@ public class ProcessConsolePanel extends AbstractConsolePanel implements Console
 
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
+
         return run(installData);
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConsolePanel.java
@@ -126,7 +126,7 @@ public class ShortcutConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         boolean result = true;
         try

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetConsolePanel.java
@@ -90,7 +90,7 @@ public class TargetConsolePanel extends AbstractConsolePanel implements ConsoleP
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         File pathFile;
         String normalizedPath;

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksConsolePanel.java
@@ -103,7 +103,7 @@ public class TreePacksConsolePanel extends AbstractConsolePanel implements Conso
      */
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         List<Pack> selectedPacks;
         packsModel = new PacksModel(installData);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputConsolePanel.java
@@ -215,7 +215,7 @@ public class UserInputConsolePanel extends AbstractConsolePanel
     @Override
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         boolean result = true;
         if (fields != null && !fields.isEmpty())

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathConsolePanel.java
@@ -101,7 +101,7 @@ public class UserPathConsolePanel extends AbstractConsolePanel
 
     public boolean run(InstallData installData, Console console)
     {
-        super.run(installData, console);
+        printHeadLine(installData, console);
 
         loadLangpack(installData);
 


### PR DESCRIPTION
This request implements post-fixes for IZPACK-1327, initially implemented in #427.

Especially the `CheckedHelloConsolePanel` showed it contents including the prompt two times, which broke the `WindowsConsoleInstallationTest`.