### PR TITLE
Izpack 1361: Several fixes for element <excutable>

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -773,7 +773,16 @@
     			</xs:restriction>
         	</xs:simpleType>
 	    </xs:attribute>
-        <xs:attribute name="class" type="xs:string" />        
+        <xs:attribute name="failure" default="ask" >    
+        	<xs:simpleType>
+    		    <xs:restriction base="xs:string">
+    				<xs:enumeration value="ask" />
+    				<xs:enumeration value="abort" />
+    				<xs:enumeration value="warn" />
+    				<xs:enumeration value="ignore" />
+    			</xs:restriction>
+        	</xs:simpleType>
+	    </xs:attribute>    
     </xs:complexType>
 
     <xs:complexType name="updateCheckType">

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -765,6 +765,15 @@
         </xs:attribute>
         <xs:attribute name="keep" type="xs:boolean" use="optional" default="false"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
+        <xs:attribute name="type" default="bin" >
+        	<xs:simpleType>
+    		    <xs:restriction base="xs:string">
+    				<xs:enumeration value="bin" />
+    				<xs:enumeration value="jar" />
+    			</xs:restriction>
+        	</xs:simpleType>
+	    </xs:attribute>
+        <xs:attribute name="class" type="xs:string" />        
     </xs:complexType>
 
     <xs:complexType name="updateCheckType">


### PR DESCRIPTION
- IZPACK-1362: Add XSD for <executable> attributes "type" and "class"
- IZPACK-1364: <executable>: XSD is missing attribute "failure"
