### PR TITLE
IZPACK-1413: UserInputPanel automation: auto-install.xml should not contain variables of fields which are not displayed

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
@@ -112,30 +112,33 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
 
         for (FieldView view : views)
         {
-            String variable = view.getField().getVariable();
-
-            if (variable != null)
+            if (view.isDisplayed())
             {
-                String entry = installData.getVariable(variable);
-                if (view.getField().getOmitFromAuto()){
-                    omitFromAutoSet.add(variable);
+                String variable = view.getField().getVariable();
+
+                if (variable != null)
+                {
+                    String entry = installData.getVariable(variable);
+                    if (view.getField().getOmitFromAuto())
+                    {
+                        omitFromAutoSet.add(variable);
+                    }
+                    entries.put(variable, entry);
                 }
-                entries.put(variable, entry);
-            }
 
-            // Grab all the variables contained within the custom field
-            List <String> namedVariables = new ArrayList<String>();
-            if(view instanceof CustomFieldType)
-            {
-                CustomFieldType customField = (CustomFieldType) view;
-                namedVariables = customField.getVariables();
-            }
+                // Grab all the variables contained within the custom field
+                List<String> namedVariables = new ArrayList<String>();
+                if (view instanceof CustomFieldType)
+                {
+                    CustomFieldType customField = (CustomFieldType) view;
+                    namedVariables = customField.getVariables();
+                }
 
-            for(String numberedVariable : namedVariables)
-            {
-                entries.put(numberedVariable, installData.getVariable(numberedVariable));
+                for (String numberedVariable : namedVariables)
+                {
+                    entries.put(numberedVariable, installData.getVariable(numberedVariable));
+                }
             }
-
         }
         return entries;
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
@@ -22,13 +22,6 @@
 
 package com.izforge.izpack.panels.userinput;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.data.InstallData;
@@ -38,6 +31,9 @@ import com.izforge.izpack.installer.automation.PanelAutomation;
 import com.izforge.izpack.panels.userinput.field.AbstractFieldView;
 import com.izforge.izpack.panels.userinput.field.FieldView;
 import com.izforge.izpack.panels.userinput.field.custom.CustomFieldType;
+
+import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Functions to support automated usage of the UserInputPanel
@@ -72,9 +68,9 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
     }
 
     /**
+     * Creates an {@link UserInputPanelAutomationHelper}
      *
-     * @param variables
-     * @param views
+     * @param views AbstractFieldView
      */
     public UserInputPanelAutomationHelper(List<? extends AbstractFieldView> views)
     {
@@ -145,7 +141,6 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
 
     /**
      * Deserialize state from panelRoot and set installData variables accordingly.
-     *
      *
      * @param idata     The installation installDataGUI.
      * @param panelRoot The XML root element of the panels blackbox tree.


### PR DESCRIPTION
Fix for [IZPACK-1413](https://izpack.atlassian.net/browse/IZPACK-1413):

Currently, if the user saves the auto-install.xml record at the end of the installation in the FinishPanel, there are saved variable entries for all fields of a UserInputPanel, regardless of whether they are presented to the user depending on a condition (e.g. whether they are displayed or invisible).

For invisible fields there are use empty values: `""`

This is not correct. The right record of an installation for a UserInputPanel should contain just variables of those fields which are really displayed and user-editable.