### PR TITLE
IZPACK-1401: GUI "custom" field doesn't show default value for "rule" subfields

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputRows.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/custom/CustomInputRows.java
@@ -124,6 +124,7 @@ public class CustomInputRows extends JPanel
             //TODO: Check for condition
             //if (guiField.getField().isConditionTrue())
             field.setDisplayed(true);
+            field.updateView();
             for (Component component : field.getComponents())
             {
                 JComponent jComponent = component.getComponent();


### PR DESCRIPTION
This is a fix for [IZPACK-1401](https://izpack.atlassian.net/browse/IZPACK-1401):

Provided the following definitions:

*UserInputSpec.xml:*
```xml
  <panel id="activemq.connection.panel">
    <field id="activemq.connection.panel.title" type="title"/>
    <field align="left" id="activemq.connection.description" type="staticText"/>
    <field type="space"/>
    <field type="check" variable="activemq.cluster.use">
        <spec default="false" false="false" id="activemq.cluster.use.label"
            true="true" txt="Use failover connection in cluster"/>
    </field>
    <field type="space"/>
    <field type="divider"/>
    <field type="space"/>
    <field conditionid="ActiveMQClusterSelected" maxRow="10" minRow="1" type="custom" variable="activemq.connection.count">
        <spec>
            <col>
                <field type="rule" variable="activemq.connection.address">
                    <spec default="tcp://localhost:7000"
                        id="activemq.connection.url.label"
                        layout="O:5:U :// O:15:U : N:5:5" resultFormat="displayFormat"/>
                </field>
                <validator
                    class="com.izforge.izpack.panels.userinput.validator.UniqueValidator" id="activemq.connection.host.unique"/>
            </col>
        </spec>
    </field>
    <field conditionid="!ActiveMQClusterSelected" maxRow="1" minRow="1" type="custom" variable="activemq.connection.count">
        <spec>
            <col>
                <field type="rule" variable="activemq.connection.address">
                    <spec default="tcp://localhost:7000"
                        id="activemq.connection.url.label"
                        layout="O:5:U :// O:15:U : N:5:5" resultFormat="displayFormat"/>
                </field>
            </col>
        </spec>
    </field>
  </panel>
```

*install.xml.xml:*
```xml
  ...
  <conditions>
    <condition id="ActiveMQClusterSelected" type="variable">
      <name>activemq.cluster.use</name>
      <value>true</value>
    </condition>
  </conditions>
  ...
  <panels>
    <panel classname="UserInputPanel" id="activemq.connection.panel"/>
  </panels>
  ...
```

For this use case (and probably for others, too), the default values _tcp://localhost:7000_ are not shown for the "rule" subfields in each new row of the "custom" field, but just for the GUI mode. In the console installation mode the defaults are displayed as expected.

This is a regression in 5.0.7.