### PR TITLE
Fix some regressions in console installation mode / Update reporting plugins

### DIFF
--- a/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/Console.java
@@ -235,7 +235,6 @@ public class Console
         {
             Terminal terminal = consoleReader.getTerminal();
             termWidth = terminal.getWidth();
-            wrapLineFull = terminal.hasWeirdWrap();
         }
         if (title != null && title.length() > termWidth)
         {
@@ -248,10 +247,7 @@ public class Console
         int len = title != null ? Math.max(title.length(), message.length()) : message.length();
         int width = Math.min(termWidth, len);
         print('-', width);
-        if (wrapLineFull)
-        {
-            println();
-        }
+        println();
         if (title != null)
         {
             println(title);
@@ -259,10 +255,7 @@ public class Console
         }
         println(message);
         print('-', width);
-        if (wrapLineFull)
-        {
-            println();
-        }
+        println();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
       <dependency>
         <groupId>jline</groupId>
         <artifactId>jline</artifactId>
-        <version>2.14.1</version>
+        <version>2.12.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -860,12 +860,12 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.4</version>
+        <version>2.7</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>2.5.5</version>
         <configuration>
           <findbugsXmlOutput>true</findbugsXmlOutput>
           <effort>Max</effort>
@@ -874,7 +874,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.5</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
This fixes some small issues appeared during testing the console installation mode:
- Reverted JLine to 2.12.1 - best experience with path auto-completion (no automatic appending of spaces after pressing tab)
- Fixed line wrapping on console "message boxes"

Increased versions of reporting plugins