### PR TITLE
IZPACK-1416

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -694,7 +694,7 @@ public class TreePacksPanel extends IzPanel
                     Pack childPack = packsModel.getPack(childPackName);
                     int row = packsModel.getNameToRow().get(childPackName);
 
-                    if (packsModel.isCheckBoxSelectable(row))
+                    if (packsModel.isChecked(row) || packsModel.isPartiallyChecked(row))
                     {
                         bytes += childPack.getSize();//SOMETHING HERE
                     }


### PR DESCRIPTION
TreePacksPanel counts parent pack size from selected or partially
selected packs, excluding the deselected as it was previously.