### PR TITLE
IZPACK-1376: Using AntActionInstallerListener forces to add commons-io.jar explicitly	

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -85,8 +85,7 @@ import com.izforge.izpack.util.IoHelper;
 import com.izforge.izpack.util.OsConstraintHelper;
 import com.izforge.izpack.util.PlatformModelMatcher;
 import com.izforge.izpack.util.file.DirectoryScanner;
-import com.izforge.izpack.util.file.FileUtils;
-
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.*;
@@ -112,6 +111,8 @@ import static com.izforge.izpack.api.data.Info.EXPIRE_DATE_FORMAT;
 public class CompilerConfig extends Thread
 {
     private static Logger logger;
+
+    private static final File TEMP_DIR = FileUtils.getTempDirectory();
 
     /**
      * Constant for checking attributes.
@@ -1540,7 +1541,7 @@ public class CompilerConfig extends Thread
 
             try
             {
-                File temp = FileUtils.createTempFile("izpack", null);
+                File temp = File.createTempFile("izpack", null, TEMP_DIR);
                 temp.deleteOnExit();
 
                 FileOutputStream out = new FileOutputStream(temp);
@@ -1756,7 +1757,7 @@ public class CompilerConfig extends Thread
                 if (parsexml || !encoding.isEmpty() || (substitute && !packager.getVariables().isEmpty()))
                 {
                     // make the substitutions into a temp file
-                    File parsedFile = FileUtils.createTempFile("izpp", null);
+                    File parsedFile = File.createTempFile("izpp", null, TEMP_DIR);
                     parsedFile.deleteOnExit();
                     FileOutputStream outFile = new FileOutputStream(parsedFile);
                     os = new BufferedOutputStream(outFile);
@@ -1767,7 +1768,7 @@ public class CompilerConfig extends Thread
 
                 if (!encoding.isEmpty())
                 {
-                    File recodedFile = FileUtils.createTempFile("izenc", null);
+                    File recodedFile = File.createTempFile("izenc", null, TEMP_DIR);
                     recodedFile.deleteOnExit();
 
                     InputStreamReader reader = new InputStreamReader(originalUrl.openStream(), encoding);
@@ -3153,7 +3154,7 @@ public class CompilerConfig extends Thread
                     }
 
                     // writing merged strings to a new file
-                    File mergedPackLangFile = FileUtils.createTempFile("izpp", null);
+                    File mergedPackLangFile = File.createTempFile("izpp", null, TEMP_DIR);
                     mergedPackLangFile.deleteOnExit();
 
                     FileOutputStream outFile = new FileOutputStream(mergedPackLangFile);

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -445,7 +445,7 @@ public abstract class PackagerBase implements IPackager
         mergeManager.addResourceToMerge("org/apache/regexp/");
         mergeManager.addResourceToMerge("com/coi/tools/");
         mergeManager.addResourceToMerge("org/apache/tools/zip/");
-        mergeManager.addResourceToMerge("org/apache/commons/io/FilenameUtils.class");
+        mergeManager.addResourceToMerge("org/apache/commons/io/");
         mergeManager.addResourceToMerge("jline/");
         mergeManager.addResourceToMerge("org/fusesource/");
         mergeManager.addResourceToMerge("META-INF/native/");

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -37,6 +37,7 @@ import com.izforge.izpack.merge.MergeManager;
 import com.izforge.izpack.merge.resolve.MergeableResolver;
 import com.izforge.izpack.util.FileUtil;
 import com.izforge.izpack.util.IoHelper;
+import org.apache.commons.io.FileUtils;
 
 import java.io.*;
 import java.net.URL;
@@ -418,7 +419,7 @@ public abstract class PackagerBase implements IPackager
     protected void writeManifest() throws IOException
     {
         Manifest manifest = new Manifest(PackagerBase.class.getResourceAsStream("MANIFEST.MF"));
-        File tempManifest = com.izforge.izpack.util.file.FileUtils.createTempFile("MANIFEST", ".MF");
+        File tempManifest = File.createTempFile("MANIFEST", ".MF", FileUtils.getTempDirectory());
         manifest.write(new FileOutputStream(tempManifest));
         mergeManager.addResourceToMerge(tempManifest.getAbsolutePath(), "META-INF/MANIFEST.MF");
     }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/io/FileSpanningInputStream.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/io/FileSpanningInputStream.java
@@ -18,6 +18,8 @@
 
 package com.izforge.izpack.core.io;
 
+import org.apache.commons.io.IOUtils;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -26,8 +28,6 @@ import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
-
-import com.izforge.izpack.util.file.FileUtils;
 
 
 /**
@@ -258,7 +258,7 @@ public class FileSpanningInputStream extends InputStream
             magicNumber = new byte[FileSpanningOutputStream.MAGIC_NUMBER_LENGTH];
             if (stream.read(magicNumber) != FileSpanningOutputStream.MAGIC_NUMBER_LENGTH)
             {
-                FileUtils.close(stream);
+                IOUtils.closeQuietly(stream);
                 throw new CorruptVolumeException();
             }
             if (logger.isLoggable(Level.FINE))
@@ -381,7 +381,7 @@ public class FileSpanningInputStream extends InputStream
                         try
                         {
                             // try to open new stream to next volume
-                            FileUtils.close(stream);
+                            IOUtils.closeQuietly(stream);
                             stream = new FileInputStream(volume);
                             current = volume;
                             checkMagicNumber();
@@ -445,7 +445,7 @@ public class FileSpanningInputStream extends InputStream
             }
             catch (IOException exception)
             {
-                FileUtils.close(stream);
+                IOUtils.closeQuietly(stream);
                 throw exception;
             }
         }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/resource/AbstractResources.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/resource/AbstractResources.java
@@ -21,19 +21,18 @@
 
 package com.izforge.izpack.core.resource;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.ObjectInputStream;
-import java.net.URL;
-import java.util.Arrays;
-
-import javax.swing.ImageIcon;
-
 import com.izforge.izpack.api.exception.ResourceException;
 import com.izforge.izpack.api.exception.ResourceNotFoundException;
 import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
+
+import javax.swing.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.URL;
+import java.util.Arrays;
 
 
 /**
@@ -187,8 +186,8 @@ public abstract class AbstractResources implements Resources
         }
         finally
         {
-            FileUtils.close(objectIn);
-            FileUtils.close(in);
+            IOUtils.closeQuietly(objectIn);
+            IOUtils.closeQuietly(in);
         }
         return result;
     }
@@ -282,16 +281,13 @@ public abstract class AbstractResources implements Resources
     {
         String result;
         InputStream in = getInputStream(name);
-        InputStreamReader reader = null;
         try
         {
-            reader = (encoding != null) ? new InputStreamReader(in, encoding) : new InputStreamReader(in);
-            result = FileUtils.readFully(reader);
+            result = IOUtils.toString(in, Charsets.toCharset(encoding));
         }
         finally
         {
-            FileUtils.close(reader);
-            FileUtils.close(in);
+            IOUtils.closeQuietly(in);
         }
         return result;
     }

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntAction.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntAction.java
@@ -23,30 +23,19 @@
 
 package com.izforge.izpack.event;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
+import com.izforge.izpack.api.exception.InstallerException;
+import com.izforge.izpack.api.exception.IzPackException;
+import com.izforge.izpack.api.handler.Prompt;
+import org.apache.commons.io.IOUtils;
+import org.apache.tools.ant.*;
+import org.apache.tools.ant.taskdefs.Ant;
+import org.apache.tools.ant.util.JavaEnvUtils;
+
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
-
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.BuildLogger;
-import org.apache.tools.ant.DefaultLogger;
-import org.apache.tools.ant.DemuxOutputStream;
-import org.apache.tools.ant.Location;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.Target;
-import org.apache.tools.ant.taskdefs.Ant;
-import org.apache.tools.ant.util.JavaEnvUtils;
-
-import com.izforge.izpack.api.exception.InstallerException;
-import com.izforge.izpack.api.exception.IzPackException;
-import com.izforge.izpack.api.handler.Prompt;
-import com.izforge.izpack.util.file.FileUtils;
 
 /**
  * This class contains data and 'perform' logic for ant action listeners.
@@ -56,16 +45,9 @@ import com.izforge.izpack.util.file.FileUtils;
  */
 public class AntAction extends ActionBase
 {
-    private static final transient Logger logger = Logger.getLogger(AntAction.class.getName());
-
-    // --------AntAction specific String constants for ------------
-    // --- parsing the XML specification ------------
+    private static final Logger logger = Logger.getLogger(AntAction.class.getName());
 
     private static final long serialVersionUID = 3258131345250005557L;
-
-    public static final String ANTACTIONS = "antactions";
-
-    public static final String ANTACTION = "antaction";
 
     public static final String ANTCALL = "antcall";
 
@@ -170,7 +152,7 @@ public class AntAction extends ActionBase
             List<String> choosenTargets = (uninstall) ? uninstallTargets : targets;
             if (choosenTargets.size() > 0)
             {
-                Ant antcall = null;
+                Ant antcall;
                 for (String choosenTarget : choosenTargets)
                 {
                     antcall = (Ant) antProj.createTask("ant");
@@ -255,7 +237,7 @@ public class AntAction extends ActionBase
     /**
      * Sets the build working directory to be used to the given string.
      *
-     * @param buildFile build working directory path to be used
+     * @param buildDir build working directory path to be used
      */
     public void setBuildDir(File buildDir)
     {
@@ -584,7 +566,7 @@ public class AntAction extends ActionBase
         }
         finally
         {
-            FileUtils.close(fis);
+            IOUtils.closeQuietly(fis);
         }
         addProperties(proj, props);
     }

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntActionInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntActionInstallerListener.java
@@ -22,19 +22,6 @@
 
 package com.izforge.izpack.event;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Pack;
@@ -47,8 +34,15 @@ import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.installer.data.UninstallData;
 import com.izforge.izpack.util.FileUtil;
-import com.izforge.izpack.util.file.FileUtils;
 import com.izforge.izpack.util.helper.SpecHelper;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * Installer listener for performing ANT actions. The definition what should be done will be made in
@@ -504,8 +498,8 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
             }
             finally
             {
-                FileUtils.close(bos);
-                FileUtils.close(bis);
+                IOUtils.closeQuietly(bos);
+                IOUtils.closeQuietly(bis);
             }
         }
         return buildResourceFile;
@@ -533,8 +527,8 @@ public class AntActionInstallerListener extends AbstractProgressInstallerListene
         }
         finally
         {
-            FileUtils.close(bis);
-            FileUtils.close(bos);
+            IOUtils.closeQuietly(bis);
+            IOUtils.closeQuietly(bos);
         }
     }
 }

--- a/izpack-event/src/main/java/com/izforge/izpack/event/BSFInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/BSFInstallerListener.java
@@ -21,15 +21,6 @@
 
 package com.izforge.izpack.event;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Pack;
@@ -41,8 +32,17 @@ import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.installer.data.UninstallData;
-import com.izforge.izpack.util.file.FileUtils;
 import com.izforge.izpack.util.helper.SpecHelper;
+import org.apache.commons.io.IOUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
 
 
 public class BSFInstallerListener extends AbstractProgressInstallerListener
