### PR TITLE
Requirements check changes across installer modes

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerConsole.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerConsole.java
@@ -26,18 +26,27 @@ import com.izforge.izpack.installer.console.ConsoleInstaller;
 import com.izforge.izpack.installer.container.impl.ConsoleInstallerContainer;
 import com.izforge.izpack.installer.container.impl.InstallerContainer;
 import com.izforge.izpack.installer.language.LanguageConsoleDialog;
+import com.izforge.izpack.installer.requirement.RequirementsChecker;
+import java.util.logging.Logger;
 
 /**
  * Console installer bootstrap
  */
 public class InstallerConsole
 {
+  private static final Logger logger = Logger.getLogger(InstallerConsole.class.getName());
+  
   public static void run(final int type, final int consoleAction, final String path, final String langCode, final String mediaPath, final String[] args)
   {
     final InstallerContainer applicationComponent = new ConsoleInstallerContainer();
     final Container installerContainer = applicationComponent.getComponent(Container.class);
     try
     {
+      if (!installerContainer.getComponent(RequirementsChecker.class).check())
+      {
+        logger.info("Not all installer requirements are fulfilled.");
+        System.exit(-1);
+      }
       if (mediaPath != null)
       {
         InstallData installData = applicationComponent.getComponent(InstallData.class);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
@@ -29,6 +29,8 @@ import com.izforge.izpack.installer.container.impl.InstallerContainer;
 import com.izforge.izpack.installer.gui.InstallerController;
 import com.izforge.izpack.installer.gui.SplashScreen;
 import com.izforge.izpack.installer.language.LanguageDialog;
+import com.izforge.izpack.installer.requirement.RequirementsChecker;
+import java.util.logging.Logger;
 
 import javax.swing.*;
 
@@ -37,7 +39,8 @@ import javax.swing.*;
  */
 public class InstallerGui
 {
-
+    private static final Logger logger = Logger.getLogger(InstallerGui.class.getName());
+    
     public static void run(final String langCode, final String mediaPath) throws Exception
     {
         final InstallerContainer applicationComponent = new GUIInstallerContainer();
@@ -49,6 +52,11 @@ public class InstallerGui
             {
                 try
                 {
+                    if (!installerContainer.getComponent(RequirementsChecker.class).check())
+                    {
+                        logger.info("Not all installer requirements are fulfilled.");
+                        System.exit(-1);
+                    }
                     final SplashScreen splashScreen = installerContainer.getComponent(SplashScreen.class);
                     splashScreen.displaySplashScreen();
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/language/LanguageConsoleDialog.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/language/LanguageConsoleDialog.java
@@ -21,7 +21,6 @@ package com.izforge.izpack.installer.language;
 import com.izforge.izpack.api.resource.Locales;
 import com.izforge.izpack.installer.container.provider.AbstractInstallDataProvider;
 import com.izforge.izpack.installer.data.ConsoleInstallData;
-import com.izforge.izpack.installer.requirement.RequirementsChecker;
 import com.izforge.izpack.util.Console;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -34,16 +33,14 @@ public class LanguageConsoleDialog {
   private final ConsoleInstallData installData;
   private final Console console;
   private final Locales locales;
-  private final RequirementsChecker requirements;
   private Map<String, String> displayNames = new LinkedHashMap<String, String>();
   private static final Logger logger = Logger.getLogger(LanguageConsoleDialog.class.getName());
   
-  public LanguageConsoleDialog(Locales locales, ConsoleInstallData installData, Console console, RequirementsChecker requirements)
+  public LanguageConsoleDialog(Locales locales, ConsoleInstallData installData, Console console)
   {
     this.installData = installData;
     this.console = console;
     this.locales = locales;
-    this.requirements = requirements;
   }
   
   /**
@@ -72,11 +69,6 @@ public class LanguageConsoleDialog {
         int numberOfUniqueLanguage = console.prompt(installData.getMessages().get("ConsoleInstaller.inputSelection"), 0, displayNames.keySet().size() - 1, 0, 0);
         String[] keys = displayNames.keySet().toArray(new String[0]);
         propagateLocale(keys[numberOfUniqueLanguage]);
-    }
-    if (!requirements.check())
-    {
-      logger.info("Not all installer requirements are fulfilled.");
-      System.exit(-1);
     }
   }
   

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/language/LanguageDialog.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/language/LanguageDialog.java
@@ -25,7 +25,6 @@ import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.gui.IconsDatabase;
 import com.izforge.izpack.installer.container.provider.AbstractInstallDataProvider;
 import com.izforge.izpack.installer.data.GUIInstallData;
-import com.izforge.izpack.installer.requirement.RequirementsChecker;
 
 import javax.swing.*;
 import java.awt.*;
@@ -69,11 +68,6 @@ public class LanguageDialog extends JDialog
     private final Locales locales;
 
     /**
-     * Installation requirements checker.
-     */
-    private final RequirementsChecker requirements;
-
-    /**
      * Maps ISO3 codes to the corresponding language display values.
      */
     private Map<String, String> displayNames = new HashMap<String, String>();
@@ -96,10 +90,8 @@ public class LanguageDialog extends JDialog
      * @param resources    the resources
      * @param locales      the locales
      * @param installData  the installation data
-     * @param requirements the installation requirements
      */
-    public LanguageDialog(Resources resources, Locales locales, GUIInstallData installData, IconsDatabase icons,
-                          RequirementsChecker requirements)
+    public LanguageDialog(Resources resources, Locales locales, GUIInstallData installData, IconsDatabase icons)
     {
         super();
         ImageIcon imageIcon = icons.get("JFrameIcon");
@@ -107,7 +99,6 @@ public class LanguageDialog extends JDialog
         this.resources = resources;
         this.locales = locales;
         this.installData = installData;
-        this.requirements = requirements;
         this.setName(GuiId.DIALOG_PICKER.id);
         initialise();
     }
@@ -132,13 +123,6 @@ public class LanguageDialog extends JDialog
         default:
             super.getOwner().setVisible(false);
             setVisible(true);
-        }
-
-        // check installer conditions
-        if (!requirements.check())
-        {
-            logger.info("Not all installer requirements are fulfilled.");
-            System.exit(-1);
         }
     }
 

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/language/LanguageDialogTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/language/LanguageDialogTest.java
@@ -32,14 +32,12 @@ import org.hamcrest.core.Is;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
 import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.resource.Locales;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.container.TestLanguageContainer;
 import com.izforge.izpack.installer.data.GUIInstallData;
-import com.izforge.izpack.installer.requirement.RequirementsChecker;
 import com.izforge.izpack.test.Container;
 import com.izforge.izpack.test.junit.PicoRunner;
 
@@ -176,7 +174,7 @@ public class LanguageDialogTest
     private LanguageDialog createDialog(String langDisplayType)
     {
         installData.guiPrefs.modifier.put("langDisplayType", langDisplayType);
-        return new LanguageDialog(resources, locales, installData, icons, Mockito.mock(RequirementsChecker.class));
+        return new LanguageDialog(resources, locales, installData, icons);
     }
 
 }

--- a/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsoleInstaller.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/installer/console/TestConsoleInstaller.java
@@ -23,7 +23,6 @@ package com.izforge.izpack.installer.console;
 
 import com.izforge.izpack.installer.data.ConsoleInstallData;
 import com.izforge.izpack.installer.data.UninstallDataWriter;
-import com.izforge.izpack.installer.requirement.RequirementsChecker;
 import com.izforge.izpack.test.util.TestConsole;
 import com.izforge.izpack.test.util.TestHousekeeper;
 
@@ -42,18 +41,16 @@ public class TestConsoleInstaller extends ConsoleInstaller
      *
      * @param panels       the panels
      * @param installData  the installation date
-     * @param requirements the installation requirements
      * @param writer       the uninstallation data writer
      * @param console      the console
      * @param housekeeper  the house-keeper
      * @throws Exception for any error
      */
-    public TestConsoleInstaller(ConsolePanels panels, ConsoleInstallData installData,
-                                RequirementsChecker requirements, UninstallDataWriter writer,
+    public TestConsoleInstaller(ConsolePanels panels, ConsoleInstallData installData, UninstallDataWriter writer,
                                 TestConsole console, TestHousekeeper housekeeper)
             throws Exception
     {
-        super(panels, installData, requirements, writer, console, housekeeper);
+        super(panels, installData, writer, console, housekeeper);
     }
 
     /**


### PR DESCRIPTION
I'm not sure about the log message "Not all installer requirements are fulfilled." though because this is displayed even when user decides not run another instance of izpack when one is already running. Maybe this can be finetuned even more.