### PR TITLE
IZPACK-1354: Do installer requirement checks after the language dialog has been confirmed

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerConsole.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerConsole.java
@@ -27,6 +27,8 @@ import com.izforge.izpack.installer.container.impl.ConsoleInstallerContainer;
 import com.izforge.izpack.installer.container.impl.InstallerContainer;
 import com.izforge.izpack.installer.language.LanguageConsoleDialog;
 import com.izforge.izpack.installer.requirement.RequirementsChecker;
+import com.izforge.izpack.util.Housekeeper;
+
 import java.util.logging.Logger;
 
 /**
@@ -42,11 +44,6 @@ public class InstallerConsole
     final Container installerContainer = applicationComponent.getComponent(Container.class);
     try
     {
-      if (!installerContainer.getComponent(RequirementsChecker.class).check())
-      {
-        logger.info("Not all installer requirements are fulfilled.");
-        System.exit(-1);
-      }
       if (mediaPath != null)
       {
         InstallData installData = applicationComponent.getComponent(InstallData.class);
@@ -60,6 +57,11 @@ public class InstallerConsole
       else
       {
         installerContainer.getComponent(LanguageConsoleDialog.class).propagateLocale(langCode);
+      }
+      if (!installerContainer.getComponent(RequirementsChecker.class).check())
+      {
+        logger.info("Not all installer requirements are fulfilled.");
+        installerContainer.getComponent(Housekeeper.class).shutDown(-1);
       }
       consoleInstaller.run(consoleAction, path, args);
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
@@ -30,6 +30,8 @@ import com.izforge.izpack.installer.gui.InstallerController;
 import com.izforge.izpack.installer.gui.SplashScreen;
 import com.izforge.izpack.installer.language.LanguageDialog;
 import com.izforge.izpack.installer.requirement.RequirementsChecker;
+import com.izforge.izpack.util.Housekeeper;
+
 import java.util.logging.Logger;
 
 import javax.swing.*;
@@ -52,11 +54,6 @@ public class InstallerGui
             {
                 try
                 {
-                    if (!installerContainer.getComponent(RequirementsChecker.class).check())
-                    {
-                        logger.info("Not all installer requirements are fulfilled.");
-                        System.exit(-1);
-                    }
                     final SplashScreen splashScreen = installerContainer.getComponent(SplashScreen.class);
                     splashScreen.displaySplashScreen();
 
@@ -75,6 +72,11 @@ public class InstallerGui
                     else
                     {
                       installerContainer.getComponent(LanguageDialog.class).propagateLocale(langCode);
+                    }
+                    if (!installerContainer.getComponent(RequirementsChecker.class).check())
+                    {
+                        logger.info("Not all installer requirements are fulfilled.");
+                        installerContainer.getComponent(Housekeeper.class).shutDown(-1);
                     }
                     controller.buildInstallation().launchInstallation();
                 }


### PR DESCRIPTION
This issue improves the implementation of [IZPACK-1354](https://izpack.atlassian.net/browse/IZPACK-1354):

There is a number of installer requirement checks done before the first panel appears.
One of them is the lock check, whether the current installer is already running at the current host in another instance. 
Some more are user-defined, see https://izpack.atlassian.net/wiki/x/HYAH.
There's also a check whether the chosen language pack exists.

At the moment, these checks are executed in the language dialog for GUI and console mode installations. In case of using the `-language` command line option, this dialog is skipped and the according checks are not executed at all.  This option has been fixed recently to match the documentation.

Move the requirement checks off the language dialog and execute them still +after+ the language has been chosen.