### PR TITLE
IZPACK-1385: Distribution installer does not overwrite existing files

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -680,7 +680,7 @@
         <xs:attribute name="includes" type="xs:string" use="optional"/>
         <xs:attribute name="excludes" type="xs:string" use="optional"/>
         <xs:attribute name="targetdir" type="xs:string" use="optional" default="${INSTALL_PATH}"/>
-        <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
+        <xs:attribute name="override" type="overrideType" use="optional" default="update"/>
         <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
         <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
@@ -706,7 +706,7 @@
         </xs:choice>
         <xs:attribute name="src" type="xs:string" use="required"/>
         <xs:attribute name="targetdir" type="xs:string" use="required"/>
-        <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
+        <xs:attribute name="override" type="overrideType" use="optional" default="update"/>
         <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
         <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="unpack" type="xs:boolean" use="optional" default="false"/>
@@ -724,7 +724,7 @@
         </xs:choice>
         <xs:attribute name="src" type="xs:string" use="required"/>
         <xs:attribute name="target" type="xs:string" use="required"/>
-        <xs:attribute name="override" type="overrideType" use="optional" default="false"/>
+        <xs:attribute name="override" type="overrideType" use="optional" default="update"/>
         <xs:attribute name="overrideRenameTo" type="xs:string" use="optional"/>
         <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="unpack" type="xs:boolean" use="optional" default="false"/>

--- a/izpack-dist/src/main/izpack/install.xml
+++ b/izpack-dist/src/main/izpack/install.xml
@@ -115,7 +115,7 @@
         <!-- The core files -->
         <pack name="Core" required="yes">
             <description>The IzPack core files.</description>
-            <fileset dir="" targetdir="$INSTALL_PATH">
+            <fileset dir="" override="true">
                 <include name="README.md"/>
                 <include name="LICENSE"/>
                 <include name="KEYS"/>
@@ -152,7 +152,7 @@
         <!-- Utilities pack -->
         <pack name="Utilities" required="no">
             <description>IzPack utilities (izpack2exe, izpack2app, izpack2jnlp)</description>
-            <fileset dir="" targetdir="$INSTALL_PATH">
+            <fileset dir="" override="true">
                 <include name="utils/**/*"/>
             </fileset>
             <executable


### PR DESCRIPTION
In our dist installer we rely on the default value of the _override_ attribute for installing files in packs:
```xml
        <pack name="Core" required="yes">
            <fileset dir="" targetdir="$INSTALL_PATH">
                <include name="README.md"/>
                <include name="LICENSE"/>
                <include name="KEYS"/>
                <include name="NOTICE"/>
                <include name="bin/**"/>
                <include name="lib/**"/>
                <include name="legal/**"/>
                <include name="schema/**"/>
            </fileset>
            ...
        </pack>
```
This is wrong, but the default should be at least _"update"_ (overwrite newer files). But even this probably doesn't happen, because beginning from 5.0.7, in case of not using an attribute, but this attribute is defined in the XSD with a default value, default value from the XSD is used, which is also wrong and does not match the compiler implementation for all three tags, fileset, file and singlefile:
```xml
<xs:attribute name="override" type="overrideType" use="optional" default="false"/>
```