### PR TITLE
IZPACK-1103: fix "Resource leak: 'jis' is not closed at this location"

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/helper/CompilerHelper.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/helper/CompilerHelper.java
@@ -68,54 +68,6 @@ public class CompilerHelper
     }
 
     /**
-     * Returns the qualified class name for the given class. This method expects as the url param a
-     * jar file which contains the given class. It scans the zip entries of the jar file.
-     *
-     * @param url       url of the jar file which contains the class
-     * @param className short name of the class for which the full name should be resolved
-     * @return full qualified class name
-     * @throws IOException if the jar cannot be read
-     */
-    public String getFullClassName(URL url, String className) throws IOException
-    {
-        JarInputStream jis = new JarInputStream(url.openStream());
-        ZipEntry zentry;
-        while ((zentry = jis.getNextEntry()) != null)
-        {
-            String name = zentry.getName();
-            int lastPos = name.lastIndexOf(".class");
-            if (lastPos < 0)
-            {
-                continue; // No class file.
-            }
-            name = name.replace('/', '.');
-            int pos = -1;
-            int nonCasePos = -1;
-            if (className != null)
-            {
-                pos = name.indexOf(className);
-                nonCasePos = name.toLowerCase().indexOf(className.toLowerCase());
-            }
-            if (pos != -1 && name.length() == pos + className.length() + 6) // "Main" class found
-            {
-                jis.close();
-                return (name.substring(0, lastPos));
-            }
-
-            if (nonCasePos != -1 && name.length() == nonCasePos + className.length() + 6)
-            // "Main" class with different case found
-            {
-                jis.close();
-                throw new IllegalArgumentException(
-                        "Fatal error! The declared panel name in the xml file (" + className
-                                + ") differs in case to the founded class file (" + name + ").");
-            }
-        }
-        jis.close();
-        return (null);
-    }
-
-    /**
      * Returns a list which contains the pathes of all files which are included in the given url.
      * This method expects as the url param a jar.
      *

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/helper/CompilerHelper.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/helper/CompilerHelper.java
@@ -105,6 +105,7 @@ public class CompilerHelper
             if (nonCasePos != -1 && name.length() == nonCasePos + className.length() + 6)
             // "Main" class with different case found
             {
+                jis.close();
                 throw new IllegalArgumentException(
                         "Fatal error! The declared panel name in the xml file (" + className
                                 + ") differs in case to the founded class file (" + name + ").");


### PR DESCRIPTION
minor correction, may be delayed after 5.0.7