### PR TITLE
IZPACK-1367: Custom conditions with fully qualified path names in type no longer accepted

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/rules/RulesEngine.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/rules/RulesEngine.java
@@ -19,14 +19,14 @@
 
 package com.izforge.izpack.api.rules;
 
-import java.io.OutputStream;
-import java.util.Map;
-import java.util.Set;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.data.Variables;
+
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Interface of rulesEngine
@@ -65,12 +65,29 @@ public interface RulesEngine
     Condition instantiateCondition(IXMLElement condition);
 
     /**
+     * Returns the class name implementing a condition type.
+     *
+     * @param type the condition type
+     * @return the class name
+     */
+    public String getClassName(String type);
+
+    /**
      * Creates a condition given its XML specification.
      *
      * @param condition the condition XML specification
      * @return a new  condition
      */
     Condition createCondition(IXMLElement condition);
+
+    /**
+     * Creates a condition given its XML specification.
+     *
+     * @param condition the condition XML specification
+     * @param conditionClass the dedicated class implementing a {@code Condition}
+     * @return a new  condition
+     */
+    public Condition createCondition(IXMLElement condition, Class<Condition> conditionClass);
 
     /**
      * Check whether references condition exist This must be done after all conditions have been

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -323,6 +323,8 @@ public class CompilerConfig extends Thread
         substituteProperties(data);
 
         // We add all the information
+        addNativeLibraries(data);
+        addJars(data);
         addVariables(data);
         addConditions(data);
         addDynamicVariables(data);
@@ -332,8 +334,6 @@ public class CompilerConfig extends Thread
         addGUIPrefs(data);
         addLangpacks(data);
         addResources(data);
-        addNativeLibraries(data);
-        addJars(data);
         addPanelJars(data);
         addListenerJars(data);
         addPanels(data);
@@ -2733,7 +2733,12 @@ public class CompilerConfig extends Thread
             {
                 try
                 {
-                    Condition condition = rules.createCondition(conditionNode);
+                    // Workaround for reading user-defined conditions with fully defined class name
+                    // from compile-time classpath
+                    String className = rules.getClassName(conditionNode.getAttribute("type"));
+
+                    Class<Condition> conditionClass = classLoader.loadClass(className, Condition.class);
+                    Condition condition = rules.createCondition(conditionNode, conditionClass);
                     if (condition != null)
                     {
                         String conditionid = condition.getId();

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -68,23 +68,30 @@
         <xs:attribute name="refid" type="xs:string"/>
         <xs:attribute name="type" use="optional">
             <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="ref"/>
-                    <xs:enumeration value="and"/>
-                    <xs:enumeration value="not"/>
-                    <xs:enumeration value="or"/>
-                    <xs:enumeration value="xor"/>
-                    <xs:enumeration value="comparenumerics"/>
-                    <xs:enumeration value="compareversions"/>
-                    <xs:enumeration value="compareversionsmajor"/>
-                    <xs:enumeration value="empty"/>
-                    <xs:enumeration value="exists"/>
-                    <xs:enumeration value="java"/>
-                    <xs:enumeration value="packselection"/>
-                    <xs:enumeration value="user"/>
-                    <xs:enumeration value="variable"/>
-                    <xs:enumeration value="contains"/>
-                </xs:restriction>
+                <xs:union>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="ref"/>
+                            <xs:enumeration value="and"/>
+                            <xs:enumeration value="not"/>
+                            <xs:enumeration value="or"/>
+                            <xs:enumeration value="xor"/>
+                            <xs:enumeration value="comparenumerics"/>
+                            <xs:enumeration value="compareversions"/>
+                            <xs:enumeration value="compareversionsmajor"/>
+                            <xs:enumeration value="empty"/>
+                            <xs:enumeration value="exists"/>
+                            <xs:enumeration value="java"/>
+                            <xs:enumeration value="packselection"/>
+                            <xs:enumeration value="user"/>
+                            <xs:enumeration value="variable"/>
+                            <xs:enumeration value="contains"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                    <xs:simpleType>
+                        <xs:restriction base="fullyQualifiedClassNameType"/>
+                    </xs:simpleType>
+                </xs:union>
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
@@ -234,6 +241,12 @@
             <xs:enumeration value="false"/>
             <xs:enumeration value="yes"/>
             <xs:enumeration value="no"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="fullyQualifiedClassNameType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([\p{L}_$][\p{L}\p{N}_$]*\.)*[\p{L}_$][\p{L}\p{N}_$]*"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -21,17 +21,6 @@
 
 package com.izforge.izpack.core.rules;
 
-import java.io.OutputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.XMLException;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
@@ -52,6 +41,12 @@ import com.izforge.izpack.core.rules.logic.XorCondition;
 import com.izforge.izpack.core.rules.process.*;
 import com.izforge.izpack.util.Platform;
 import com.izforge.izpack.util.Platforms;
+
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.logging.Logger;
 
 
 /**
@@ -153,14 +148,8 @@ public class RulesEngineImpl implements RulesEngine
         return createCondition(condition);
     }
 
-    /**
-     * Creates a condition given its XML specification.
-     *
-     * @param condition the condition XML specification
-     * @return a new  condition
-     */
     @Override
-    public Condition createCondition(IXMLElement condition)
+    public Condition createCondition(IXMLElement condition, Class<Condition> conditionClass)
     {
         String id = condition.getAttribute("id");
         String type = condition.getAttribute("type");
@@ -168,7 +157,10 @@ public class RulesEngineImpl implements RulesEngine
         if (type != null)
         {
             String className = getClassName(type);
-            Class<Condition> conditionClass = container.getClass(className, Condition.class);
+            if (conditionClass == null)
+            {
+                conditionClass = container.getClass(className, Condition.class);
+            }
             try
             {
                 if (id == null || id.isEmpty() || "UNKNOWN".equals(id))
@@ -193,6 +185,12 @@ public class RulesEngineImpl implements RulesEngine
             }
         }
         return result;
+    }
+
+    @Override
+    public Condition createCondition(IXMLElement condition)
+    {
+        return createCondition(condition, null);
     }
 
     @Override
@@ -827,13 +825,8 @@ public class RulesEngineImpl implements RulesEngine
         return result;
     }
 
-    /**
-     * Returns the class name implementing a condition type.
-     *
-     * @param type the condition type
-     * @return the class name
-     */
-    private String getClassName(String type)
+    @Override
+    public String getClassName(String type)
     {
         String result;
         if (type.indexOf('.') != -1)


### PR DESCRIPTION
This fixes [IZPACK-1367](https://izpack.atlassian.net/browse/IZPACK-1367):

When using the following condition definition
```xml
<conditions>
    <condition type="com.mycompany.myapp.izpack.conditions.IsAdminCondition" id="IsAdmin" />
    ...
<conditions>
```

to refer to a custom condition of mine, the compiler fails with the following message:

```
[ERROR] Failed to execute goal org.codehaus.izpack:izpack-maven-plugin:5.0.7:izpack (default-izpack) on project my-app-installer: Failure: Error in /home/rkrell/src/myapp/installer/install.xml at line 65, column 106 : javax.xml.transform.TransformerException: com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: cvc-enumeration-valid: Value 'com.mycompany.myapp.izpack.conditions.IsAdminCondition' is not facet-valid with respect to enumeration '[ref, and, not, or, xor, comparenumerics, compareversions, compareversionsmajor, empty, exists, java, packselection, user, variable, contains]'. It must be a value from the enumeration. -> [Help 1]
```

Fully qualified class names are no longer accepted although the implementation supports them.

This breaks an important part of functionality and should be fixed soon in the XSD.