### PR TITLE
IzPackIZPACK-1374: AntActionListener - add compiler cross check whether referenced pack exists

### DIFF
--- a/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
@@ -39,8 +39,6 @@ public class ActionBase implements Serializable
 
     private static final long serialVersionUID = 3690478013149884728L;
 
-    public static final String PACK = "pack";
-
     public static final String NAME = "name";
 
     public static final String ANTCALL_CONDITIONID_ATTR = "condition";

--- a/izpack-util/src/main/java/com/izforge/izpack/util/helper/SpecHelper.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/helper/SpecHelper.java
@@ -58,9 +58,9 @@ public class SpecHelper
      */
     private final Resources resources;
 
-    private static final String PACK_KEY = "pack";
+    public static final String PACK_KEY = "pack";
 
-    private static final String PACK_NAME = "name";
+    public static final String PACK_NAME = "name";
 
     /**
      * Constructs a <tt>SpecHelper</tt>.


### PR DESCRIPTION
This solves [IZPACK-1374](https://izpack.atlassian.net/browse/IZPACK-1374):

In _AntActionSpec.xml_ there are usually referenced packs from install.xml by the pack's {{name}} attribute.

If there is a typo in the reference value the compiled installer doesn't even fail when executing the `AntActionInstallationListener`, but just ignores all the Ant actions nested to the
```xml
<pack name="...">
...
</pack>
```
with the misspelled name.

There should be a compiler cross check to let the compilation fail if a referenced pack hasn't been defined by that name in install.xml.

Check also the _AntActionSpec.xml_ resource, whether all resources defined by the _buildresource_ attributes exist.