### PR TITLE
Izpack 1408: Fix for multiline matches

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
@@ -126,7 +126,7 @@ public class ContainsCondition extends Condition {
 
     if (isRegEx)
     {
-        pattern = Pattern.compile(value);
+        pattern = Pattern.compile(value,Pattern.MULTILINE);
         if (isByLine)
         {
             return matchesByLine(new StringReader(content));

--- a/izpack-core/src/test/java/com/izforge/izpack/core/rules/process/ContainsConditionTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/rules/process/ContainsConditionTest.java
@@ -77,21 +77,45 @@ public class ContainsConditionTest
         doTests(variables, "contains_in_variable.xml");
     }
 
+    /**
+     * Run defined set of tests
+     * 
+     * @param resource      the name of the <conditions> xml
+     */
     private void doTests(String resource)
     {
         doTests(resource, null);
     }
 
+    /**
+     * Run defined set of tests and additional tests
+     * 
+     * @param resource      the name of the <conditions> xml
+     * @param additional    additional tests to be run
+     */
     private void doTests(String resource, Map<String, Boolean> additional)
     {
         doTests(new DefaultVariables(), resource, additional);
     }
 
+    /**
+     * Run defined set of tests with variables set
+     * 
+     * @param variables     defined variables for test
+     * @param resource      the name of the <conditions> xml
+     */
     private void doTests(Variables variables, String resource)
     {
         doTests(variables, resource, null);
     }
 
+    /**
+     * Run defined set of tests and additional tests with variables set
+     * 
+     * @param variables     defined variables for test
+     * @param resource      the name of the <conditions> xml
+     * @param additional    additional tests to be run
+     */
     private void doTests(Variables variables, String resource, Map<String, Boolean> additional)
     {
         RulesEngine rules = createRulesEngine(new AutomatedInstallData(variables, Platforms.UNIX));

--- a/izpack-core/src/test/java/com/izforge/izpack/core/rules/process/ContainsConditionTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/rules/process/ContainsConditionTest.java
@@ -1,0 +1,111 @@
+/*
+ * IzPack - Copyright 2001-2016 The IzPack project team.
+ * All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.izforge.izpack.core.rules.process;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.izforge.izpack.api.adaptator.IXMLElement;
+import com.izforge.izpack.api.adaptator.IXMLParser;
+import com.izforge.izpack.api.adaptator.impl.XMLParser;
+import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Variables;
+import com.izforge.izpack.api.rules.RulesEngine;
+import com.izforge.izpack.core.container.DefaultContainer;
+import com.izforge.izpack.core.data.DefaultVariables;
+import com.izforge.izpack.core.rules.ConditionContainer;
+import com.izforge.izpack.core.rules.RulesEngineImpl;
+import com.izforge.izpack.util.Platforms;
+
+
+public class ContainsConditionTest
+{
+
+    /**
+     * Checks conditions for strings read from the test <em>contains_in_string.xml</em> file.
+     */
+    @Test
+    public void testInString()
+    {
+        doTests("contains_in_string.xml");
+    }
+
+    /**
+     * Checks conditions for file read from the test <em>contains_in_file.xml</em> file.
+     */
+    @Test
+    public void testInFile()
+    {
+        doTests("contains_in_file.xml");
+    }
+    
+    /**
+     * Checks conditions for variables read from the test <em>contains_in_variable.xml</em> file.
+     */
+    @Test
+    public void testInVariable()
+    {
+        Variables variables = new DefaultVariables();
+        variables.set("text", "This is A line of text");
+        doTests(variables, "contains_in_variable.xml");
+    }
+
+    private void doTests(String resource)
+    {
+        doTests(new DefaultVariables(), resource);
+    }
+    
+    private void doTests(Variables variables, String resource)
+    {
+        RulesEngine rules = createRulesEngine(new AutomatedInstallData(variables, Platforms.UNIX));
+        IXMLParser parser = new XMLParser();
+        IXMLElement conditions = parser.parse(getClass().getResourceAsStream(resource));
+        rules.analyzeXml(conditions);
+
+        assertTrue(rules.isConditionTrue("value_found"));               // a simple substring
+        assertFalse(rules.isConditionTrue("value_not_found1"));         // not found because string is uppercase
+        assertFalse(rules.isConditionTrue("value_not_found2"));         // not found because value is uppercase
+        assertTrue(rules.isConditionTrue("value_found_ignore_case"));   // different case 
+
+        assertTrue(rules.isConditionTrue("trivial_regex"));             // a simple substring
+        assertTrue(rules.isConditionTrue("regex_with_wildcard"));       // a regex with wildcards substring
+        assertTrue(rules.isConditionTrue("regex_whole_line"));          // a regex matching the whole line
+        assertFalse(rules.isConditionTrue("regex_not_whole_line"));     // a regex not matching the whole line
+        assertFalse(rules.isConditionTrue("regex_not_found1"));         // not found because string is uppercase
+        assertFalse(rules.isConditionTrue("regex_not_found2"));         // not found because value is uppercase
+    }
+
+    /**
+     * Creates a new {@link RulesEngine}.
+     *
+     * @param installData the installation data
+     * @return a new rules engine
+     */
+    private RulesEngine createRulesEngine(InstallData installData)
+    {
+        DefaultContainer parent = new DefaultContainer();
+        RulesEngine rules = new RulesEngineImpl(installData, new ConditionContainer(parent), installData.getPlatform());
+        parent.addComponent(RulesEngine.class, rules);
+        return rules;
+    }
+
+}

--- a/izpack-core/src/test/java/com/izforge/izpack/core/rules/process/ContainsConditionTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/rules/process/ContainsConditionTest.java
@@ -20,6 +20,11 @@ package com.izforge.izpack.core.rules.process;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import org.junit.Test;
 
@@ -55,7 +60,10 @@ public class ContainsConditionTest
     @Test
     public void testInFile()
     {
-        doTests("contains_in_file.xml");
+        Map<String,Boolean> additional = new HashMap<String, Boolean>();
+        additional.put("regex_multiple_lines_dotall", true);
+        additional.put("regex_multiple_lines", false);
+        doTests("contains_in_file.xml", additional);
     }
     
     /**
@@ -71,10 +79,20 @@ public class ContainsConditionTest
 
     private void doTests(String resource)
     {
-        doTests(new DefaultVariables(), resource);
+        doTests(resource, null);
     }
-    
+
+    private void doTests(String resource, Map<String, Boolean> additional)
+    {
+        doTests(new DefaultVariables(), resource, additional);
+    }
+
     private void doTests(Variables variables, String resource)
+    {
+        doTests(variables, resource, null);
+    }
+
+    private void doTests(Variables variables, String resource, Map<String, Boolean> additional)
     {
         RulesEngine rules = createRulesEngine(new AutomatedInstallData(variables, Platforms.UNIX));
         IXMLParser parser = new XMLParser();
@@ -92,6 +110,15 @@ public class ContainsConditionTest
         assertFalse(rules.isConditionTrue("regex_not_whole_line"));     // a regex not matching the whole line
         assertFalse(rules.isConditionTrue("regex_not_found1"));         // not found because string is uppercase
         assertFalse(rules.isConditionTrue("regex_not_found2"));         // not found because value is uppercase
+
+        if (additional!=null) {
+            for (Entry<String, Boolean> test : additional.entrySet())
+            {
+                String cond = test.getKey();
+                Boolean expected = test.getValue();
+                assertEquals("condition '" + cond + "':", expected, rules.isConditionTrue(cond));
+            }
+        }
     }
 
     /**

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains.txt
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains.txt
@@ -1,0 +1,2 @@
+This is A line of text
+and another line

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains_in_file.xml
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains_in_file.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<izpack:conditions version="5.0"
+                   xmlns:izpack="http://izpack.org/schema/conditions"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://izpack.org/schema/conditions http://izpack.org/schema/5.0/izpack-conditions-5.0.xsd">
+
+    <condition type="contains" id="value_found">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="false">A line</value>
+    </condition>
+
+    <condition type="contains" id="value_not_found1">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value>a line</value>
+    </condition>
+
+    <condition type="contains" id="value_not_found2">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value>A LINE</value>
+    </condition>
+
+    <condition type="contains" id="value_found_ignore_case">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value caseInsensitive="true">a LINE</value>
+    </condition>
+
+    <condition type="contains" id="trivial_regex">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="true">A line</value>
+    </condition>
+
+    <condition type="contains" id="regex_with_wildcard">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="true">is.*line</value>
+    </condition>
+
+    <condition type="contains" id="regex_whole_line">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="true">^This is.*line.*text$</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_whole_line">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="true">^is.*line.*$</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_found1">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="true">a line</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_found2">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="true">A LINE</value>
+    </condition>
+
+</izpack:conditions>

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains_in_file.xml
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains_in_file.xml
@@ -54,4 +54,15 @@
         <value regex="true">A LINE</value>
     </condition>
 
+    <!-- tests used for <file> only -->
+    <condition type="contains" id="regex_multiple_lines_dotall">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="true" >\A(?s)This is.*line.*text.*line\Z</value>
+    </condition>
+
+    <condition type="contains" id="regex_multiple_lines">
+        <file>src/test/resources/com/izforge/izpack/core/rules/process/contains.txt</file>
+        <value regex="true" >\AThis is.*line.*text.*line\Z</value>
+    </condition>
+
 </izpack:conditions>

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains_in_string.xml
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains_in_string.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" ?>
+<izpack:conditions version="5.0"
+                   xmlns:izpack="http://izpack.org/schema/conditions"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://izpack.org/schema/conditions http://izpack.org/schema/5.0/izpack-conditions-5.0.xsd">
+
+    <condition type="contains" id="value_found">
+        <string>This is A line of text</string>
+        <value regex="false">A line</value>
+    </condition>
+
+    <condition type="contains" id="value_not_found1">
+        <string>This is A line of text</string>
+        <value>a line</value>
+    </condition>
+
+    <condition type="contains" id="value_not_found2">
+        <string>This is A line of text</string>
+        <value>A LINE</value>
+    </condition>
+
+    <condition type="contains" id="value_found_ignore_case">
+        <string>This is A line of text</string>
+        <value caseInsensitive="true">a LINE</value>
+    </condition>
+
+    <condition type="contains" id="trivial_regex">
+        <string>This is A line of text</string>
+        <value regex="true">A line</value>
+    </condition>
+
+    <condition type="contains" id="regex_with_wildcard">
+        <string>This is A line of text</string>
+        <value regex="true">is.*line</value>
+    </condition>
+
+    <condition type="contains" id="regex_whole_line">
+        <string>This is A line of text</string>
+        <value regex="true">^This is.*line.*text$</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_whole_line">
+        <string>This is A line of text</string>
+        <value regex="true">^is.*line.*$</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_found1">
+        <string>This is A line of text</string>
+        <value regex="true">a line</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_found2">
+        <string>This is A line of text</string>
+        <value regex="true">A LINE</value>
+    </condition>
+
+    <condition type="contains" id="regex_found_ignore_case">
+        <string>This is A line of text</string>
+        <value regex="true" caseInsensitive="true">a LINE</value>
+    </condition>
+
+</izpack:conditions>

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains_in_variable.xml
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/rules/process/contains_in_variable.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" ?>
+<izpack:conditions version="5.0"
+                   xmlns:izpack="http://izpack.org/schema/conditions"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://izpack.org/schema/conditions http://izpack.org/schema/5.0/izpack-conditions-5.0.xsd">
+
+    <condition type="contains" id="value_found">
+        <variable>text</variable>
+        <value regex="false">A line</value>
+    </condition>
+
+    <condition type="contains" id="value_not_found1">
+        <variable>text</variable>
+        <value>a line</value>
+    </condition>
+
+    <condition type="contains" id="value_not_found2">
+        <variable>text</variable>
+        <value>A LINE</value>
+    </condition>
+
+    <condition type="contains" id="value_found_ignore_case">
+        <variable>text</variable>
+        <value caseInsensitive="true">a LINE</value>
+    </condition>
+
+    <condition type="contains" id="trivial_regex">
+        <variable>text</variable>
+        <value regex="true">A line</value>
+    </condition>
+
+    <condition type="contains" id="regex_with_wildcard">
+        <variable>text</variable>
+        <value regex="true">is.*line</value>
+    </condition>
+
+    <condition type="contains" id="regex_whole_line">
+        <variable>text</variable>
+        <value regex="true">^This is.*line.*text$</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_whole_line">
+        <variable>text</variable>
+        <value regex="true">^is.*line.*$</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_found1">
+        <variable>text</variable>
+        <value regex="true">a line</value>
+    </condition>
+
+    <condition type="contains" id="regex_not_found2">
+        <variable>text</variable>
+        <value regex="true">A LINE</value>
+    </condition>
+
+    <condition type="contains" id="regex_found_ignore_case">
+        <variable>text</variable>
+        <value regex="true" caseInsensitive="true">a LINE</value>
+    </condition>
+
+    <condition type="contains" id="regex_multiple_line">
+        <variable>text</variable>
+        <value regex="true">\AThis is.*line.*text\Z</value>
+    </condition>
+
+</izpack:conditions>


### PR DESCRIPTION
The boundaries ^ and $ did not work as supposed