### PR TITLE
IZPACK-1383: "os" attribute not accepted for <singlefile>/<file>/<fileset> in packs to specify OS family

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -684,6 +684,7 @@
         <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
         <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
+        <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
     </xs:complexType>
 
 
@@ -712,6 +713,7 @@
         <xs:attribute name="casesensitive" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="defaultexcludes" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="followsymlinks" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="singleFileType">
@@ -726,6 +728,7 @@
         <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
         <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="unpack" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="parsableType">


### PR DESCRIPTION
This resolves [IZPACK-1383](https://izpack.atlassian.net/browse/IZPACK-1383):

Along with the XSD validation introduced in 5.0.7, the _os_ attribute is no longer accepted for `<singlefile>`/`<file>`/`<fileset>` tags in packs to specify OS family.