### PR TITLE
Increased JLine version to latest 2.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
       <dependency>
         <groupId>jline</groupId>
         <artifactId>jline</artifactId>
-        <version>2.13</version>
+        <version>2.14.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
For changes against the previous 2.13 used in IzPack see https://github.com/jline/jline2/compare/jline-2.13...jline-2.14.1