### PR TITLE
Fix pom: maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
               <!-- need to always fork as ClassUtils.loadJarInSystemClassLoader() mangles the system class loader -->
-              <forkMode>always</forkMode>
+              <forkCount>1</forkCount>
+              <reuseFork>false</reuseFork>
           </configuration>
       </plugin>
       <plugin>
@@ -696,7 +697,8 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <jvm>/opt/jdk/jdk1.6.0/bin/java</jvm>
-              <forkMode>once</forkMode>
+              <forkCount>1</forkCount>
+              <reuseFork>false</reuseFork>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -803,6 +803,8 @@
             <configuration>
               <includes>
                 <include>**/integration/**</include>
+              </includes>
+              <excludes>
                 <exclude>**/InstallationTest.java</exclude>
                 <exclude>**/EventTest.java</exclude>
                 <exclude>**/ExecutableFileTest.java</exclude>
@@ -817,8 +819,6 @@
                 <exclude>**/PackagingTest.java</exclude>
                 <exclude>**/PanelActionTest.java</exclude>
                 <exclude>**/MultiVolumeInstallationTest.java</exclude>
-              </includes>
-              <excludes>
                 <exclude>**/Abstract*</exclude>
                 <exclude>**/Test*Container*</exclude>
               </excludes>


### PR DESCRIPTION
some minor corrections for the maven-surefire-plugin
- `<exclude>`'s should be in `<excludes>`, not in `<includes>`
- replaced deprecated parameter `<forkMode>` by `<forkCount>` and `<reuseFork>`