### PR TITLE
IZPACK-1382: "os" attribute not accepted for <parsable>/<executable> to specify OS family

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -736,6 +736,7 @@
         <xs:attribute name="type" type="substitutionType" use="optional" default="plain"/>
         <xs:attribute name="encoding" type="xs:string" use="optional"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
+        <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="executableType">
@@ -783,7 +784,8 @@
     				<xs:enumeration value="ignore" />
     			</xs:restriction>
         	</xs:simpleType>
-	    </xs:attribute>    
+	    </xs:attribute>
+        <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="updateCheckType">

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -30,12 +30,20 @@
     <!-- OS                                                                                                     -->
     <!--                                                                                                        -->
     <xs:complexType name="osType">
-        <xs:attribute type="xs:string" name="family" use="optional"/>
+        <xs:attribute type="osFamilyAttributeType" name="family" use="optional"/>
         <xs:attribute type="xs:string" name="name" use="optional"/>
         <xs:attribute type="xs:string" name="arch" use="optional"/>
         <xs:attribute type="xs:string" name="version" use="optional"/>
         <xs:attribute type="xs:string" name="jre" use="optional"/>
     </xs:complexType>
+
+    <xs:simpleType name="osFamilyAttributeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="windows"/>
+            <xs:enumeration value="unix"/>
+            <xs:enumeration value="mac"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <!--                                                                                                        -->
     <!-- Conditions                                                                                             -->


### PR DESCRIPTION
Along with the XSD validation introduced in 5.0.7, the _os_ attribute is no longer accepted for `<parsable>`/`<executable>` tags to specify OS family