### PR TITLE
IZPACK-1346: Compiled installer contains needless resources - save size by removing them

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -434,7 +434,7 @@ public abstract class PackagerBase implements IPackager
         mergeManager.addResourceToMerge("com/izforge/izpack/installer/");
         mergeManager.addResourceToMerge("org/picocontainer/");
         mergeManager.addResourceToMerge("com/izforge/izpack/img/");
-        mergeManager.addResourceToMerge("com/izforge/izpack/bin/");
+        mergeManager.addResourceToMerge("com/izforge/izpack/bin/icons/");
         mergeManager.addResourceToMerge("com/izforge/izpack/api/");
         mergeManager.addResourceToMerge("com/izforge/izpack/event/");
         mergeManager.addResourceToMerge("com/izforge/izpack/core/");


### PR DESCRIPTION
The compiled installer jar contains all available DLLs, flag icons and translations regardless of the choice in install.xml in a separate resource folder:

```
/com/izforge/izpack/bin/
├── langpacks
│   ├── flags
│   │   ├── bra.gif
│   │   ├── cat.gif
│   │   ├── ces.gif
│   │   ├── dan.gif
│   │   ├── deu.gif
│   │   ├── ell.gif
│   │   ├── eng.gif
│   │   ├── eus.gif
│   │   ├── fa.gif
│   │   ├── fin.gif
│   │   ├── fra.gif
│   │   ├── glg.gif
│   │   ├── hun.gif
│   │   ├── chn.gif
│   │   ├── idn.gif
│   │   ├── ita.gif
│   │   ├── jpn.gif
│   │   ├── kor.gif
│   │   ├── msa.gif
│   │   ├── nld.gif
│   │   ├── nor.gif
│   │   ├── pol.gif
│   │   ├── prt.gif
│   │   ├── ron.gif
│   │   ├── rus.gif
│   │   ├── slk.gif
│   │   ├── spa.gif
│   │   ├── srp.gif
│   │   ├── swe.gif
│   │   ├── tur.gif
│   │   ├── twn.gif
│   │   └── ukr.gif
│   ├── checklangpack
│   └── installer
│       ├── bra.xml                                                                                                                                            
│       ├── cat.xml                                                                                                                                            
│       ├── ces.xml                                                                                                                                            
│       ├── dan.xml                                                                                                                                            
│       ├── deu.xml                                                                                                                                            
│       ├── ell.xml                                                                                                                                            
│       ├── eng.xml                                                                                                                                            
│       ├── eus.xml                                                                                                                                            
│       ├── fa.xml                                                                                                                                             
│       ├── fin.xml
│       ├── fra.xml
│       ├── glg.xml
│       ├── hun.xml
│       ├── chn.xml
│       ├── idn.xml
│       ├── ita.xml
│       ├── jpn.xml
│       ├── kor.xml
│       ├── msa.xml
│       ├── nld.xml
│       ├── nor.xml
│       ├── pol.xml
│       ├── prt.xml
│       ├── ron.xml
│       ├── rus.xml
│       ├── slk.xml
│       ├── spa.xml
│       ├── srp.xml
│       ├── swe.xml
│       ├── testLangpacks.ksh
│       ├── tur.xml
│       ├── twn.xml
│       └── ukr.xml
└── native
    ├── izpack
    │   ├── ShellLink.dll
    │   ├── ShellLink_x64.dll
    │   ├── WinSetupAPI.dll
    │   └── WinSetupAPI_x64.dll
    └── 3rdparty
        ├── COIOSHelper.dll
        └── COIOSHelper_x64.dll
```

The langpacks and flags are already separately compiled to `/resources/` depending on `<locale>`, the above one isn't used at all for localization purposes by the installer.

The native library resource path is correct, but there should be compiled in just those libs which are defined in the `<native>` tag. This is more or less done by the compiler, but in a later compile phase there are merged all native files that are available in the sources regardless of what is needed in the installer.

Removing the redundant files saves up to around 330 KBytes of packed installer size (depending on which native files are needed for several purposes).