### PR TITLE
fixed XML for DataValidatorTest

### DIFF
--- a/izpack-test/src/test/resources/samples/datavalidators.xml
+++ b/izpack-test/src/test/resources/samples/datavalidators.xml
@@ -13,10 +13,12 @@
         <langpack iso3="eng"/>
     </locale>
 
-    <condition type="variable" id="isCorrectVersion">
-      <name>APP_VER</name>
-      <value>1.4 beta 666</value>
-    </condition>
+	<conditions>
+    	<condition type="variable" id="isCorrectVersion">
+      		<name>APP_VER</name>
+      		<value>1.4 beta 666</value>
+    	</condition>
+    </conditions>
 
     <panels>
         <panel classname="HelloPanel" id="HelloPanel">


### PR DESCRIPTION
All tests in **/integration/** are not executed during maven build since commit 2bd7816a4cf853aa7d1ebe18f496112bbcd6fdb5 from IZPACK-1094, so the defect xml is not dtected during build.

There seem to be several (?) other problems with the implementation tests, which I do not understand yet. But at least the simple error in this xml can be fixed now.