### PR TITLE
IZPACK-1360: getter needs no parameter

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/data/PackInfo.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/data/PackInfo.java
@@ -129,7 +129,13 @@ public class PackInfo implements Serializable
         pack.setOsConstraints(osConstraints);
     }
 
-    public List<OsModel> getOsConstraints(List osConstraints)
+    @Deprecated
+    public List<OsModel> getOsConstraints(List<OsModel> osConstraints)
+    {
+        return pack.getOsConstraints();
+    }
+    
+    public List<OsModel> getOsConstraints()
     {
         return pack.getOsConstraints();
     }


### PR DESCRIPTION
see https://izpack.atlassian.net/browse/IZPACK-1360:
-  created new getter without parameter
-  marked getter with parameter as deprecated