### PR TITLE
IZPACK-1389: Dynamic variables have attribute unset="false" by default, but should be true

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -203,7 +203,7 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-        <xs:attribute type="xs:boolean" name="unset" use="optional" default="false"/>
+        <xs:attribute type="xs:boolean" name="unset" use="optional" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="dynamicVariableFiltersType">


### PR DESCRIPTION
The attribute _unset_ is set to _"false"_ by default in the XSD, but should be _"true"_, like before 5.0.7 in the code. The wrong default is also active at runtime from XSD if the _unset_ attribute isn't explicitly used.