### PR TITLE
Fix a bug which deletes directories in current wd

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -89,6 +89,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.*;
@@ -1562,10 +1563,11 @@ public class CompilerConfig extends Thread
         }
 
         // This corrects issues that could arise due to subfolders
+	File tempDir = Files.createTempDirectory("izpack").toFile();
         Collections.sort(allDirList);
         for (String dirName : allDirList)
         {
-            File tmp = new File(dirName);
+            File tmp = new File(tempDir, dirName);
             org.apache.commons.io.FileUtils.forceMkdir(tmp);
             org.apache.commons.io.FileUtils.forceDeleteOnExit(tmp);
             String target = targetdir + "/" + dirName;


### PR DESCRIPTION
The addArchiveContent has a block of code at the end which creates all the directories in the archive in the current directory and then deletes them again. However, if one of those directories already exists in the current directory, then those existing directories are deleted by the addArchiveContent method. This caused my entire project subtree to be deleted in Jenkins when it called maven from a different directory than I normally run maven from.

By using a temporary directory instead, the directories are created and deleted there, which does not conflict with any existing files.

I also wonder if it is even necessary to create the entire subtree of empty directories, or if it is good enough to just create 1 empty directory and add it for the different targets.

Note that my patch is Java 7+, there is no good facility to create a temporary directory in Java 6. Maybe there are utility classes somewhere in the izPack source to do this?