### PR TITLE
IZPACK-1353: Consolidate behavior of TargetPanel in GUI and console installation mode

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputBase.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputBase.java
@@ -1,14 +1,14 @@
 package com.izforge.izpack.panels.path;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.util.IoHelper;
 import com.izforge.izpack.util.Platform;
 import com.izforge.izpack.util.Platforms;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Link common functionality for PathInputPanels here.
@@ -19,7 +19,22 @@ import com.izforge.izpack.util.Platforms;
 public class PathInputBase
 {
     private static InstallData installData;
-    private static final transient Logger logger = Logger.getLogger(PathInputPanel.class.getName());
+    private static final Logger logger = Logger.getLogger(PathInputPanel.class.getName());
+
+    /**
+     * ShowCreateDirectoryMessage configuration option<br>
+     * If 'ShowCreateDirectoryMessage' configuration option set 'false' then don't show
+     * then don't show "directory will be created" dialog
+     */
+    public static final String SHOWCREATEDIRECTORYMESSAGE = "ShowCreateDirectoryMessage";
+
+    /**
+     * ShowExistingDirectoryWarning configuration option<br>
+     * If 'ShowExistingDirectoryWarning' configuration option set 'false' then don't show
+     * "The directory already exists! Are you sure you want to install here and possibly overwrite existing files?"
+     * warning dialog
+     */
+    public static final String SHOWEXISTINGDIRECTORYWARNING = "ShowExistingDirectoryWarning";
 
     public static void setInstallData(InstallData installData)
     {
@@ -97,7 +112,6 @@ public class PathInputBase
             path = home + path.substring(1);
         }
 
-        String normalizedPath = new File(path).getAbsolutePath();
-        return normalizedPath;
+        return new File(path).getAbsolutePath();
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputConsolePanel.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.panels.path;
+
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.handler.Prompt;
+import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.installer.console.AbstractConsolePanel;
+import com.izforge.izpack.installer.console.ConsolePanel;
+import com.izforge.izpack.installer.panel.PanelView;
+import com.izforge.izpack.util.Console;
+
+import java.io.File;
+import java.util.Properties;
+
+import static com.izforge.izpack.api.handler.Prompt.Option.OK;
+import static com.izforge.izpack.api.handler.Prompt.Options.OK_CANCEL;
+import static com.izforge.izpack.api.handler.Prompt.Type.WARNING;
+
+public class PathInputConsolePanel extends AbstractConsolePanel
+{
+    private final Prompt prompt;
+    private InstallData installData;
+    /**
+     * Constructs an {@code PathInputConsolePanel}.
+     *
+     * @param panel the parent panel/view. May be {@code null}
+     * @param installData the install data
+     * @param prompt the console prompt
+     */
+    public PathInputConsolePanel(PanelView<ConsolePanel> panel, InstallData installData, Prompt prompt)
+    {
+        super(panel);
+        this.installData = installData;
+        this.prompt = prompt;
+    }
+
+    @Override
+    public boolean run(InstallData installData, Properties properties)
+    {
+        this.installData = installData;
+        return false;
+    }
+
+    /**
+     * Determines if the specified directory can be created.
+     *
+     * @param dir the directory
+     * @return {@code true} if the directory may be created, otherwise {@code false}
+     */
+    protected boolean checkCreateDirectory(File dir, Console console)
+    {
+        boolean result = true;
+        // if 'ShowCreateDirectoryMessage' configuration option set 'false' then don't show
+        // then don't show "directory will be created" dialog:
+        String show = getPanel().getConfigurationOptionValue(PathInputBase.SHOWCREATEDIRECTORYMESSAGE, installData.getRules());
+        if (show == null || Boolean.getBoolean(show))
+        {
+            Messages messages = installData.getMessages();
+            result = (OK == prompt.confirm(WARNING,
+                    messages.get("installer.Message"),
+                    messages.get("TargetPanel.createdir") + "\n" + dir,
+                    OK_CANCEL, OK));
+        }
+        return result;
+    }
+
+    /**
+     * Determines if an existing directory can be written to.
+     *
+     * @param dir the directory
+     * @return {@code true} if the directory can be written to, otherwise {@code false}
+     */
+    protected boolean checkOverwrite(File dir, Console console)
+    {
+        boolean result = true;
+        // if 'ShowExistingDirectoryWarning' configuration option set 'false' then don't show
+        // "The directory already exists! Are you sure you want to install here and possibly overwrite existing files?"
+        // warning dialog:
+        String show = getPanel().getConfigurationOptionValue(PathInputBase.SHOWEXISTINGDIRECTORYWARNING, installData.getRules());
+        if ((show == null || Boolean.getBoolean(show)) && dir.isDirectory() && dir.list().length > 0)
+        {
+            Messages messages = installData.getMessages();
+            result = askUser(messages.get("installer.warning"), messages.get("TargetPanel.warn"), Prompt.Option.NO);
+        }
+        return result;
+    }
+
+    /**
+     * Helper method to read the input of user
+     * Method returns true if user types "y", "yes" or <Enter>·
+     *
+     * @return boolean  - true if condition above satisfied. Otherwise false
+     */
+    private boolean askUser(String title, String message, Prompt.Option defaultOption)
+    {
+        return Prompt.Option.YES == prompt.confirm(Prompt.Type.QUESTION, title, message, Prompt.Options.YES_NO, defaultOption);
+    }
+}

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputPanel.java
@@ -21,12 +21,6 @@
 
 package com.izforge.izpack.panels.path;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.File;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.handler.AbstractUIHandler;
@@ -36,6 +30,12 @@ import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
 import com.izforge.izpack.installer.gui.IzPanel;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Base class for panels which asks for paths to directories.
@@ -47,21 +47,6 @@ public class PathInputPanel extends IzPanel implements ActionListener
     private static final long serialVersionUID = 3257566217698292531L;
 
     private static final transient Logger logger = Logger.getLogger(PathInputPanel.class.getName());
-
-    /**
-     * ShowCreateDirectoryMessage configuration option<br>
-     * If 'ShowCreateDirectoryMessage' configuration option set 'false' then don't show
-     * then don't show "directory will be created" dialog
-     */
-    private static final String SHOWCREATEDIRECTORYMESSAGE = "ShowCreateDirectoryMessage";
-
-    /**
-     * ShowExistingDirectoryWarning configuration option<br>
-     * If 'ShowExistingDirectoryWarning' configuration option set 'false' then don't show
-     * "The directory already exists! Are you sure you want to install here and possibly overwrite existing files?"
-     * warning dialog
-     */
-    private static final String SHOWEXISTINGDIRECTORYWARNING = "ShowExistingDirectoryWarning";
 
     /**
      * Flag whether the choosen path must exist or not
@@ -76,11 +61,11 @@ public class PathInputPanel extends IzPanel implements ActionListener
     /**
      * The path selection sub panel
      */
-    protected PathSelectionPanel pathSelectionPanel;
+    protected final PathSelectionPanel pathSelectionPanel;
 
-    protected String emptyTargetMsg;
+    protected final String emptyTargetMsg;
 
-    protected String warnMsg;
+    protected final String warnMsg;
 
     /**
      * Constructs a <tt>PathInputPanel</tt>.
@@ -133,8 +118,7 @@ public class PathInputPanel extends IzPanel implements ActionListener
     public String getPath()
     {
         String chosenPath = pathSelectionPanel.getPath();
-        String normalizedPath = PathInputBase.normalizePath(chosenPath);
-        return normalizedPath;
+        return PathInputBase.normalizePath(chosenPath);
     }
 
     /**
@@ -360,7 +344,7 @@ public class PathInputPanel extends IzPanel implements ActionListener
         boolean result = true;
         // if 'ShowCreateDirectoryMessage' configuration option set 'false' then don't show
         // then don't show "directory will be created" dialog:
-        String show = getMetadata().getConfigurationOptionValue(SHOWCREATEDIRECTORYMESSAGE, installData.getRules());
+        String show = getMetadata().getConfigurationOptionValue(PathInputBase.SHOWCREATEDIRECTORYMESSAGE, installData.getRules());
         if (show == null || Boolean.getBoolean(show))
         {
             result = emitNotificationFeedback(getI18nStringForClass("createdir", "TargetPanel") + "\n" + dir);
@@ -380,8 +364,8 @@ public class PathInputPanel extends IzPanel implements ActionListener
         // if 'ShowExistingDirectoryWarning' configuration option set 'false' then don't show
         // "The directory already exists! Are you sure you want to install here and possibly overwrite existing files?"
         // warning dialog:
-        String show = getMetadata().getConfigurationOptionValue(SHOWEXISTINGDIRECTORYWARNING, installData.getRules());
-        if (show == null || Boolean.getBoolean(show))
+        String show = getMetadata().getConfigurationOptionValue(PathInputBase.SHOWEXISTINGDIRECTORYWARNING, installData.getRules());
+        if ((show == null || Boolean.getBoolean(show))  && dir.isDirectory() && dir.list().length > 0)
         {
             result = askWarningQuestion(getString("installer.warning"), warnMsg,
                     AbstractUIHandler.CHOICES_YES_NO, AbstractUIHandler.ANSWER_YES) == AbstractUIHandler.ANSWER_YES;

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/test/TestConsolePanelContainer.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/test/TestConsolePanelContainer.java
@@ -22,13 +22,12 @@ package com.izforge.izpack.panels.test;
 
 import com.izforge.izpack.api.data.ConsolePrefs;
 import com.izforge.izpack.api.exception.ContainerException;
-import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.core.handler.ConsolePrompt;
+import com.izforge.izpack.installer.container.provider.MessagesProvider;
 import com.izforge.izpack.installer.data.ConsoleInstallData;
 import com.izforge.izpack.test.provider.ConsoleInstallDataMockProvider;
 import com.izforge.izpack.test.util.TestConsole;
-import org.mockito.Mockito;
 import org.picocontainer.MutablePicoContainer;
 import org.picocontainer.PicoException;
 import org.picocontainer.injectors.ProviderAdapter;
@@ -57,11 +56,11 @@ public class TestConsolePanelContainer extends AbstractTestPanelContainer
     protected void fillContainer(MutablePicoContainer container)
     {
         super.fillContainer(container);
+        container.addAdapter(new ProviderAdapter(new MessagesProvider()));
         container.addAdapter(new ProviderAdapter(new ConsoleInstallDataMockProvider()));
         ConsoleInstallData installData = container.getComponent(ConsoleInstallData.class);
         addComponent(ConsolePrefs.class, installData.consolePrefs);
         addComponent(TestConsole.class);
-        addComponent(Messages.class, Mockito.mock(Messages.class));
         addComponent(ConsolePrompt.class);
 
         getComponent(RulesEngine.class); // force creation of the rules

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/console/ConsoleInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/console/ConsoleInstallationTest.java
@@ -86,7 +86,7 @@ public class ConsoleInstallationTest extends AbstractConsoleInstallationTest
         console.addScript("HelloPanel", "1");
         console.addScript("InfoPanel", "1");
         console.addScript("LicensePanel", "\n", "1");
-        console.addScript("TargetPanel", "\n", "1");
+        console.addScript("TargetPanel", "\n", "O", "1");
 
         checkInstall(installer, getInstallData(), false);
     }
@@ -104,7 +104,7 @@ public class ConsoleInstallationTest extends AbstractConsoleInstallationTest
         console.addScript("HelloPanel", "1");
         console.addScript("InfoPanel", "1");
         console.addScript("LicensePanel", "\n", "1");
-        console.addScript("TargetPanel", "\n", "1");
+        console.addScript("TargetPanel", "\n", "O", "1");
 
         checkInstall(installer, getInstallData());
     }

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/console/PacksConsoleInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/console/PacksConsoleInstallationTest.java
@@ -21,13 +21,6 @@
 
 package com.izforge.izpack.integration.console;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.compiler.container.TestConsoleInstallationContainer;
@@ -37,6 +30,12 @@ import com.izforge.izpack.test.Container;
 import com.izforge.izpack.test.InstallFile;
 import com.izforge.izpack.test.junit.PicoRunner;
 import com.izforge.izpack.test.util.TestConsole;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -80,7 +79,7 @@ public class PacksConsoleInstallationTest extends AbstractConsoleInstallationTes
     {
         TestConsole console = installer.getConsole();
         console.addScript("HelloPanel", "1");
-        console.addScript("TargetPanel", "\n", "1");
+        console.addScript("TargetPanel", "\n", "O", "1");
         console.addScript("PacksPanel",installData.getMessages().get("ConsolePrompt.no") , installData.getMessages().get("ConsolePrompt.no"), "1");
         console.addScript("UserInputPanel", "\n", "1");
 
@@ -98,7 +97,7 @@ public class PacksConsoleInstallationTest extends AbstractConsoleInstallationTes
     {
         TestConsole console = installer.getConsole();
         console.addScript("HelloPanel", "1");
-        console.addScript("TargetPanel", "\n", "1");
+        console.addScript("TargetPanel", "\n", "O", "1");
         console.addScript("PacksPanel", installData.getMessages().get("ConsolePrompt.yes"), "\n", "1");
         console.addScript("UserInputPanel", "1");
         console.addScript("UserInputPanel", "xyz", "\n", "1");

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsConsoleInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsConsoleInstallationTest.java
@@ -319,7 +319,7 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
         TestConsole console = installer.getConsole();
         console.addScript("CheckedHelloPanel", "1");
         console.addScript("InfoPanel", "1");
-        console.addScript("TargetPanel", "\n", "1");
+        console.addScript("TargetPanel", "\n", "O", "1");
 
         //run installer and check that default uninstaller doesn't exist
         InstallData installData = getInstallData();
@@ -354,7 +354,7 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
 
         TestConsole console = installer.getConsole();
         console.addScript("CheckedHelloPanel", "1");
-        console.addScript("TargetPanel", "\n", "1");
+        console.addScript("TargetPanel", "\n", "O", "1");
         console.addScript("PacksPanel", "1");
         console.addScript("ShortcutPanel", "N");
         


### PR DESCRIPTION
Implementation for [IZPACK-1353](https://izpack.atlassian.net/browse/IZPACK-1353):

In TargetPanel and PathInputPanel there is a functional difference between the GUI and the console installation mode:

The configuration parameters _ShowCreateDirectoryMessage_ and _ShowExistingDirectoryWarning_ according to the [documentation](https://izpack.atlassian.net/wiki/x/eoAH) are ignored.