### PR TITLE
IZPACK-1388: Missing attributes of <fileset> inside <pack> in installation schema

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -3356,24 +3356,6 @@ public class CompilerConfig extends Thread
                 }
                 fs.setDir(dir);
             }
-
-            dir_attr = fileSetNode.getAttribute("file");
-            if (dir_attr != null)
-            {
-                File dir = FileUtil.getAbsoluteFile(dir_attr, compilerData.getBasedir());
-                // if the path does not exist, maybe it contains variables
-                if (! dir.exists()) {
-                    dir = new File(variableSubstitutor.substitute(dir.getAbsolutePath()));
-                }
-                fs.setFile(dir);
-            }
-            else
-            {
-                if (fs.getDir() == null)
-                {
-                    throw new CompilerException("At least one of both attributes, 'dir' or 'file' required in fileset");
-                }
-            }
         }
         catch (Exception e)
         {

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -685,6 +685,9 @@
         <xs:attribute name="blockable" type="blockableType" use="optional" default="none"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
         <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
+        <xs:attribute name="casesensitive" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="defaultexcludes" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="followsymlinks" type="xs:boolean" use="optional" default="true"/>
     </xs:complexType>
 
 


### PR DESCRIPTION
The `file`, `defaultexcludes`, `casesensitive` and `followsymlinks` attributes of `<fileset>` inside `<pack>` are missing in the installation schema (`<xs:complexType name="fileSetTypeDisk">`) and cannot be used since XML is validated using schema.

Fix also the documentation at https://izpack.atlassian.net/wiki/x/W4AH.

The implementation and overall meaning of the `file` attribute along with the documentation is more than stupid. I'd prefer to remove the file attribute completely from the `<fileset>` tag because it does exactly the same as if dir was used, thus it is duplicate of `dir`.