### PR TITLE
IZPACK-1433: Global temporary folder never gets deleted

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
@@ -137,7 +137,7 @@ public abstract class AbstractInstallDataProvider implements Provider
             {
                 TemporaryDirectory directory = new TemporaryDirectory(tempDir, installData, housekeeper);
                 directory.create();
-                directory.cleanUp();
+                directory.deleteOnExit();
             }
         }
     }


### PR DESCRIPTION
[IZPACK-1433](https://izpack.atlassian.net/browse/IZPACK-1433):

I replaced cleanup() with deleteOnExit(). cleanup() does nothing that create() in the line before didn't already do, so I guess it was accidentally called instead of deleteOnExit() when this mechanism was initially implemented.