### PR TITLE
IZPACK-1375: Fatal error: Missing instance of class java.util.logging.Handler for command line build

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/bootstrap/CompilerLauncher.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/bootstrap/CompilerLauncher.java
@@ -19,12 +19,14 @@
 
 package com.izforge.izpack.compiler.bootstrap;
 
-import java.util.Date;
-
 import com.izforge.izpack.compiler.CompilerConfig;
 import com.izforge.izpack.compiler.container.CompilerContainer;
 import com.izforge.izpack.compiler.exception.HelpRequestedException;
 import com.izforge.izpack.compiler.exception.NoArgumentException;
+
+import java.util.Date;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
 
 /**
  * CompilerLauncher class initizaling bindings and launching the compiler
@@ -47,6 +49,7 @@ public class CompilerLauncher
         {
             CompilerContainer compilerContainer = new CompilerContainer();
             compilerContainer.processCompileDataFromArgs(args);
+            compilerContainer.addComponent(Handler.class, new ConsoleHandler());
 
             CompilerConfig compiler = compilerContainer.getComponent(CompilerConfig.class);
             compiler.executeCompiler();
@@ -82,6 +85,5 @@ public class CompilerLauncher
         // Closes the JVM
         System.exit(exitCode);
     }
-
 
 }


### PR DESCRIPTION
There are currently failing command line builds like `compile install.xml -o test.jar`:

```
{code}
-> Fatal error :
   org.picocontainer.injectors.AbstractInjector$UnsatisfiableDependenciesException: com.izforge.izpack.compiler.CompilerConfig has unsatisfied dependency 'class java.util.logging.Handler' for constructor 'public com.izforge.izpack.compiler.CompilerConfig(com.izforge.izpack.compiler.data.CompilerData,com.izforge.izpack.api.substitutor.VariableSubstitutor,com.izforge.izpack.compiler.Compiler,com.izforge.izpack.compiler.helper.XmlCompilerHelper,com.izforge.izpack.compiler.data.PropertyManager,com.izforge.izpack.merge.MergeManager,com.izforge.izpack.compiler.helper.AssertionHelper,com.izforge.izpack.api.rules.RulesEngine,com.izforge.izpack.compiler.merge.CompilerPathResolver,com.izforge.izpack.compiler.resource.ResourceFinder,com.izforge.izpack.api.factory.ObjectFactory,com.izforge.izpack.util.PlatformModelMatcher,com.izforge.izpack.compiler.util.CompilerClassLoader,java.util.logging.Handler)' from org.picocontainer.DefaultPicoContainer@25282528:27<|
com.izforge.izpack.api.exception.ContainerException: org.picocontainer.injectors.AbstractInjector$UnsatisfiableDependenciesException: com.izforge.izpack.compiler.CompilerConfig has unsatisfied dependency 'class java.util.logging.Handler' for constructor 'public com.izforge.izpack.compiler.CompilerConfig(com.izforge.izpack.compiler.data.CompilerData,com.izforge.izpack.api.substitutor.VariableSubstitutor,com.izforge.izpack.compiler.Compiler,com.izforge.izpack.compiler.helper.XmlCompilerHelper,com.izforge.izpack.compiler.data.PropertyManager,com.izforge.izpack.merge.MergeManager,com.izforge.izpack.compiler.helper.AssertionHelper,com.izforge.izpack.api.rules.RulesEngine,com.izforge.izpack.compiler.merge.CompilerPathResolver,com.izforge.izpack.compiler.resource.ResourceFinder,com.izforge.izpack.api.factory.ObjectFactory,com.izforge.izpack.util.PlatformModelMatcher,com.izforge.izpack.compiler.util.CompilerClassLoader,java.util.logging.Handler)' from org.picocontainer.DefaultPicoContainer@25282528:27<|
        at com.izforge.izpack.core.container.AbstractContainer.getComponent(AbstractContainer.java:135)
        at com.izforge.izpack.compiler.bootstrap.CompilerLauncher.main(CompilerLauncher.java:51)
Caused by: org.picocontainer.injectors.AbstractInjector$UnsatisfiableDependenciesException: com.izforge.izpack.compiler.CompilerConfig has unsatisfied dependency 'class java.util.logging.Handler' for constructor 'public com.izforge.izpack.compiler.CompilerConfig(com.izforge.izpack.compiler.data.CompilerData,com.izforge.izpack.api.substitutor.VariableSubstitutor,com.izforge.izpack.compiler.Compiler,com.izforge.izpack.compiler.helper.XmlCompilerHelper,com.izforge.izpack.compiler.data.PropertyManager,com.izforge.izpack.merge.MergeManager,com.izforge.izpack.compiler.helper.AssertionHelper,com.izforge.izpack.api.rules.RulesEngine,com.izforge.izpack.compiler.merge.CompilerPathResolver,com.izforge.izpack.compiler.resource.ResourceFinder,com.izforge.izpack.api.factory.ObjectFactory,com.izforge.izpack.util.PlatformModelMatcher,com.izforge.izpack.compiler.util.CompilerClassLoader,java.util.logging.Handler)' from org.picocontainer.DefaultPicoContainer@25282528:27<|
        at org.picocontainer.injectors.ConstructorInjector.getGreediestSatisfiableConstructor(ConstructorInjector.java:197)
        at org.picocontainer.injectors.ConstructorInjector.getGreediestSatisfiableConstructor(ConstructorInjector.java:112)
        at org.picocontainer.injectors.ConstructorInjector.access$100(ConstructorInjector.java:52)
        at org.picocontainer.injectors.ConstructorInjector$1.run(ConstructorInjector.java:337)
        at org.picocontainer.injectors.AbstractInjector$ThreadLocalCyclicDependencyGuard.observe(AbstractInjector.java:272)
        at org.picocontainer.injectors.ConstructorInjector.getComponentInstance(ConstructorInjector.java:370)
        at org.picocontainer.behaviors.AbstractBehavior.getComponentInstance(AbstractBehavior.java:64)
        at org.picocontainer.behaviors.Stored.getComponentInstance(Stored.java:91)
        at org.picocontainer.DefaultPicoContainer.getInstance(DefaultPicoContainer.java:692)
        at org.picocontainer.DefaultPicoContainer.getComponent(DefaultPicoContainer.java:646)
        at org.picocontainer.DefaultPicoContainer.getComponent(DefaultPicoContainer.java:671)
        at com.izforge.izpack.core.container.AbstractContainer.getComponent(AbstractContainer.java:131)
        ... 1 more
```