### PR TITLE
IZPACK-1370: UserInputPanel: Field type "button" not accepted (by XSD)

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -447,6 +447,7 @@
     <!--                                                                                                        -->
     <xs:simpleType name="typeType">
         <xs:restriction base="xs:string">
+            <xs:enumeration value="button"/>
             <xs:enumeration value="check"/>
             <xs:enumeration value="combo"/>
             <xs:enumeration value="custom"/>


### PR DESCRIPTION
The field type "_button_" is not accepted during validating the UserInputPanelSpec.xml resource.