### PR TITLE
IZPACK-1390: Unrecognized attributes to pack and refpack elements in 5.0.7

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -795,7 +795,7 @@ public class CompilerConfig extends Thread
             String group = packElement.getAttribute("group");
             String installGroups = packElement.getAttribute("installGroups");
             String excludeGroup = packElement.getAttribute("excludeGroup");
-            boolean uninstall = "yes".equalsIgnoreCase(packElement.getAttribute("uninstall", "yes"));
+            boolean uninstall = xmlCompilerHelper.validateYesNoAttribute(packElement, "uninstall", YES);
             long size = xmlCompilerHelper.getLong(packElement, "size", 0);
             String parent = packElement.getAttribute("parent");
             boolean hidden = Boolean.parseBoolean(packElement.getAttribute("hidden", "false"));

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -474,16 +474,22 @@
         </xs:choice>
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="packImgId" type="xs:string" use="optional"/>
         <xs:attribute name="required" type="types:yesNoTrueFalseType"/>
         <xs:attribute name="hidden" type="xs:boolean" default="false"/>
         <xs:attribute name="preselected" type="types:yesNoTrueFalseType" use="optional"/>
         <xs:attribute name="loose" type="xs:boolean" use="optional"/>
+        <xs:attribute name="uninstall" type="types:yesNoTrueFalseType" use="optional"/>
         <xs:attribute name="condition" type="xs:string" use="optional"/>
         <xs:attribute name="installGroups" type="xs:string" use="optional"/>
+        <xs:attribute name="excludeGroup" type="xs:string" use="optional"/>
+        <xs:attribute name="parent" type="xs:string" use="optional"/>
+        <xs:attribute name="group" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="refpackType">
         <xs:attribute name="file" type="xs:string" use="required"/>
+        <xs:attribute name="selfcontained" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="refpackSetType">
@@ -876,6 +882,5 @@
             <xs:enumeration value="xml"/>
         </xs:restriction>
     </xs:simpleType>
-
 
 </xs:schema>


### PR DESCRIPTION
This fixes issue [IZPACK-1390](https://izpack.atlassian.net/browse/IZPACK-1390):

The following attributes are missing in the XSDs and are not recognized during compiling:

Element `pack`:
- _packImgId_
- _uninstall_ (works now also with values "true" and "false")
- _excludeGroup_
- _parent_
- _group_

Element `refpack`
- _selfcontained_