@@ -376,8 +376,8 @@ public class BSFInstallerListener extends AbstractProgressInstallerListener
             }
             finally
             {
-                FileUtils.close(subis);
-                FileUtils.close(is);
+                IOUtils.closeQuietly(subis);
+                IOUtils.closeQuietly(is);
             }
         }
         else

--- a/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
@@ -21,26 +21,12 @@
 
 package com.izforge.izpack.event;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Iterator;
-import java.util.List;
-import java.util.StringTokenizer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.event.ProgressListener;
-import com.izforge.izpack.api.exception.InstallerException;
-import com.izforge.izpack.api.exception.IzPackException;
-import com.izforge.izpack.api.exception.NativeLibException;
-import com.izforge.izpack.api.exception.ResourceNotFoundException;
-import com.izforge.izpack.api.exception.WrappedNativeLibException;
+import com.izforge.izpack.api.exception.*;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
@@ -53,6 +39,17 @@ import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.IoHelper;
 import com.izforge.izpack.util.file.FileUtils;
 import com.izforge.izpack.util.helper.SpecHelper;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
+import java.util.StringTokenizer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Installer custom action for handling registry entries on Windows. On Unix nothing will be done.
@@ -581,7 +578,7 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
             
             // make sure the 'Uninstaller' directory exists
             File uninstallerIcon = new File(iconPath);
-            FileUtils.getFileUtils().createNewFile(uninstallerIcon, true);
+            FileUtils.createNewFile(uninstallerIcon, true);
             
             out = new FileOutputStream(uninstallerIcon);
             IoHelper.copyStream(in, out);
@@ -600,8 +597,8 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
         }
         finally
         {
-            FileUtils.close(in);
-            FileUtils.close(out);
+            IOUtils.closeQuietly(in);
+            IOUtils.closeQuietly(out);
         }
     }
 

--- a/izpack-event/src/main/java/com/izforge/izpack/event/SummaryLoggerInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/SummaryLoggerInstallerListener.java
@@ -21,12 +21,6 @@
 
 package com.izforge.izpack.event;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.List;
