### PR TITLE
IZPACK-1380: Dynamic variables of executable type uses stderr="true" by default

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -182,7 +182,7 @@
         <!-- Command execution -->
         <xs:attribute type="xs:string" name="executable" use="optional"/>
         <xs:attribute type="xs:string" name="dir" use="optional"/>
-        <xs:attribute type="xs:boolean" name="stderr" use="optional"/>
+        <xs:attribute type="xs:boolean" name="stderr" use="optional" default="false"/>
         <!-- Type - same name for config file type and execution type -->
         <xs:attribute name="type" use="optional">
             <xs:simpleType>


### PR DESCRIPTION
This is a fix for [IZPACK-1380](https://izpack.atlassian.net/browse/IZPACK-1380):

Provided the following definition:
```xml
<variable name="service.target" executable="/usr/bin/ls" type="process" ignorefailure="true" condition="izpack.linuxinstall+haveInstallPath">
      <arg>-l</arg>
      <arg>/etc/init.d/${service.name}</arg>
      <filters>
        <regex regexp=" \-> (.+)" select="\1"/>
      </filters>
</variable>
```

If executed on Linux it doesn't set the variable although `${service.name}` refers to a valid service identifier.

The DEBUG log shows:
```
com.izforge.izpack.util.FileExecutor executeCommand
FINE: executeCommand
        params: /usr/bin/ls
        params: -l
        params: /etc/init.d/MyApp

com.izforge.izpack.util.FileExecutor executeCommand
FINE: stdout:
com.izforge.izpack.util.FileExecutor executeCommand
FINE: lrwxrwxrwx 1 root root 65 led 20 16:55 /etc/init.d/MyApp -> /home/rkrell/myapp/bin/wrapper.sh

com.izforge.izpack.util.FileExecutor executeCommand
FINE: stderr:
com.izforge.izpack.util.FileExecutor executeCommand
FINE: 
com.izforge.izpack.util.FileExecutor executeCommand
FINE: exit status: 0
com.izforge.izpack.core.data.DynamicVariableImpl filterValue
FINE: Dynamic variable before filtering: service.target=
com.izforge.izpack.core.data.DynamicVariableImpl filterValue
FINE: Dynamic variable after applying filter RegularExpressionFilter: service.target=null
```

From an analyze there was clear the stderr of the executed command is used instead of stdout by
```xml
<variable name="service.target" executable="/usr/bin/ls" type="process" stderr="true" ignorefailure="true" condition="izpack.linuxinstall+haveInstallPath">
      <arg>-l</arg>
      <arg>/etc/init.d/${service.name}</arg>
      <filters>
        <regex regexp=" \-> (.+)" select="\1"/>
      </filters>
</variable>
```
