### PR TITLE
IZPACK-1414: UserInputPanel: Check for run class of button field at compile time

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -75,9 +75,11 @@ import com.izforge.izpack.panels.process.ProcessPanelWorker;
 import com.izforge.izpack.panels.shortcut.ShortcutConstants;
 import com.izforge.izpack.panels.treepacks.PackValidator;
 import com.izforge.izpack.panels.userinput.UserInputPanel;
+import com.izforge.izpack.panels.userinput.action.ButtonAction;
 import com.izforge.izpack.panels.userinput.field.FieldReader;
 import com.izforge.izpack.panels.userinput.field.SimpleChoiceReader;
 import com.izforge.izpack.panels.userinput.field.UserInputPanelSpec;
+import com.izforge.izpack.panels.userinput.field.button.ButtonFieldReader;
 import com.izforge.izpack.util.FileUtil;
 import com.izforge.izpack.util.IoHelper;
 import com.izforge.izpack.util.OsConstraintHelper;
@@ -2001,7 +2003,23 @@ public class CompilerConfig extends Thread
                                     elList.add(choiceDef);
                                 }
                             }
-
+                            // Check whether button field run class can be loaded
+                            for (IXMLElement runDef : fieldSpecDef.getChildrenNamed(ButtonFieldReader.RUN_ELEMENT))
+                            {
+                                String actionClassName = runDef.getAttribute(ButtonFieldReader.RUN_ELEMENT_CLASS_ATTR);
+                                if (actionClassName != null)
+                                {
+                                    try
+                                    {
+                                        Class<ButtonAction> buttonActionClass = (Class<ButtonAction>) Class.forName(actionClassName);
+                                    }
+                                    catch (ClassNotFoundException e)
+                                    {
+                                        assertionHelper.parseError(userInputSpec, "Resource " + UserInputPanelSpec.SPEC_FILE_NAME
+                                                + ": Button action class '" + actionClassName + "' cannot be loaded");
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/button/ButtonFieldReader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/button/ButtonFieldReader.java
@@ -18,6 +18,14 @@ public class ButtonFieldReader extends SimpleFieldReader implements ButtonFieldC
     private final Messages messages;
     private final InstallData installData;
 
+    public static final String SPEC_SUCCESSMSG_ATTR = "successMsg";
+    public static final String RUN_ELEMENT = "run";
+    public static final String RUN_ELEMENT_CLASS_ATTR = "class";
+    public static final String RUN_MSG_ELEMENT = "msg";
+    public static final String RUN_MSG_ELEMENT_ID_ATTR = "id";
+    public static final String RUN_MSG_ELEMENT_NAME_ATTR = "name";
+
+
     /**
      * Constructs a {@code FieldReader}.
      *
@@ -69,9 +77,10 @@ public class ButtonFieldReader extends SimpleFieldReader implements ButtonFieldC
      */
     public String getSuccessMsg()
     {
-        String successMsg = getSpec().getAttribute("successMsg");
+        String successMsg = getSpec().getAttribute(SPEC_SUCCESSMSG_ATTR);
         if(successMsg == null)
         {
+            // TODO: Can be removed when XSD validation isn't optional any longer, because default comes from XSD
             successMsg = "";
         }
         return messages.get(successMsg);
@@ -84,21 +93,21 @@ public class ButtonFieldReader extends SimpleFieldReader implements ButtonFieldC
     {
         List<ButtonAction> buttonActions = new ArrayList<ButtonAction>();
 
-        for(IXMLElement runSpec : this.getSpec().getChildrenNamed("run"))
+        for(IXMLElement runSpec : this.getSpec().getChildrenNamed(RUN_ELEMENT))
         {
             Map<String, String> buttonMessages = new HashMap<String, String>();
 
-            String actionClass = runSpec.getAttribute("class");
+            String actionClass = runSpec.getAttribute(RUN_ELEMENT_CLASS_ATTR);
             try
             {
                 Class<ButtonAction> buttonActionClass = (Class<ButtonAction>) Class.forName(actionClass);
                 Constructor<ButtonAction> buttonActionConstructor = buttonActionClass.getConstructor(InstallData.class);
                 ButtonAction buttonAction = buttonActionConstructor.newInstance(installData);
 
-                for (IXMLElement message : runSpec.getChildrenNamed("msg"))
+                for (IXMLElement message : runSpec.getChildrenNamed(RUN_MSG_ELEMENT))
                 {
-                    String id = message.getAttribute("id");
-                    String name = message.getAttribute("name");
+                    String id = message.getAttribute(RUN_MSG_ELEMENT_ID_ATTR);
+                    String name = message.getAttribute(RUN_MSG_ELEMENT_NAME_ATTR);
                     String value = messages.get(id);
 
                     buttonMessages.put(name, value);


### PR DESCRIPTION
Fix for [IZPACK-1414](https://izpack.atlassian.net/browse/IZPACK-1414):

Example definition from the [documentation|https://izpack.atlassian.net/wiki/x/koAH]:
```xml
<field type="button" id="pokedex.query">
    <spec id="pokedex.button" successMsg="pokedex.working">
        <run class="com.mtjandra.button.PokemonConnectionTest" >
            <msg id="pokedex.error" name="error"/>
        </run>
    </spec>
</field>
```

The existance of the run class (_com.mtjandra.button.PokemonConnectionTest_ in the above example) is not checked at compile time, but the installer fails with a ClassNotFoundError.

Check whether the class is part of the installer classpath already at compile time.