### PR TITLE
IZPACK-1377: XSD is missing 'webdir' element for installation descriptor

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -92,6 +92,7 @@
             <xs:element name="writeinstallationinformation" type="types:yesNoTrueFalseType" minOccurs="0"/>
             <xs:element name="readinstallationinformation" type="types:yesNoTrueFalseType" minOccurs="0"/>
             <xs:element name="rebootaction" type="rebootActionType" minOccurs="0"/>
+            <xs:element name="webdir" type="xs:anyURI" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 


### PR DESCRIPTION
This fixes [IZPACK-1377](https://izpack.atlassian.net/browse/IZPACK-1377):

In 5.0.7, the `<webdir>` element is no longer accepted in the `<info>` section:
```
ERROR:  'cvc-complex-type.2.4.a: contenuto non valido che inizia con l'elemento "webdir". È previsto un elemento "{appsubpath, pack200, tempdir, summarylogfilepath, uninstaller, writeinstallationinformation, rebootaction}".'
ERROR:  'com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: cvc-complex-type.2.4.a: contenuto non valido che inizia con l'elemento "webdir". È previsto un elemento "{appsubpath, pack200, tempdir, summarylogfilepath, uninstaller, writeinstallationinformation, rebootaction}".'
```

Furthermore, there is missing the 5.0 documentation for the `<webdir>` tag.