### PR TITLE
IZPACK-1386: "condition" attribute not accepted for <file> and <singlefile> tags in packs

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -714,6 +714,7 @@
         <xs:attribute name="defaultexcludes" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="followsymlinks" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
+        <xs:attribute name="condition" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="singleFileType">
@@ -729,6 +730,7 @@
         <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="unpack" type="xs:boolean" use="optional" default="false"/>
         <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
+        <xs:attribute name="condition" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="parsableType">


### PR DESCRIPTION
In a `<pack>` definition, there is not allowed the `condition` attribute for nested `<file>` and `<singlefile>` tags.

It is missing in the XSD.