-
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.event.ProgressListener;
@@ -34,7 +28,13 @@ import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.util.SummaryProcessor;
 import com.izforge.izpack.util.IoHelper;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
 
 /**
  * Installer listener which writes the summary of all panels into the logfile which is defined by
@@ -105,7 +105,7 @@ public class SummaryLoggerInstallerListener extends AbstractProgressInstallerLis
             }
             finally
             {
-                FileUtils.close(out);
+                IOUtils.closeQuietly(out);
             }
 
         }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/ConsoleInstaller.java
@@ -33,7 +33,7 @@ import com.izforge.izpack.installer.data.UninstallDataWriter;
 import com.izforge.izpack.util.Console;
 import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.PrivilegedRunner;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -352,7 +352,7 @@ public class ConsoleInstaller implements InstallerBase
         }
         finally
         {
-            FileUtils.close(in);
+            IOUtils.closeQuietly(in);
         }
     }
 
@@ -388,7 +388,7 @@ public class ConsoleInstaller implements InstallerBase
         }
         finally
         {
-            FileUtils.close(in);
+            IOUtils.closeQuietly(in);
         }
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/GeneratePropertiesAction.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/GeneratePropertiesAction.java
@@ -21,12 +21,12 @@
 
 package com.izforge.izpack.installer.console;
 
+import com.izforge.izpack.api.data.InstallData;
+import org.apache.commons.io.IOUtils;
+
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
-
-import com.izforge.izpack.api.data.InstallData;
-import com.izforge.izpack.util.file.FileUtils;
 
 /**
  * Action to generate properties for each panel.
@@ -85,7 +85,7 @@ class GeneratePropertiesAction extends ConsoleAction
     @Override
     public boolean complete()
     {
-        FileUtils.close(writer);
+        IOUtils.closeQuietly(writer);
         return true;
     }
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/data/UninstallDataWriter.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/data/UninstallDataWriter.java
@@ -1,14 +1,15 @@
 package com.izforge.izpack.installer.data;
 
-import java.io.BufferedOutputStream;
-import java.io.BufferedWriter;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
-import java.io.OutputStreamWriter;
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.merge.Mergeable;
+import com.izforge.izpack.api.rules.RulesEngine;
+import com.izforge.izpack.data.CustomData;
+import com.izforge.izpack.data.ExecutableFile;
+import com.izforge.izpack.merge.resolve.PathResolver;
+import com.izforge.izpack.util.IoHelper;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -17,15 +18,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.api.merge.Mergeable;
-import com.izforge.izpack.api.rules.RulesEngine;
-import com.izforge.izpack.data.CustomData;
-import com.izforge.izpack.data.ExecutableFile;
-import com.izforge.izpack.merge.resolve.PathResolver;
-import com.izforge.izpack.util.IoHelper;
-import com.izforge.izpack.util.file.FileUtils;
 
 /**
  * Writes uninstall data to an executable jar file.
@@ -202,6 +194,7 @@ public class UninstallDataWriter
         uninstallerMerge.addAll(pathResolver.getMergeableFromPath("com/izforge/izpack/gui/"));
         uninstallerMerge.addAll(pathResolver.getMergeableFromPath("com/izforge/izpack/img/"));
         uninstallerMerge.addAll(pathResolver.getMergeableFromPath("org/picocontainer/"));
+        uninstallerMerge.addAll(pathResolver.getMergeableFromPath("org/apache/commons/io/"));
 
         // indirectly required by Librarian, which pulls in IoHelper. TODO
         uninstallerMerge.addAll(pathResolver.getMergeableFromPath("org/apache/tools/zip/"));
@@ -523,8 +516,8 @@ public class UninstallDataWriter
      */
     private void destroyJar()
     {
-        FileUtils.close(jar);
-        FileUtils.close(jarStream); // if jar cannot be closed, then need to close underlying stream
+        IOUtils.closeQuietly(jar);
+        IOUtils.closeQuietly(jarStream); // if jar cannot be closed, then need to close underlying stream
         String path = uninstallData.getUninstallerJarFilename();
         if (path != null)
         {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeUnpacker.java
@@ -22,16 +22,6 @@
 
 package com.izforge.izpack.installer.multiunpacker;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.CodeSource;
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.data.PackFile;
@@ -45,16 +35,21 @@ import com.izforge.izpack.core.io.FileSpanningInputStream;
 import com.izforge.izpack.core.io.VolumeLocator;
 import com.izforge.izpack.installer.data.UninstallData;
 import com.izforge.izpack.installer.event.InstallerListeners;
-import com.izforge.izpack.installer.unpacker.Cancellable;
-import com.izforge.izpack.installer.unpacker.FileQueueFactory;
-import com.izforge.izpack.installer.unpacker.FileUnpacker;
-import com.izforge.izpack.installer.unpacker.LooseFileUnpacker;
-import com.izforge.izpack.installer.unpacker.PackResources;
-import com.izforge.izpack.installer.unpacker.UnpackerBase;
+import com.izforge.izpack.installer.unpacker.*;
 import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.PlatformModelMatcher;
-import com.izforge.izpack.util.file.FileUtils;
 import com.izforge.izpack.util.os.FileQueue;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.CodeSource;
+import java.util.List;
+import java.util.logging.Logger;
 
 
 /**
@@ -155,8 +150,8 @@ public class MultiVolumeUnpacker extends UnpackerBase
         }
         finally
         {
-            FileUtils.close(in);
-            FileUtils.close(objectIn);
+            IOUtils.closeQuietly(in);
+            IOUtils.closeQuietly(objectIn);
         }
     }
 
@@ -208,7 +203,7 @@ public class MultiVolumeUnpacker extends UnpackerBase
     protected void cleanup()
     {
         super.cleanup();
-        FileUtils.close(volumes);
+        IOUtils.closeQuietly(volumes);
     }
 
     /**

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
@@ -21,21 +21,15 @@
 
 package com.izforge.izpack.installer.unpacker;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InterruptedIOException;
-import java.io.ObjectInputStream;
-import java.io.OutputStream;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.data.Blockable;
 import com.izforge.izpack.api.data.PackFile;
 import com.izforge.izpack.api.exception.InstallerException;
-import com.izforge.izpack.util.file.FileUtils;
 import com.izforge.izpack.util.os.FileQueue;
 import com.izforge.izpack.util.os.FileQueueMove;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
+import java.util.logging.Logger;
 
 
 /**
@@ -143,7 +137,7 @@ public abstract class FileUnpacker
         }
         finally
         {
-            FileUtils.close(out);
+            IOUtils.closeQuietly(out);
         }
         postCopy(file);
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/Pack200FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/Pack200FileUnpacker.java
@@ -21,18 +21,14 @@
 
 package com.izforge.izpack.installer.unpacker;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.OutputStream;
-import java.util.jar.JarOutputStream;
-import java.util.jar.Pack200;
-
 import com.izforge.izpack.api.data.PackFile;
 import com.izforge.izpack.api.exception.InstallerException;
-import com.izforge.izpack.util.file.FileUtils;
 import com.izforge.izpack.util.os.FileQueue;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Pack200;
 
 
 /**
@@ -96,9 +92,9 @@ class Pack200FileUnpacker extends FileUnpacker
         }
         finally
         {
-            FileUtils.close(in);
-            FileUtils.close(out);
-            FileUtils.close(jarOut);
+            IOUtils.closeQuietly(in);
+            IOUtils.closeQuietly(out);
+            IOUtils.closeQuietly(jarOut);
         }
 
         postCopy(file);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -49,10 +49,10 @@ import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.IoHelper;
 import com.izforge.izpack.util.PlatformModelMatcher;
 import com.izforge.izpack.util.file.DirectoryScanner;
-import com.izforge.izpack.util.file.FileUtils;
 import com.izforge.izpack.util.file.GlobPatternMapper;
 import com.izforge.izpack.util.file.types.FileSet;
 import com.izforge.izpack.util.os.FileQueue;
+import org.apache.commons.io.IOUtils;
 
 import java.io.*;
 import java.net.URI;
@@ -502,8 +502,8 @@ public abstract class UnpackerBase implements IUnpacker
         }
         finally
         {
-            FileUtils.close(packInputStream);
-            FileUtils.close(in);
+            IOUtils.closeQuietly(packInputStream);
+            IOUtils.closeQuietly(in);
         }
     }
 
@@ -634,10 +634,10 @@ public abstract class UnpackerBase implements IUnpacker
         }
         finally
         {
-            FileUtils.close(in);
+            IOUtils.closeQuietly(in);
             if (packStream != packInputStream)
             {
-                FileUtils.close(packStream);
+                IOUtils.closeQuietly(packStream);
             }
         }
     }
@@ -1161,8 +1161,8 @@ public abstract class UnpackerBase implements IUnpacker
             }
             finally
             {
-                FileUtils.close(oin);
-                FileUtils.close(fin);
+                IOUtils.closeQuietly(oin);
+                IOUtils.closeQuietly(fin);
             }
             for (Pack pack : packs)
             {
@@ -1176,8 +1176,8 @@ public abstract class UnpackerBase implements IUnpacker
         oout.writeObject(installData.getVariables().getProperties());
 
         logger.fine("Writing installation information finished");
-        FileUtils.close(oout);
-        FileUtils.close(fout);
+        IOUtils.closeQuietly(oout);
+        IOUtils.closeQuietly(fout);
 
         uninstallData.addFile(installationInfo.getAbsolutePath(), true);
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/util/TemporaryDirectory.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/util/TemporaryDirectory.java
@@ -22,14 +22,14 @@
 
 package com.izforge.izpack.util;
 
+import com.izforge.izpack.api.data.Info.TempDir;
+import com.izforge.izpack.api.data.InstallData;
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.izforge.izpack.api.data.Info.TempDir;
-import com.izforge.izpack.api.data.InstallData;
-import com.izforge.izpack.util.file.FileUtils;
 
 /**
  * Manages the life-cycle of a temporary directory
@@ -114,11 +114,15 @@ public class TemporaryDirectory implements CleanupClient
         {
             if (deleteOnExit)
             {
-                if (!FileUtils.deleteRecursively(tempdir))
+                try
+                {
+                    FileUtils.deleteDirectory(tempdir);
+                }
+                catch (IOException e)
                 {
                     logger.warning("Failed to properly clean up files in "
-                            + tempdir.getAbsolutePath()
-                            + " manual clean up may be required.");
+                            + tempdir.getAbsolutePath() + ": " + e.getMessage()
+                            + ", manual clean up may be required.");
                 }
             }
             else

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicenceConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicenceConsolePanel.java
@@ -31,11 +31,11 @@ import com.izforge.izpack.installer.gui.IzPanel;
 import com.izforge.izpack.installer.panel.PanelView;
 import com.izforge.izpack.installer.util.PanelHelper;
 import com.izforge.izpack.util.Console;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.logging.Logger;
 
@@ -138,16 +138,13 @@ public abstract class AbstractLicenceConsolePanel extends AbstractTextConsolePan
             url = loadLicence();
 
             InputStream in = url.openStream();
-            InputStreamReader reader = null;
             try
             {
-                reader = (encoding != null) ? new InputStreamReader(in, encoding) : new InputStreamReader(in);
-                result = FileUtils.readFully(reader);
+                result = IOUtils.toString(in, Charsets.toCharset(encoding));
             }
             finally
             {
-                FileUtils.close(reader);
-                FileUtils.close(in);
+                IOUtils.closeQuietly(in);
             }
         }
         catch (IOException e)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicencePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/AbstractLicencePanel.java
@@ -25,12 +25,12 @@ import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
 import com.izforge.izpack.installer.gui.IzPanel;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
 
 import java.awt.*;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.logging.Logger;
 
@@ -110,16 +110,13 @@ public abstract class AbstractLicencePanel extends IzPanel
             url = loadLicence();
 
             InputStream in = url.openStream();
-            InputStreamReader reader = null;
             try
             {
-                reader = (encoding != null) ? new InputStreamReader(in, encoding) : new InputStreamReader(in);
-                result = FileUtils.readFully(reader);
+                result = IOUtils.toString(in, Charsets.toCharset(encoding));
             }
             finally
             {
-                FileUtils.close(reader);
-                FileUtils.close(in);
+                IOUtils.closeQuietly(in);
             }
         }
         catch (IOException e)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
@@ -19,73 +19,6 @@
 
 package com.izforge.izpack.panels.shortcut;
 
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.AUTO_KEY_CREATE_DESKTOP_SHORTCUTS;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.AUTO_KEY_CREATE_MENU_SHORTCUTS;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.AUTO_KEY_CREATE_SHORTCUTS_LEGACY;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.AUTO_KEY_CREATE_STARTUP_SHORTCUTS;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.AUTO_KEY_PROGRAM_GROUP;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.AUTO_KEY_SHORTCUT_TYPE;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.AUTO_KEY_SHORTCUT_TYPE_VALUE_ALL;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.AUTO_KEY_SHORTCUT_TYPE_VALUE_USER;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.CREATE_FOR_ALL;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.DEFAULT_FOLDER;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SEPARATOR_LINE;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_APPLICATIONS;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_COMMAND;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_CONDITION;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_DEFAULT_GROUP;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_DESCRIPTION;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_DESKTOP;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_ENCODING;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_ICON;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_ICON_INDEX;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_INITIAL_STATE;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_INSTALLGROUP;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_KDE_SUBST_UID;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_KDE_USERNAME;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_LOCATION;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_MIMETYPE;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_NAME;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_PROGRAM_GROUP;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_RUN_AS_ADMINISTRATOR;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_STARTUP;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_START_MENU;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_SUBGROUP;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_TARGET;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_TERMINAL;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_TERMINAL_OPTIONS;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_TYPE;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_URL;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_ATTRIBUTE_WORKING_DIR;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_CATEGORIES;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_FILE_NAME;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_KEY_DEF_CUR_USER;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_KEY_LATE_INSTALL;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_KEY_NOT_SUPPORTED;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_KEY_PACKS;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_KEY_PROGRAM_GROUP;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_KEY_SHORTCUT;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_KEY_SKIP_IFNOT_SUPPORTED;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_TRYEXEC;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_VALUE_APPLICATIONS;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_VALUE_MAXIMIZED;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_VALUE_MINIMIZED;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_VALUE_NORMAL;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_VALUE_NO_SHOW;
-import static com.izforge.izpack.panels.shortcut.ShortcutConstants.SPEC_VALUE_START_MENU;
-import static com.izforge.izpack.util.Platform.Name.UNIX;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Vector;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLParser;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
@@ -105,18 +38,21 @@ import com.izforge.izpack.core.substitutor.VariableSubstitutorImpl;
 import com.izforge.izpack.data.ExecutableFile;
 import com.izforge.izpack.installer.data.UninstallData;
 import com.izforge.izpack.installer.event.InstallerListeners;
-import com.izforge.izpack.util.CleanupClient;
-import com.izforge.izpack.util.Housekeeper;
-import com.izforge.izpack.util.OsConstraintHelper;
-import com.izforge.izpack.util.OsVersion;
-import com.izforge.izpack.util.Platform;
-import com.izforge.izpack.util.PlatformModelMatcher;
-import com.izforge.izpack.util.StringTool;
-import com.izforge.izpack.util.TargetFactory;
-import com.izforge.izpack.util.file.FileUtils;
+import com.izforge.izpack.util.*;
 import com.izforge.izpack.util.os.Shortcut;
 import com.izforge.izpack.util.unix.UnixHelper;
 import com.izforge.izpack.util.xml.XMLHelper;
+import org.apache.commons.io.FileUtils;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Vector;
+import java.util.logging.Logger;
+
+import static com.izforge.izpack.panels.shortcut.ShortcutConstants.*;
+import static com.izforge.izpack.util.Platform.Name.UNIX;
 
 /**
  * This class implements a the logic for the creation of shortcuts. The logic is used in the
@@ -817,7 +753,7 @@ public class ShortcutPanelLogic implements CleanupClient
         try
         {
             test = File.createTempFile("shortcut", "", dir);
-            FileUtils.delete(test);
+            FileUtils.deleteQuietly(test);
         }
         catch (IOException exception)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelHelper.java
@@ -18,6 +18,11 @@
  */
 package com.izforge.izpack.panels.target;
 
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Pack;
+import com.izforge.izpack.util.Platform;
+import org.apache.commons.io.IOUtils;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.ObjectInputStream;
@@ -26,11 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.izforge.izpack.api.data.InstallData;
-import com.izforge.izpack.api.data.Pack;
-import com.izforge.izpack.util.Platform;
-import com.izforge.izpack.util.file.FileUtils;
 
 
 /**
@@ -139,8 +139,8 @@ public class TargetPanelHelper
             }
             finally
             {
-                FileUtils.close(objectInput);
-                FileUtils.close(input);
+                IOUtils.closeQuietly(objectInput);
+                IOUtils.closeQuietly(input);
             }
         }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -17,7 +17,7 @@ import com.izforge.izpack.installer.web.WebAccessor;
 import com.izforge.izpack.panels.packs.PacksModel;
 import com.izforge.izpack.panels.packs.PacksPanelAutomationHelper;
 import com.izforge.izpack.util.IoHelper;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.IOUtils;
 
 import javax.swing.*;
 import javax.swing.tree.TreeModel;
@@ -660,7 +660,7 @@ public class TreePacksPanel extends IzPanel
                 }
                 finally
                 {
-                    FileUtils.close(langPackStream);
+                    IOUtils.closeQuietly(langPackStream);
                 }
             }
             if (fallback)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
@@ -21,12 +21,6 @@
 
 package com.izforge.izpack.panels.userinput.field;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLParser;
 import com.izforge.izpack.api.adaptator.impl.XMLParser;
@@ -35,7 +29,13 @@ import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.factory.ObjectFactory;
 import com.izforge.izpack.api.resource.Messages;
 import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 /**
@@ -119,7 +119,7 @@ public class Config
         }
         finally
         {
-            FileUtils.close(input);
+            IOUtils.closeQuietly(input);
         }
     }
 

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/target/TargetPanelHelperTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/target/TargetPanelHelperTest.java
@@ -20,9 +20,16 @@
  */
 package com.izforge.izpack.panels.target;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Pack;
+import com.izforge.izpack.api.data.Variables;
+import com.izforge.izpack.core.data.DefaultVariables;
+import com.izforge.izpack.util.Platforms;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -30,17 +37,7 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.api.data.InstallData;
-import com.izforge.izpack.api.data.Pack;
-import com.izforge.izpack.api.data.Variables;
-import com.izforge.izpack.core.data.DefaultVariables;
-import com.izforge.izpack.util.Platforms;
-import com.izforge.izpack.util.file.FileUtils;
+import static org.junit.Assert.*;
 
 
 /**
@@ -161,7 +158,7 @@ public class TargetPanelHelperTest
     }
 
     /**
-     * Tests the {@link TargetPanelHelper#isIncompatibleInstallation(String)} method.
+     * Tests the {@link TargetPanelHelper#isIncompatibleInstallation(String, Boolean)} method.
      *
      * @throws IOException for any I/O error
      */
@@ -169,7 +166,7 @@ public class TargetPanelHelperTest
     public void testIsIncompatibleInstallation() throws IOException
     {
         File dir = File.createTempFile("junit", "");
-        FileUtils.delete(dir);
+        FileUtils.deleteQuietly(dir);
 
         // verify that the method returns false for non-existent directory
         assertFalse(dir.exists());

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/file/ConsoleDirFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/file/ConsoleDirFieldTest.java
@@ -21,30 +21,24 @@
 
 package com.izforge.izpack.panels.userinput.console.file;
 
-import static com.izforge.izpack.api.handler.Prompt.Option.OK;
-import static com.izforge.izpack.api.handler.Prompt.Options.OK_CANCEL;
-import static com.izforge.izpack.api.handler.Prompt.Type.WARNING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-
+import com.izforge.izpack.panels.userinput.console.AbstractConsoleFieldTest;
+import com.izforge.izpack.panels.userinput.field.file.DirField;
+import com.izforge.izpack.panels.userinput.field.file.TestDirFieldConfig;
+import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.izforge.izpack.panels.userinput.console.AbstractConsoleFieldTest;
-import com.izforge.izpack.panels.userinput.field.file.DirField;
-import com.izforge.izpack.panels.userinput.field.file.TestDirFieldConfig;
-import com.izforge.izpack.util.file.FileUtils;
+import java.io.File;
+import java.io.IOException;
+
+import static com.izforge.izpack.api.handler.Prompt.Option.OK;
+import static com.izforge.izpack.api.handler.Prompt.Options.OK_CANCEL;
+import static com.izforge.izpack.api.handler.Prompt.Type.WARNING;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -139,7 +133,7 @@ public class ConsoleDirFieldTest extends AbstractConsoleFieldTest
     {
         ConsoleDirField field = createField(null, false, false);
 
-        File file = FileUtils.createTempFile("foo", "bar");
+        File file = File.createTempFile("foo", "bar", FileUtils.getTempDirectory());
         checkInvalid(field, file.getPath());
         assertNull(installData.getVariable("dir"));
 
@@ -151,7 +145,7 @@ public class ConsoleDirFieldTest extends AbstractConsoleFieldTest
     /**
      * Helper to create a field that updates the 'dir' variable.
      *
-     * @param defaultValue the default value. May be {@code null}
+     * @param initialValue the initial value. May be {@code null}
      * @param mustExist    if {@code true}, the directory must exist
      * @return a new field
      */

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/file/ConsoleFileFieldTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/userinput/console/file/ConsoleFileFieldTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +36,6 @@ import org.junit.Test;
 import com.izforge.izpack.panels.userinput.console.AbstractConsoleFieldTest;
 import com.izforge.izpack.panels.userinput.field.file.FileField;
 import com.izforge.izpack.panels.userinput.field.file.TestFileFieldConfig;
-import com.izforge.izpack.util.file.FileUtils;
 
 
 /**
@@ -60,7 +60,7 @@ public class ConsoleFileFieldTest extends AbstractConsoleFieldTest
     @Before
     public void aetUp() throws IOException
     {
-        file = FileUtils.createTempFile("foo", "bar");
+        file = File.createTempFile("foo", "bar", FileUtils.getTempDirectory());
     }
 
     /**
@@ -117,7 +117,7 @@ public class ConsoleFileFieldTest extends AbstractConsoleFieldTest
     {
         ConsoleFileField field = createField(null);
 
-        File dir = FileUtils.createTempFile("foo", "bar");
+        File dir = File.createTempFile("foo", "bar", FileUtils.getTempDirectory());
         assertTrue(dir.delete());
         assertTrue(dir.mkdir());
         checkInvalid(field, dir.getPath());
@@ -129,7 +129,7 @@ public class ConsoleFileFieldTest extends AbstractConsoleFieldTest
     /**
      * Helper to create a field that updates the 'file' variable.
      *
-     * @param defaultValue the default value. May be {@code null}
+     * @param initialValue the initial value. May be {@code null}
      * @return a new field
      */
     private ConsoleFileField createField(String initialValue)

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/UninstallHelper.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/UninstallHelper.java
@@ -36,7 +36,7 @@ import com.izforge.izpack.uninstaller.Destroyer;
 import com.izforge.izpack.uninstaller.console.ConsoleUninstallerContainer;
 import com.izforge.izpack.uninstaller.gui.GUIUninstallerContainer;
 import com.izforge.izpack.util.IoHelper;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.FileUtils;
 
 
 /**
@@ -157,7 +157,7 @@ public class UninstallHelper
         Method run = destroyerClass.getMethod("run");
         run.invoke(destroyer);
 
-        FileUtils.delete(jar); // probably won't delete as the class loader will still have a reference to it?
+        FileUtils.deleteQuietly(jar); // probably won't delete as the class loader will still have a reference to it?
 
     }
 

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsConsoleInstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/windows/WindowsConsoleInstallationTest.java
@@ -21,25 +21,6 @@
 
 package com.izforge.izpack.integration.windows;
 
-import static com.izforge.izpack.integration.windows.WindowsHelper.registryDeleteUninstallKey;
-import static com.izforge.izpack.integration.windows.WindowsHelper.registryKeyExists;
-import static com.izforge.izpack.integration.windows.WindowsHelper.registryValueStringEquals;
-import static com.izforge.izpack.util.Platform.Name.WINDOWS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.NativeLibException;
@@ -62,7 +43,19 @@ import com.izforge.izpack.test.util.TestConsole;
 import com.izforge.izpack.util.FileUtil;
 import com.izforge.izpack.util.Platforms;
 import com.izforge.izpack.util.PrivilegedRunner;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.izforge.izpack.integration.windows.WindowsHelper.*;
+import static com.izforge.izpack.util.Platform.Name.WINDOWS;
+import static org.junit.Assert.*;
 
 
 /**
@@ -191,7 +184,7 @@ public class WindowsConsoleInstallationTest extends AbstractConsoleInstallationT
     	if (getUninstallerJar() != null) {
             try {
                 // remove the uninstaller dir
-                FileUtils.deleteRecursively(getUninstallerJar().getParentFile());
+                FileUtils.deleteDirectory(getUninstallerJar().getParentFile());
             }
             catch (Exception ex) {
                 logger.log(Level.SEVERE, "Delete uninstaller directory failed.", ex);

--- a/izpack-uninstaller/pom.xml
+++ b/izpack-uninstaller/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/izpack-uninstaller/src/main/java/com/izforge/izpack/uninstaller/Uninstaller.java
+++ b/izpack-uninstaller/src/main/java/com/izforge/izpack/uninstaller/Uninstaller.java
@@ -19,15 +19,6 @@
 
 package com.izforge.izpack.uninstaller;
 
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.swing.JOptionPane;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-
 import com.izforge.izpack.core.resource.DefaultResources;
 import com.izforge.izpack.uninstaller.console.ConsoleUninstaller;
 import com.izforge.izpack.uninstaller.console.ConsoleUninstallerContainer;
@@ -35,11 +26,13 @@ import com.izforge.izpack.uninstaller.container.UninstallerContainer;
 import com.izforge.izpack.uninstaller.gui.GUIUninstallerContainer;
 import com.izforge.izpack.uninstaller.gui.UninstallerFrame;
 import com.izforge.izpack.uninstaller.resource.InstallLog;
-import com.izforge.izpack.util.Housekeeper;
-import com.izforge.izpack.util.Platform;
-import com.izforge.izpack.util.Platforms;
-import com.izforge.izpack.util.PrivilegedRunner;
-import com.izforge.izpack.util.SelfModifier;
+import com.izforge.izpack.util.*;
+
+import javax.swing.*;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The uninstaller class.

--- a/izpack-uninstaller/src/main/java/com/izforge/izpack/uninstaller/resource/InstallLog.java
+++ b/izpack-uninstaller/src/main/java/com/izforge/izpack/uninstaller/resource/InstallLog.java
@@ -21,19 +21,15 @@
 
 package com.izforge.izpack.uninstaller.resource;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import com.izforge.izpack.api.exception.IzPackException;
+import com.izforge.izpack.api.resource.Resources;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeSet;
-
-import com.izforge.izpack.api.exception.IzPackException;
-import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.util.file.FileUtils;
 
 
 /**
@@ -87,8 +83,8 @@ public class InstallLog
         }
         finally
         {
-            FileUtils.close(inReader);
-            FileUtils.close(in);
+            IOUtils.closeQuietly(inReader);
+            IOUtils.closeQuietly(in);
         }
     }
 
@@ -136,8 +132,8 @@ public class InstallLog
         }
         finally
         {
-            FileUtils.close(reader);
-            FileUtils.close(in);
+            IOUtils.closeQuietly(reader);
+            IOUtils.closeQuietly(in);
         }
         return installPath;
     }

--- a/izpack-uninstaller/src/main/java/com/izforge/izpack/uninstaller/resource/RootScripts.java
+++ b/izpack-uninstaller/src/main/java/com/izforge/izpack/uninstaller/resource/RootScripts.java
@@ -21,6 +21,14 @@
 
 package com.izforge.izpack.uninstaller.resource;
 
+import com.izforge.izpack.api.exception.IzPackException;
+import com.izforge.izpack.api.exception.ResourceNotFoundException;
+import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.installer.data.UninstallData;
+import com.izforge.izpack.util.Platform;
+import com.izforge.izpack.util.unix.ShellScript;
+import org.apache.commons.io.IOUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,14 +37,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.izforge.izpack.api.exception.IzPackException;
-import com.izforge.izpack.api.exception.ResourceNotFoundException;
-import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.installer.data.UninstallData;
-import com.izforge.izpack.util.Platform;
-import com.izforge.izpack.util.file.FileUtils;
-import com.izforge.izpack.util.unix.ShellScript;
 
 
 /**
@@ -123,7 +123,7 @@ public class RootScripts
                 }
                 finally
                 {
-                    FileUtils.close(in);
+                    IOUtils.closeQuietly(in);
                 }
             }
             catch (ResourceNotFoundException ignore)

--- a/izpack-util/pom.xml
+++ b/izpack-util/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom2</artifactId>
             <version>2.0.5</version>
@@ -54,12 +58,6 @@
             <artifactId>dtdparser</artifactId>
             <version>1.21</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-          <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/Librarian.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Librarian.java
@@ -21,6 +21,9 @@
 
 package com.izforge.izpack.util;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -31,8 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.izforge.izpack.util.file.FileUtils;
 
 /**
  * This class handles loading of native libraries. There must only be one instance of
@@ -312,7 +313,7 @@ public class Librarian implements CleanupClient
         String path = null;
         try
         {
-            file = FileUtils.createTempFile(name, extension);
+            file = File.createTempFile(name, extension, FileUtils.getTempDirectory());
             in = url.openStream();
             out = new FileOutputStream(file);
             IoHelper.copyStream(in, out);
@@ -324,8 +325,8 @@ public class Librarian implements CleanupClient
         }
         finally
         {
-            FileUtils.close(in);
-            FileUtils.close(out);
+            IOUtils.closeQuietly(in);
+            IOUtils.closeQuietly(out);
         }
         if (path != null)
         {
@@ -333,7 +334,7 @@ public class Librarian implements CleanupClient
         }
         if (!result)
         {
-            FileUtils.delete(file);
+            FileUtils.deleteQuietly(file);
         }
         else
         {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/SelfModifier.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/SelfModifier.java
@@ -21,14 +21,10 @@
 
 package com.izforge.izpack.util;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.io.RandomAccessFile;
+import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URI;
@@ -36,16 +32,10 @@ import java.net.URL;
 import java.text.CharacterIterator;
 import java.text.SimpleDateFormat;
 import java.text.StringCharacterIterator;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.List;
+import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
-
-import com.izforge.izpack.util.file.FileUtils;
 
 /**
  * Allows an application to modify the jar file from which it came, including outright deletion. The
@@ -577,8 +567,8 @@ public class SelfModifier
                     out.write(buf, 0, n);
                 }
 
-                FileUtils.close(out);
-                FileUtils.close(in);
+                IOUtils.closeQuietly(out);
+                IOUtils.closeQuietly(in);
                 extracted++;
             }
             log("Extracted " + extracted + " file" + (extracted > 1 ? "s" : "") + " into "
@@ -586,9 +576,19 @@ public class SelfModifier
         }
         finally
         {
-            FileUtils.close(jar);
-            FileUtils.close(out);
-            FileUtils.close(in);
+            if (jar != null)
+            {
+                try
+                {
+                    jar.close();
+                }
+                catch (IOException ignore)
+                {
+                    // do nothing
+                }
+            }
+            IOUtils.closeQuietly(out);
+            IOUtils.closeQuietly(in);
         }
     }
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/ConfigurableFileCopyTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/ConfigurableFileCopyTask.java
@@ -22,12 +22,13 @@
 
 package com.izforge.izpack.util.config;
 
+import com.izforge.izpack.util.file.FileCopyTask;
+import com.izforge.izpack.util.file.FileUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.logging.Logger;
-
-import com.izforge.izpack.util.file.FileCopyTask;
 
 public abstract class ConfigurableFileCopyTask extends FileCopyTask implements ConfigurableTask
 {
@@ -149,7 +150,7 @@ public abstract class ConfigurableFileCopyTask extends FileCopyTask implements C
                         doFileOperation(from, to, toTmp, patchPreserveEntries,
                                 patchPreserveValues, patchResolveVariables);
 
-                        getFileUtils().copyFile(toTmp, to, forceOverwrite, preserveLastModified);
+                        FileUtils.copyFile(toTmp, to, forceOverwrite, preserveLastModified);
                         if (cleanup && from.exists())
                         {
                             if (!from.delete())

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/DirectoryScanner.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/DirectoryScanner.java
@@ -17,23 +17,15 @@
 
 package com.izforge.izpack.util.file;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
-
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.util.file.types.Resource;
 import com.izforge.izpack.util.file.types.ResourceFactory;
 import com.izforge.izpack.util.file.types.selectors.FileSelector;
 import com.izforge.izpack.util.file.types.selectors.SelectorUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Class for scanning a directory for files/directories which match certain
@@ -164,11 +156,6 @@ public class DirectoryScanner
             // Mac
             "**/.DS_Store"
     };
-
-    /**
-     * Helper.
-     */
-    private static final FileUtils FILE_UTILS = FileUtils.getFileUtils();
 
     /**
      * iterations for case-sensitive scanning.
@@ -899,7 +886,7 @@ public class DirectoryScanner
                     try
                     {
                         File canonFile = myfile.getCanonicalFile();
-                        String path = FILE_UTILS.removeLeadingPath(canonBase,
+                        String path = FileUtils.removeLeadingPath(canonBase,
                                 canonFile);
                         if (!path.equals(currentelement)/* || ON_VMS*/)
                         {
@@ -907,7 +894,7 @@ public class DirectoryScanner
                             if (myfile != null)
                             {
                                 currentelement =
-                                        FILE_UTILS.removeLeadingPath(basedir,
+                                        FileUtils.removeLeadingPath(basedir,
                                                 myfile);
                             }
                         }
@@ -924,7 +911,7 @@ public class DirectoryScanner
                     {
                         // adapt currentelement to the case we've
                         // actually found
-                        currentelement = FILE_UTILS.removeLeadingPath(basedir,
+                        currentelement = FileUtils.removeLeadingPath(basedir,
                                 f);
                         myfile = f;
                     }
@@ -1130,7 +1117,7 @@ public class DirectoryScanner
             {
                 try
                 {
-                    if (FILE_UTILS.isSymbolicLink(dir, newfile))
+                    if (FileUtils.isSymbolicLink(dir, newfile))
                     {
                         String name = vpath + newfile;
                         File file = new File(dir, newfile);
@@ -1630,7 +1617,7 @@ public class DirectoryScanner
      */
     public synchronized Resource getResource(String name) throws Exception
     {
-        File f = FILE_UTILS.resolveFile(basedir, name);
+        File f = FileUtils.resolveFile(basedir, name);
         return new Resource(name, f.exists(), f.lastModified(),
                 f.isDirectory(), f.length());
     }
@@ -1738,7 +1725,7 @@ public class DirectoryScanner
             String current = pathElements.remove(0);
             try
             {
-                return FILE_UTILS.isSymbolicLink(base, current)
+                return FileUtils.isSymbolicLink(base, current)
                         || isSymlink(new File(base, current), pathElements);
             }
             catch (IOException ioe)

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/FileCopyTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/FileCopyTask.java
@@ -59,7 +59,6 @@ public class FileCopyTask
     protected Hashtable<File, File> completeDirMap = new Hashtable<File, File>();
 
     protected Mapper mapperElement = null;
-    protected FileUtils fileUtils;
     private long granularity = 0;
 
     /**
@@ -67,16 +66,7 @@ public class FileCopyTask
      */
     public FileCopyTask()
     {
-        fileUtils = FileUtils.getFileUtils();
-        granularity = fileUtils.getFileTimestampGranularity();
-    }
-
-    /**
-     * @return the fileutils object
-     */
-    protected FileUtils getFileUtils()
-    {
-        return fileUtils;
+        granularity = FileUtils.getFileTimestampGranularity();
     }
 
     /**
@@ -457,7 +447,7 @@ public class FileCopyTask
 
         if (destFile != null)
         {
-            destDir = fileUtils.getParentFile(destFile);
+            destDir = FileUtils.getParentFile(destFile);
         }
 
     }
@@ -582,7 +572,7 @@ public class FileCopyTask
                     try
                     {
                         logger.fine("Copying " + fromFile + " to " + toFile);
-                        fileUtils.copyFile(fromFile, toFile, forceOverwrite,
+                        FileUtils.copyFile(fromFile, toFile, forceOverwrite,
                                 preserveLastModified);
                     }
                     catch (IOException ioe)

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/FileUtils.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/FileUtils.java
@@ -18,26 +18,10 @@
 package com.izforge.izpack.util.file;
 
 import com.izforge.izpack.util.OsVersion;
+import org.apache.commons.io.FilenameUtils;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.text.CharacterIterator;
-import java.text.DecimalFormat;
-import java.text.StringCharacterIterator;
-import java.util.Random;
-import java.util.Stack;
-import java.util.StringTokenizer;
-import java.util.zip.ZipFile;
 
 /**
  * This class also encapsulates methods which allow Files to be
@@ -48,20 +32,6 @@ import java.util.zip.ZipFile;
 
 public class FileUtils
 {
-
-    private static final FileUtils PRIMARY_INSTANCE = new FileUtils();
-
-    //get some non-crypto-grade randomness from various places.
-    private static Random rand = new Random(System.currentTimeMillis()
-            + Runtime.getRuntime().freeMemory());
-
-    private static final int BUF_SIZE = 8192;
-
-    // for toURI
-    private static boolean[] isSpecial = new boolean[256];
-    private static char[] escapedChar1 = new char[256];
-    private static char[] escapedChar2 = new char[256];
-
     /**
      * The granularity of timestamps under FAT.
      */
@@ -71,89 +41,6 @@ public class FileUtils
      * The granularity of timestamps under Unix.
      */
     public static final long UNIX_FILE_TIMESTAMP_GRANULARITY = 1000;
-
-
-    // stolen from FilePathToURI of the Xerces-J team
-
-    static
-    {
-        for (int i = 0; i <= 0x20; i++)
-        {
-            isSpecial[i] = true;
-            escapedChar1[i] = Character.forDigit(i >> 4, 16);
-            escapedChar2[i] = Character.forDigit(i & 0xf, 16);
-        }
-        isSpecial[0x7f] = true;
-        escapedChar1[0x7f] = '7';
-        escapedChar2[0x7f] = 'F';
-        char[] escChs = {'<', '>', '#', '%', '"', '{', '}',
-                '|', '\\', '^', '~', '[', ']', '`'};
-        int len = escChs.length;
-        char ch;
-        for (int i = 0; i < len; i++)
-        {
-            ch = escChs[i];
-            isSpecial[ch] = true;
-            escapedChar1[ch] = Character.forDigit(ch >> 4, 16);
-            escapedChar2[ch] = Character.forDigit(ch & 0xf, 16);
-        }
-    }
-
-    /**
-     * Wrapper around java.io.File#createTempFile(String, String) that caters for
-     * Mac OS X issues with "+" characters ending up in paths. It delegates to
-     * java.io.File.createTempFile(String, String) on every platform but Mac OS X, where
-     * it delegates to java.io.File.createTempFile(String, String, new File("/tmp").
-     *
-     * @param prefix temporary file prefix
-     * @param suffix temporary file suffix
-     * @return a temporary file
-     * @throws java.io.IOException when a temporary file cannot be allocated
-     * @see java.io.File#createTempFile(String, String)
-     */
-    public static File createTempFile(String prefix, String suffix) throws IOException
-    {
-        if (OsVersion.IS_OSX)
-        {
-            return File.createTempFile(prefix, suffix, new File("/tmp"));
-        }
-        else
-        {
-            return File.createTempFile(prefix, suffix);
-        }
-    }
-
-    /**
-     * Method to retrieve The FileUtils, which is shared by all users of this
-     * method.
-     *
-     * @return an instance of FileUtils.
-     */
-    public static FileUtils getFileUtils()
-    {
-        return PRIMARY_INSTANCE;
-    }
-
-    /**
-     * Empty constructor.
-     */
-    protected FileUtils()
-    {
-    }
-
-    /**
-     * Get the URL for a file taking into account # characters.
-     *
-     * @param file the file whose URL representation is required.
-     * @return The FileURL value.
-     * @throws MalformedURLException if the URL representation cannot be
-     *                               formed.
-     */
-    @Deprecated
-    public URL getFileURL(File file) throws MalformedURLException
-    {
-        return new URL(toURI(file.getAbsolutePath()));
-    }
 
     /**
      * Convenience method to copy a file from a source to a destination.
@@ -165,26 +52,11 @@ public class FileUtils
      *                   Must not be <code>null</code>.
      * @throws IOException if the copying fails.
      */
-    public void copyFile(String sourceFile, String destFile,
+    public static void copyFile(String sourceFile, String destFile,
                          boolean overwrite, boolean preserveLastModified)
             throws IOException
     {
         copyFile(new File(sourceFile), new File(destFile), overwrite, preserveLastModified);
-    }
-
-    /**
-     * Convenience method to copy a file from a source to a destination.
-     * No filtering is performed.
-     *
-     * @param sourceFile the file to copy from.
-     *                   Must not be <code>null</code>.
-     * @param destFile   the file to copy to.
-     *                   Must not be <code>null</code>.
-     * @throws IOException if the copying fails.
-     */
-    public void copyFile(File sourceFile, File destFile) throws IOException
-    {
-        copyFile(sourceFile, destFile, false, false);
     }
 
     /**
@@ -199,23 +71,14 @@ public class FileUtils
      *                             Must not be <code>null</code>.
      * @param destFile             the file to copy to.
      *                             Must not be <code>null</code>.
-     * @param filters              the collection of filters to apply to this copy.
-     * @param filterChains         filterChains to apply during the copy.
      * @param overwrite            Whether or not the destination file should be
      *                             overwritten if it already exists.
      * @param preserveLastModified Whether or not the last modified time of
      *                             the resulting file should be set to that
      *                             of the source file.
-     * @param inputEncoding        the encoding used to read the files.
-     * @param outputEncoding       the encoding used to write the files.
-     * @param project              the project instance.
      * @throws IOException if the copying fails.
      */
-    public void copyFile(File sourceFile, File destFile,
-                         /*FilterSetCollection filters, Vector filterChains,*/
-                         boolean overwrite, boolean preserveLastModified
-                         /*String inputEncoding, String outputEncoding,
-                         Project project*/)
+    public static void copyFile(File sourceFile, File destFile, boolean overwrite, boolean preserveLastModified)
             throws IOException
     {
 
@@ -235,46 +98,8 @@ public class FileUtils
                 parent.mkdirs();
             }
 
-            FileInputStream in = null;
-            FileOutputStream out = null;
-            try
-            {
-                in = new FileInputStream(sourceFile);
-                out = new FileOutputStream(destFile);
-
-                byte[] buffer = new byte[BUF_SIZE];
-                int count = 0;
-                do
-                {
-                    out.write(buffer, 0, count);
-                    count = in.read(buffer, 0, buffer.length);
-                }
-                while (count != -1);
-            }
-            finally
-            {
-                close(out);
-                close(in);
-            }
-
-            if (preserveLastModified)
-            {
-                setFileLastModified(destFile, sourceFile.lastModified());
-            }
+            org.apache.commons.io.FileUtils.copyFile(sourceFile, destFile, preserveLastModified);
         }
-    }
-
-    /**
-     * Calls File.setLastModified(long time). Originally written to
-     * to dynamically bind to that call on Java1.2+.
-     *
-     * @param file the file whose modified time is to be set
-     * @param time the time to which the last modified time is to be set.
-     *             if this is -1, the current time is used.
-     */
-    public void setFileLastModified(File file, long time)
-    {
-        file.setLastModified((time < 0) ? System.currentTimeMillis() : time);
     }
 
     /**
@@ -291,459 +116,9 @@ public class FileUtils
      *         &quot;../&quot; sequences and uses the correct separator for
      *         the current platform.
      */
-    public File resolveFile(File file, String filename) throws Exception
+    public static File resolveFile(File file, String filename) throws Exception
     {
-        filename = filename.replace('/', File.separatorChar)
-                .replace('\\', File.separatorChar);
-
-        // deal with absolute files
-        if (isAbsolutePath(filename))
-        {
-            return normalize(filename);
-        }
-        if (file == null)
-        {
-            return new File(filename);
-        }
-        File helpFile = new File(file.getAbsolutePath());
-        StringTokenizer tok = new StringTokenizer(filename, File.separator);
-        while (tok.hasMoreTokens())
-        {
-            String part = tok.nextToken();
-            if (part.equals(".."))
-            {
-                helpFile = helpFile.getParentFile();
-                if (helpFile == null)
-                {
-                    String msg = "The file or path you specified ("
-                            + filename + ") is invalid relative to "
-                            + file.getPath();
-                    throw new Exception(msg);
-                }
-            }
-            else if (part.equals("."))
-            {
-                // Do nothing here
-            }
-            else
-            {
-                helpFile = new File(helpFile, part);
-            }
-        }
-        return new File(helpFile.getAbsolutePath());
-    }
-
-    /**
-     * Verifies that the specified filename represents an absolute path.
-     *
-     * @param filename the filename to be checked.
-     * @return true if the filename represents an absolute path.
-     */
-    public static boolean isAbsolutePath(String filename)
-    {
-        if (filename.startsWith(File.separator))
-        {
-            // common for all os
-            return true;
-        }
-        if (OsVersion.IS_WINDOWS && filename.length() >= 2
-                && Character.isLetter(filename.charAt(0))
-                && filename.charAt(1) == ':')
-        {
-            // Actually on windows the : must be followed by a \ for
-            // the path to be absolute, else the path is relative
-            // to the current working directory on that drive.
-            // (Every drive may have another current working directory)
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * &quot;Normalize&quot; the given absolute path.
-     * <p/>
-     * <p>This includes:
-     * <ul>
-     * <li>Uppercase the drive letter if there is one.</li>
-     * <li>Remove redundant slashes after the drive spec.</li>
-     * <li>Resolve all ./, .\, ../ and ..\ sequences.</li>
-     * <li>DOS style paths that start with a drive letter will have
-     * \ as the separator.</li>
-     * </ul>
-     * Unlike <code>File#getCanonicalPath()</code> this method
-     * specifically does not resolve symbolic links.
-     *
-     * @param path the path to be normalized.
-     * @return the normalized version of the path.
-     * @throws java.lang.NullPointerException if the file path is
-     *                                        equal to null.
-     */
-    public File normalize(String path) throws Exception
-    {
-        String orig = path;
-
-        path = path.replace('/', File.separatorChar)
-                .replace('\\', File.separatorChar);
-
-        // make sure we are dealing with an absolute path
-        int colon = path.indexOf(":");
-
-        if (!isAbsolutePath(path))
-        {
-            String msg = path + " is not an absolute path";
-            throw new Exception(msg);
-        }
-        boolean dosWithDrive = false;
-        String root = null;
-        // Eliminate consecutive slashes after the drive spec
-        if ((OsVersion.IS_WINDOWS && path.length() >= 2
-                && Character.isLetter(path.charAt(0))
-                && path.charAt(1) == ':'))
-        {
-
-            dosWithDrive = true;
-
-            char[] ca = path.replace('/', '\\').toCharArray();
-            StringBuffer sbRoot = new StringBuffer();
-            for (int i = 0; i < colon; i++)
-            {
-                sbRoot.append(Character.toUpperCase(ca[i]));
-            }
-            sbRoot.append(':');
-            if (colon + 1 < path.length())
-            {
-                sbRoot.append(File.separatorChar);
-            }
-            root = sbRoot.toString();
-
-            // Eliminate consecutive slashes after the drive spec
-            StringBuffer sbPath = new StringBuffer();
-            for (int i = colon + 1; i < ca.length; i++)
-            {
-                if ((ca[i] != '\\')
-                        || (ca[i] == '\\' && ca[i - 1] != '\\'))
-                {
-                    sbPath.append(ca[i]);
-                }
-            }
-            path = sbPath.toString().replace('\\', File.separatorChar);
-        }
-        else
-        {
-            if (path.length() == 1)
-            {
-                root = File.separator;
-                path = "";
-            }
-            else if (path.charAt(1) == File.separatorChar)
-            {
-                // UNC drive
-                root = File.separator + File.separator;
-                path = path.substring(2);
-            }
-            else
-            {
-                root = File.separator;
-                path = path.substring(1);
-            }
-        }
-        Stack<String> s = new Stack<String>();
-        s.push(root);
-        StringTokenizer tok = new StringTokenizer(path, File.separator);
-        while (tok.hasMoreTokens())
-        {
-            String thisToken = tok.nextToken();
-            if (".".equals(thisToken))
-            {
-                continue;
-            }
-            else if ("..".equals(thisToken))
-            {
-                if (s.size() < 2)
-                {
-                    throw new Exception("Cannot resolve path " + orig);
-                }
-                else
-                {
-                    s.pop();
-                }
-            }
-            else
-            { // plain component
-                s.push(thisToken);
-            }
-        }
-        StringBuffer sb = new StringBuffer();
-        for (int i = 0; i < s.size(); i++)
-        {
-            if (i > 1)
-            {
-                // not before the filesystem root and not after it, since root
-                // already contains one
-                sb.append(File.separatorChar);
-            }
-            sb.append(s.elementAt(i));
-        }
-        path = sb.toString();
-        if (dosWithDrive)
-        {
-            path = path.replace('/', '\\');
-        }
-        return new File(path);
-    }
-
-    /**
-     * Returns a VMS String representation of a <code>File</code> object.
-     * This is useful since the JVM by default internally converts VMS paths
-     * to Unix style.
-     * The returned String is always an absolute path.
-     *
-     * @param f The <code>File</code> to get the VMS path for.
-     * @return The absolute VMS path to <code>f</code>.
-     */
-    @Deprecated
-    public String toVMSPath(File f) throws Exception
-    {
-        // format: "DEVICE:[DIR.SUBDIR]FILE"
-        String osPath;
-        String path = normalize(f.getAbsolutePath()).getPath();
-        String name = f.getName();
-        boolean isAbsolute = path.charAt(0) == File.separatorChar;
-        // treat directories specified using .DIR syntax as files
-        boolean isDirectory = f.isDirectory()
-                && !name.regionMatches(true, name.length() - 4, ".DIR", 0, 4);
-
-        String device = null;
-        StringBuffer directory = null;
-        String file = null;
-
-        int index = 0;
-
-        if (isAbsolute)
-        {
-            index = path.indexOf(File.separatorChar, 1);
-            if (index == -1)
-            {
-                return path.substring(1) + ":[000000]";
-            }
-            else
-            {
-                device = path.substring(1, index++);
-            }
-        }
-        if (isDirectory)
-        {
-            directory = new StringBuffer(path.substring(index).
-                    replace(File.separatorChar, '.'));
-        }
-        else
-        {
-            int dirEnd =
-                    path.lastIndexOf(File.separatorChar, path.length());
-            if (dirEnd == -1 || dirEnd < index)
-            {
-                file = path.substring(index);
-            }
-            else
-            {
-                directory = new StringBuffer(path.substring(index, dirEnd).
-                        replace(File.separatorChar, '.'));
-                index = dirEnd + 1;
-                if (path.length() > index)
-                {
-                    file = path.substring(index);
-                }
-            }
-        }
-        if (!isAbsolute && directory != null)
-        {
-            directory.insert(0, '.');
-        }
-        osPath = ((device != null) ? device + ":" : "")
-                + ((directory != null) ? "[" + directory + "]" : "")
-                + ((file != null) ? file : "");
-        return osPath;
-    }
-
-    /**
-     * Create a temporary file in a given directory.
-     * <p/>
-     * <p>The file denoted by the returned abstract pathname did not
-     * exist before this method was invoked, any subsequent invocation
-     * of this method will yield a different file name.</p>
-     * <p>
-     * The filename is prefixNNNNNsuffix where NNNN is a random number.
-     * </p>
-     * <p>This method is different from File.createTempFile() of JDK 1.2
-     * as it doesn't create the file itself.  It uses the location pointed
-     * to by java.io.tmpdir when the parentDir attribute is null.</p>
-     *
-     * @param prefix    prefix before the random number.
-     * @param suffix    file extension; include the '.'.
-     * @param parentDir Directory to create the temporary file in;
-     *                  java.io.tmpdir used if not specified.
-     * @return a File reference to the new temporary file.
-     */
-    @Deprecated
-    public File createTempFile(String prefix, String suffix, File parentDir)
-    {
-        File result = null;
-        String parent = (parentDir == null)
-                ? System.getProperty("java.io.tmpdir")
-                : parentDir.getPath();
-
-        DecimalFormat fmt = new DecimalFormat("#####");
-        synchronized (rand)
-        {
-            do
-            {
-                result = new File(parent,
-                        prefix + fmt.format(Math.abs(rand.nextInt()))
-                                + suffix);
-            }
-            while (result.exists());
-        }
-        return result;
-    }
-
-    /**
-     * Compares the contents of two files.
-     *
-     * @param f1 the file whose content is to be compared.
-     * @param f2 the other file whose content is to be compared.
-     * @return true if the content of the files is the same.
-     * @throws IOException if the files cannot be read.
-     */
-    public boolean contentEquals(File f1, File f2) throws Exception
-    {
-        return contentEquals(f1, f2, false);
-    }
-
-    /**
-     * Compares the contents of two files.
-     *
-     * @param f1       the file whose content is to be compared.
-     * @param f2       the other file whose content is to be compared.
-     * @param textfile true if the file is to be treated as a text file and
-     *                 differences in kind of line break are to be ignored.
-     * @return true if the content of the files is the same.
-     * @throws IOException if the files cannot be read.
-     */
-    public boolean contentEquals(File f1, File f2, boolean textfile) throws Exception
-    {
-        if (f1.exists() != f2.exists())
-        {
-            return false;
-        }
-        if (!f1.exists())
-        {
-            // two not existing files are equal
-            return true;
-        }
-        // should the following two be switched?  If f1 and f2 refer to the same file,
-        // isn't their content equal regardless of whether that file is a directory?
-        if (f1.isDirectory() || f2.isDirectory())
-        {
-            // don't want to compare directory contents for now
-            return false;
-        }
-        if (fileNameEquals(f1, f2))
-        {
-            // same filename => true
-            return true;
-        }
-        return textfile ? textEquals(f1, f2) : binaryEquals(f1, f2);
-    }
-
-    /**
-     * Binary compares the contents of two files.
-     * <p>
-     * simple but sub-optimal comparision algorithm. written for working
-     * rather than fast. Better would be a block read into buffers followed
-     * by long comparisions apart from the final 1-7 bytes.
-     * </p>
-     *
-     * @param f1 the file whose content is to be compared.
-     * @param f2 the other file whose content is to be compared.
-     * @return true if the content of the files is the same.
-     * @throws IOException if the files cannot be read.
-     */
-    private boolean binaryEquals(File f1, File f2) throws IOException
-    {
-        if (f1.length() != f2.length())
-        {
-            // different size =>false
-            return false;
-        }
-
-        InputStream in1 = null;
-        InputStream in2 = null;
-        try
-        {
-            in1 = new BufferedInputStream(new FileInputStream(f1));
-            in2 = new BufferedInputStream(new FileInputStream(f2));
-
-            int expectedByte = in1.read();
-            while (expectedByte != -1)
-            {
-                if (expectedByte != in2.read())
-                {
-                    return false;
-                }
-                expectedByte = in1.read();
-            }
-            if (in2.read() != -1)
-            {
-                return false;
-            }
-            return true;
-        }
-        finally
-        {
-            close(in1);
-            close(in2);
-        }
-    }
-
-    /**
-     * Text compares the contents of two files.
-     * <p/>
-     * Ignores different kinds of line endings.
-     *
-     * @param f1 the file whose content is to be compared.
-     * @param f2 the other file whose content is to be compared.
-     * @return true if the content of the files is the same.
-     * @throws IOException if the files cannot be read.
-     */
-    private boolean textEquals(File f1, File f2) throws IOException
-    {
-        BufferedReader in1 = null;
-        BufferedReader in2 = null;
-        try
-        {
-            in1 = new BufferedReader(new FileReader(f1));
-            in2 = new BufferedReader(new FileReader(f2));
-
-            String expected = in1.readLine();
-            while (expected != null)
-            {
-                if (!expected.equals(in2.readLine()))
-                {
-                    return false;
-                }
-                expected = in1.readLine();
-            }
-            if (in2.readLine() != null)
-            {
-                return false;
-            }
-            return true;
-        }
-        finally
-        {
-            close(in1);
-            close(in2);
-        }
+        return new File(FilenameUtils.concat(file==null?null:file.getPath(), filename));
     }
 
     /**
@@ -754,70 +129,9 @@ public class FileUtils
      * @return the given file's parent, or null if the file does not have a
      *         parent.
      */
-    public File getParentFile(File f)
+    public static File getParentFile(File f)
     {
         return (f == null) ? null : f.getParentFile();
-    }
-
-    /**
-     * Read from reader till EOF.
-     *
-     * @param rdr the reader from which to read.
-     * @return the contents read out of the given reader.
-     * @throws IOException if the contents could not be read out from the
-     *                     reader.
-     */
-    public static final String readFully(Reader rdr) throws IOException
-    {
-        return readFully(rdr, BUF_SIZE);
-    }
-
-    /**
-     * Read from reader till EOF.
-     *
-     * @param rdr        the reader from which to read.
-     * @param bufferSize the buffer size to use when reading.
-     * @return the contents read out of the given reader.
-     * @throws IOException if the contents could not be read out from the
-     *                     reader.
-     */
-    public static final String readFully(Reader rdr, int bufferSize)
-            throws IOException
-    {
-        if (bufferSize <= 0)
-        {
-            throw new IllegalArgumentException("Buffer size must be greater "
-                    + "than 0");
-        }
-        final char[] buffer = new char[bufferSize];
-        int bufferLength = 0;
-        StringBuffer textBuffer = null;
-        while (bufferLength != -1)
-        {
-            bufferLength = rdr.read(buffer);
-            if (bufferLength > 0)
-            {
-                textBuffer = (textBuffer == null) ? new StringBuffer() : textBuffer;
-                textBuffer.append(new String(buffer, 0, bufferLength));
-            }
-        }
-        return (textBuffer == null) ? null : textBuffer.toString();
-    }
-
-    /**
-     * This was originally an emulation of File.createNewFile for JDK 1.1,
-     * but it is now implemented using that method (Ant 1.6.3 onwards).
-     * <p/>
-     * <p>This method has historically <strong>not</strong> guaranteed that the
-     * operation was atomic. In its current implementation it is.
-     *
-     * @param f the file to be created.
-     * @return true if the file did not exist already.
-     * @throws IOException on error.
-     */
-    public boolean createNewFile(File f) throws IOException
-    {
-        return f.createNewFile();
     }
 
     /**
@@ -828,7 +142,7 @@ public class FileUtils
      * @return true if the file did not exist already.
      * @throws IOException on error.
      */
-    public boolean createNewFile(File f, boolean mkdirs) throws IOException
+    public static boolean createNewFile(File f, boolean mkdirs) throws IOException
     {
         File parent = f.getParentFile();
         if (mkdirs && !(parent.exists()))
@@ -850,7 +164,7 @@ public class FileUtils
      * @return true if the file is a symbolic link.
      * @throws IOException on error.
      */
-    public boolean isSymbolicLink(File parent, String name)
+    public static boolean isSymbolicLink(File parent, String name)
             throws IOException
     {
         if (parent == null)
@@ -860,7 +174,7 @@ public class FileUtils
             name = f.getName();
         }
         File toTest = new File(parent.getCanonicalPath(), name);
-        return !toTest.getAbsolutePath().equals(toTest.getCanonicalPath());
+        return org.apache.commons.io.FileUtils.isSymlink(toTest);
     }
 
     /**
@@ -871,10 +185,10 @@ public class FileUtils
      * @return path's normalized absolute if it doesn't start with
      *         leading; path's path with leading's path removed otherwise.
      */
-    public String removeLeadingPath(File leading, File path) throws Exception
+    public static String removeLeadingPath(File leading, File path) throws Exception
     {
-        String l = normalize(leading.getAbsolutePath()).getAbsolutePath();
-        String p = normalize(path.getAbsolutePath()).getAbsolutePath();
+        String l = FilenameUtils.normalize(leading.getAbsolutePath());
+        String p = FilenameUtils.normalize(path.getAbsolutePath());
         if (l.equals(p))
         {
             return "";
@@ -890,119 +204,6 @@ public class FileUtils
     }
 
     /**
-     * Constructs a <code>file:</code> URI that represents the
-     * external form of the given pathname.
-     * <p/>
-     * <p>Will be an absolute URI if the given path is absolute.</p>
-     * <p/>
-     * <p>This code doesn't handle non-ASCII characters properly.</p>
-     *
-     * @param path the path in the local file system.
-     * @return the URI version of the local path.
-     */
-    @Deprecated
-    public String toURI(String path)
-    {
-        boolean isDir = (new File(path)).isDirectory();
-
-        StringBuffer sb = new StringBuffer("file:");
-
-        // catch exception if normalize thinks this is not an absolute path
-        try
-        {
-            path = normalize(path).getAbsolutePath();
-            sb.append("//");
-            // add an extra slash for filesystems with drive-specifiers
-            if (!path.startsWith(File.separator))
-            {
-                sb.append("/");
-            }
-        }
-        catch (Exception e)
-        {
-            // relative path
-        }
-
-        path = path.replace('\\', '/');
-
-        CharacterIterator iter = new StringCharacterIterator(path);
-        for (char c = iter.first(); c != CharacterIterator.DONE;
-             c = iter.next())
-        {
-            if (c < 256 && isSpecial[c])
-            {
-                sb.append('%');
-                sb.append(escapedChar1[c]);
-                sb.append(escapedChar2[c]);
-            }
-            else
-            {
-                sb.append(c);
-            }
-        }
-        if (isDir && !path.endsWith("/"))
-        {
-            sb.append('/');
-        }
-        return sb.toString();
-    }
-
-    /**
-     * Compares two filenames.
-     * <p/>
-     * <p>Unlike java.io.File#equals this method will try to compare
-     * the absolute paths and &quot;normalize&quot; the filenames
-     * before comparing them.</p>
-     *
-     * @param f1 the file whose name is to be compared.
-     * @param f2 the other file whose name is to be compared.
-     * @return true if the file are for the same file.
-     */
-    public boolean fileNameEquals(File f1, File f2) throws Exception
-    {
-        return normalize(f1.getAbsolutePath())
-                .equals(normalize(f2.getAbsolutePath()));
-    }
-
-    /**
-     * Renames a file, even if that involves crossing file system boundaries.
-     * <p/>
-     * <p>This will remove <code>to</code> (if it exists), ensure that
-     * <code>to</code>'s parent directory exists and move
-     * <code>from</code>, which involves deleting <code>from</code> as
-     * well.</p>
-     *
-     * @param from the file to move.
-     * @param to   the new file name.
-     * @throws IOException if anything bad happens during this
-     *                     process.  Note that <code>to</code> may have been deleted
-     *                     already when this happens.
-     */
-    public void rename(File from, File to) throws IOException
-    {
-        if (to.exists() && !to.delete())
-        {
-            throw new IOException("Failed to delete " + to
-                    + " while trying to rename " + from);
-        }
-        File parent = to.getParentFile();
-        if (parent != null && !parent.exists() && !parent.mkdirs())
-        {
-            throw new IOException("Failed to create directory " + parent
-                    + " while trying to rename " + from);
-        }
-        if (!from.renameTo(to))
-        {
-            copyFile(from, to);
-            if (!from.delete())
-            {
-                throw new IOException("Failed to delete " + from
-                        + " while trying to rename it.");
-            }
-        }
-    }
-
-    /**
      * Get the granularity of file timestamps.
      * The choice is made based on OS, which is incorrect--it should really be
      * by filesystem. We do not have an easy way to probe for file systems,
@@ -1011,158 +212,10 @@ public class FileUtils
      * @return the difference, in milliseconds, which two file timestamps must have
      *         in order for the two files to be given a creation order.
      */
-    public long getFileTimestampGranularity()
+    public static long getFileTimestampGranularity()
     {
         return OsVersion.IS_WINDOWS
                 ? FAT_FILE_TIMESTAMP_GRANULARITY : UNIX_FILE_TIMESTAMP_GRANULARITY;
     }
-
-    /**
-     * Returns true if the source is older than the dest.
-     * If the dest file does not exist, then the test returns false; it is
-     * implicitly not up do date.
-     *
-     * @param source      source file (should be the older).
-     * @param dest        dest file (should be the newer).
-     * @param granularity an offset added to the source time.
-     * @return true if the source is older than the dest after accounting
-     *         for granularity.
-     */
-    public boolean isUpToDate(File source, File dest, long granularity)
-    {
-        //do a check for the destination file existing
-        if (!dest.exists())
-        {
-            //if it does not, then the file is not up to date.
-            return false;
-        }
-        long sourceTime = source.lastModified();
-        long destTime = dest.lastModified();
-        return isUpToDate(sourceTime, destTime, granularity);
-    }
-
-
-    /**
-     * Returns true if the source is older than the dest.
-     *
-     * @param source source file (should be the older).
-     * @param dest   dest file (should be the newer).
-     * @return true if the source is older than the dest, taking the granularity into account.
-     */
-    public boolean isUpToDate(File source, File dest)
-    {
-        return isUpToDate(source, dest, getFileTimestampGranularity());
-    }
-
-    /**
-     * Compare two timestamps for being up to date using
-     * the specified granularity.
-     *
-     * @param sourceTime  timestamp of source file.
-     * @param destTime    timestamp of dest file.
-     * @param granularity os/filesys granularity.
-     * @return true if the dest file is considered up to date.
-     */
-    public boolean isUpToDate(long sourceTime, long destTime, long granularity)
-    {
-        if (destTime == -1)
-        {
-            return false;
-        }
-        return destTime >= sourceTime + granularity;
-    }
-
-    /**
-     * Compare two timestamps for being up to date using the
-     * current granularity.
-     *
-     * @param sourceTime timestamp of source file.
-     * @param destTime   timestamp of dest file.
-     * @return true if the dest file is considered up to date.
-     */
-    public boolean isUpToDate(long sourceTime, long destTime)
-    {
-        return isUpToDate(sourceTime, destTime, getFileTimestampGranularity());
-    }
-
-    /**
-     * Unconditionally close a <tt>Closable</tt>.
-     * <p/>
-     * Equivalent to {@link Closeable#close()}, except any exceptions will be ignored.
-     * This is typically used in finally blocks.
-     *
-     * @param closeable the <tt>Closable</tt>to close. May be <tt>null</tt> or already closed
-     */
-    public static void close(Closeable closeable)
-    {
-        if (closeable != null)
-        {
-            try
-            {
-                closeable.close();
-            }
-            catch (IOException ignore)
-            {
-                // do nothing
-            }
-        }
-    }
-
-    /**
-     * Unconditionally close a <tt>ZipFile</tt>.
-     * <p/>
-     * Equivalent to {@link ZipFile#close()}, except any exceptions will be ignored.
-     * This is typically used in finally blocks.
-     *
-     * @param file the <tt>ZipFile</tt>to close. May be <tt>null</tt> or already closed
-     */
-    public static void close(ZipFile file)
-    {
-        if (file != null)
-        {
-            try
-            {
-                file.close();
-            }
-            catch (IOException ignore)
-            {
-                // do nothing
-            }
-        }
-    }
-
-    /**
-     * Delete the file with {@link File#delete()} if the argument is not null.
-     * Do nothing on a null argument.
-     *
-     * @param file file to delete.
-     */
-    public static void delete(File file)
-    {
-        if (file != null)
-        {
-            file.delete();
-        }
-    }
-
-    /**
-     * Delete a directory recursively
-     *
-     * @param fileToDelete
-     */
-    public static boolean deleteRecursively(File fileToDelete)
-    {
-        boolean retval = true;
-        if (fileToDelete.isDirectory())
-        {
-            for (File fileInDir : fileToDelete.listFiles())
-            {
-                retval &= deleteRecursively(fileInDir);
-            }
-        }
-        retval &= fileToDelete.delete();
-        return retval;
-    }
-
 
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/ResourceUtils.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/ResourceUtils.java
@@ -36,7 +36,6 @@ public class ResourceUtils
      * tells which source files should be reprocessed based on the
      * last modification date of target files
      *
-     * @param logTo   where to send (more or less) interesting output
      * @param source  array of resources bearing relative path and last
      *                modification date
      * @param mapper  filename mapper indicating how to find the target
@@ -53,15 +52,13 @@ public class ResourceUtils
             throws Exception
     {
         return selectOutOfDateSources(source, mapper, targets,
-                FileUtils.getFileUtils()
-                        .getFileTimestampGranularity());
+                FileUtils.getFileTimestampGranularity());
     }
 
     /**
      * tells which source files should be reprocessed based on the
      * last modification date of target files
      *
-     * @param logTo       where to send (more or less) interesting output
      * @param resources   array of resources bearing relative path and last
      *                    modification date
      * @param mapper      filename mapper indicating how to find the target

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/SourceFileScanner.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/SourceFileScanner.java
@@ -17,11 +17,11 @@
 
 package com.izforge.izpack.util.file;
 
-import java.io.File;
-import java.util.Vector;
-
 import com.izforge.izpack.util.file.types.Resource;
 import com.izforge.izpack.util.file.types.ResourceFactory;
+
+import java.io.File;
+import java.util.Vector;
 
 /**
  * Utility class that collects the functionality of the various
@@ -33,15 +33,10 @@ import com.izforge.izpack.util.file.types.ResourceFactory;
  */
 public class SourceFileScanner implements ResourceFactory
 {
-    private FileUtils fileUtils;
     private File destDir; // base directory of the fileset
 
-    /**
-     * @param task The task we should log messages through
-     */
     public SourceFileScanner()
     {
-        fileUtils = FileUtils.getFileUtils();
     }
 
     /**
@@ -59,7 +54,7 @@ public class SourceFileScanner implements ResourceFactory
                              FileNameMapper mapper) throws Exception
     {
         return restrict(files, srcDir, destDir, mapper,
-                fileUtils.getFileTimestampGranularity());
+                FileUtils.getFileTimestampGranularity());
     }
 
     /**
@@ -84,7 +79,7 @@ public class SourceFileScanner implements ResourceFactory
         Vector<Resource> v = new Vector<Resource>();
         for (String file : files)
         {
-            File src = fileUtils.resolveFile(srcDir, file);
+            File src = FileUtils.resolveFile(srcDir, file);
             v.addElement(new Resource(file, src.exists(),
                     src.lastModified(), src.isDirectory()));
         }
@@ -113,7 +108,7 @@ public class SourceFileScanner implements ResourceFactory
                                   FileNameMapper mapper) throws Exception
     {
         return restrictAsFiles(files, srcDir, destDir, mapper,
-                fileUtils.getFileTimestampGranularity());
+                FileUtils.getFileTimestampGranularity());
     }
 
     /**
@@ -142,7 +137,7 @@ public class SourceFileScanner implements ResourceFactory
      */
     public Resource getResource(String name) throws Exception
     {
-        File src = fileUtils.resolveFile(destDir, name);
+        File src = FileUtils.resolveFile(destDir, name);
         return new Resource(name, src.exists(), src.lastModified(),
                 src.isDirectory());
     }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/types/Path.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/types/Path.java
@@ -55,8 +55,6 @@ public class Path extends DataType implements Cloneable
 {
     private static final Logger logger = Logger.getLogger(Path.class.getName());
 
-    private static FileUtils fileUtils = FileUtils.getFileUtils();
-
     private Vector<Object> elements;
 
     /**
@@ -86,8 +84,8 @@ public class Path extends DataType implements Cloneable
      * Invoked by IntrospectionHelper for <code>setXXX(Path p)</code>
      * attribute setters.
      *
-     * @param project the <CODE>Project</CODE> for this path.
-     * @param path    the <CODE>String</CODE> path definition.
+     * @param idata the install data
+     * @param path  the path definition.
      */
     public Path(InstallData idata, String path) throws Exception
     {
@@ -95,9 +93,7 @@ public class Path extends DataType implements Cloneable
     }
 
     /**
-     * Construct an empty <CODE>Path</CODE>.
-     *
-     * @param project the <CODE>Project</CODE> for this path.
+     * Construct an empty Path.
      */
     public Path()
     {
@@ -457,7 +453,7 @@ public class Path extends DataType implements Cloneable
     private static String resolveFile(InstallData idata, String relativeName)
             throws Exception
     {
-        File f = fileUtils.resolveFile(new File(idata.getInstallPath()), relativeName);
+        File f = FileUtils.resolveFile(new File(idata.getInstallPath()), relativeName);
         return f.getAbsolutePath();
     }
 

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/types/selectors/DifferentSelector.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/types/selectors/DifferentSelector.java
@@ -20,7 +20,7 @@ package com.izforge.izpack.util.file.types.selectors;
 import java.io.File;
 
 import com.izforge.izpack.api.exception.IzPackException;
-import com.izforge.izpack.util.file.FileUtils;
+import org.apache.commons.io.FileUtils;
 
 /**
  * This selector selects files against a mapped set of target files, selecting
@@ -46,9 +46,6 @@ import com.izforge.izpack.util.file.FileUtils;
  */
 public class DifferentSelector extends MappingSelector
 {
-
-    private FileUtils fileUtils = FileUtils.getFileUtils();
-
     private boolean ignoreFileTimes = true;
     private boolean ignoreContents = false;
 
@@ -113,7 +110,7 @@ public class DifferentSelector extends MappingSelector
             //here do a bulk comparison
             try
             {
-                return !fileUtils.contentEquals(srcfile, destfile);
+                return !FileUtils.contentEquals(srcfile, destfile);
             }
             catch (Exception e)
             {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/file/types/selectors/MappingSelector.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/file/types/selectors/MappingSelector.java
@@ -43,7 +43,7 @@ public abstract class MappingSelector extends BaseSelector
      */
     public MappingSelector()
     {
-        granularity = (int) FileUtils.getFileUtils().getFileTimestampGranularity();
+        granularity = (int) FileUtils.getFileTimestampGranularity();
     }
 
 


### PR DESCRIPTION
This is a fix for [IZPACK-1376](https://izpack.atlassian.net/browse/IZPACK-1376):

When using AntActionInstallerListener, there is the need to add commons-io.jar to the list of jars in install.xml, otherwise the installer will fail with:

```
FEIN: Executing all beforepack Ant actions of pack mycore ...
Exception in thread "IzPack - Unpacker thread" java.lang.NoClassDefFoundError: org/apache/commons/io/FileUtils
        at com.izforge.izpack.event.AntAction.createLogger(AntAction.java:519)
        at com.izforge.izpack.event.AntAction.performAction(AntAction.java:162)
        at com.izforge.izpack.event.AntAction.performInstallAction(AntAction.java:118)
        at com.izforge.izpack.event.AntActionInstallerListener.performAllActions(AntActionInstallerListener.java:310)
        at com.izforge.izpack.event.AntActionInstallerListener.beforePack(AntActionInstallerListener.java:200)
        at com.izforge.izpack.installer.event.InstallerListeners.beforePack(InstallerListeners.java:190)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:429)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:251)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.run(UnpackerBase.java:236)
        at java.lang.Thread.run(Unknown Source)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.io.FileUtils
        at java.net.URLClassLoader.findClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at sun.misc.Launcher$AppClassLoader.loadClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        ... 10 more
```

Normally, , there should be all classes built-in needed by the Ant action execution functionality except dependencies that Ant and native or additional Ant tasks need.

Add Apaches's FileUtils and depending classes as built-in classes to the installer.