### PR TITLE
IZPACK-1349: allow "empty" resource xmls

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-compilation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-compilation-5.0.xsd
@@ -26,7 +26,7 @@
 
     <xs:element name="compilation">
         <xs:complexType>
-            <xs:choice maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element name="global" type="globalType"/>
                 <xs:element name="jobs" type="jobsType"/>
             </xs:choice>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-configurationactions-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-configurationactions-5.0.xsd
@@ -32,7 +32,7 @@
     <xs:element name="configurationactions">
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="pack" type="packType" minOccurs="1" maxOccurs="unbounded"/>
+                <xs:element name="pack" type="packType" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <xs:attribute name="version" type="xs:string" fixed="5.0" use="required"/>
         </xs:complexType>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-langpack-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-langpack-5.0.xsd
@@ -32,7 +32,7 @@
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="str" maxOccurs="unbounded">
+                <xs:element name="str" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>A string definition</xs:documentation>
                     </xs:annotation>


### PR DESCRIPTION
All resource xml's should allow optional "empty" files.
See (https://izpack.atlassian.net/browse/IZPACK-1349) for details