### PR TITLE
IZPACK-1387: <processor> tag nested to field <spec> not accepted during compiling UserInputSpec.xml resource

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -135,6 +135,7 @@
                         <xs:element name="pwd" type="passwordSpecType" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element name="choice" type="choiceSpecType" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element name="col" type="columnFieldColSpecType" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="processor" type="processorFieldColSpecType" minOccurs="0" maxOccurs="unbounded"/>
                     </xs:choice>
                     <xs:attribute name="id" type="xs:string" use="optional"/>
                     <xs:attribute name="false" type="xs:string" use="optional"/>
@@ -419,6 +420,16 @@
             <xs:element name="field" type="fieldType" minOccurs="1" maxOccurs="unbounded"/>
             <xs:element name="validator" type="fieldValidatorType" minOccurs="1" maxOccurs="unbounded"/>
         </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="processorFieldColSpecType">
+        <xs:attribute name="class" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The class implementing the field processor.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="fieldValidatorType">


### PR DESCRIPTION
The `<processor class="..."/>` element nested to `<field><spec>...</spec></field>` is no longer accepted when compiling the _UserInputSpec.xml_ resource.

There is a missing definition in the XSD.