### PR TITLE
IZPACK-961: IzPack 5 unable to create web installer (patch from Marco Meschieri)

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/AbstractPackResources.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/AbstractPackResources.java
@@ -40,6 +40,11 @@ import com.izforge.izpack.api.resource.Resources;
 public abstract class AbstractPackResources implements PackResources
 {
     /**
+     * Temporary directory for web installers.
+     */
+    protected static final String WEB_TEMP_SUB_PATH = "/IzpackWebTemp";
+
+    /**
      * The resources.
      */
     private final Resources resources;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/GUIPackResources.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/GUIPackResources.java
@@ -1,11 +1,5 @@
 package com.izforge.izpack.installer.unpacker;
 
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InterruptedIOException;
-import java.net.URL;
-
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.ResourceException;
 import com.izforge.izpack.api.exception.ResourceInterruptedException;
@@ -14,6 +8,12 @@ import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.web.WebRepositoryAccessor;
 import com.izforge.izpack.util.IoHelper;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.net.URL;
+import java.util.logging.Logger;
 
 /**
  * {@link PackResources} implementation for the GUI-based installer.
@@ -22,11 +22,10 @@ import com.izforge.izpack.util.IoHelper;
  */
 public class GUIPackResources extends AbstractPackResources
 {
-
     /**
-     * Temporary directory.
+     * The logger.
      */
-    private static final String tempSubPath = "/IzpackWebTemp";
+    private static final Logger logger = Logger.getLogger(GUIPackResources.class.getName());
 
     /**
      * Constructs a {@code GUIPackResources}.
@@ -39,46 +38,51 @@ public class GUIPackResources extends AbstractPackResources
         super(resources, installData);
     }
 
-    /**
-     * Returns the stream to a web-based pack resource.
-     *
-     * @param name      the resource name
-     * @param webDirURL the web URL to load the resource from
-     * @return a stream to the resource
-     * @throws ResourceNotFoundException    if the resource cannot be found
-     * @throws ResourceInterruptedException if resource retrieval is interrupted
-     */
+    @Override
     protected InputStream getWebPackStream(String name, String webDirURL)
     {
         InputStream result;
 
-        // TODO: Look first in same directory as primary jar
-        // This may include prompting for changing of media
-        // TODO: download and cache them all before starting copy process
-
-        // See compiler.Packager#getJarOutputStream for the counterpart
         InstallData installData = getInstallData();
         String baseName = installData.getInfo().getInstallerBase();
-        String packURL = webDirURL + "/" + baseName + ".pack-" + name + ".jar";
-        String tempFolder = IoHelper.translatePath(
-                installData.getInfo().getUninstallerPath() + GUIPackResources.tempSubPath,
-                installData.getVariables());
-        String tempFile;
+        File installerDir = new File(baseName).getParentFile();
+
+        if (baseName.contains("/"))
+            baseName = baseName.substring(baseName.lastIndexOf('/'));
+
+        String packFileName = baseName + ".pack-" + name + ".jar";
+
+        // Look first in same directory as primary jar, then download it if not found
+        File packLocalFile = new File(installerDir, packFileName);
+        if (packLocalFile.exists() && packLocalFile.canRead())
+        {
+            logger.info("Found local pack " + packLocalFile.getAbsolutePath());
+        }
+        else
+        {
+            String packURL = webDirURL + "/" + baseName + ".pack-" + name.replace(" ", "%20") + ".jar";
+            logger.info("Downloading remote pack " + packURL);
+            String tempFolder = IoHelper.translatePath(installData.getInfo().getUninstallerPath()
+                    + WEB_TEMP_SUB_PATH, installData.getVariables());
+            String tempFile;
+            try
+            {
+                tempFile = WebRepositoryAccessor.getCachedUrl(packURL, tempFolder);
+                packLocalFile = new File(tempFile);
+            }
+            catch (InterruptedIOException exception)
+            {
+                throw new ResourceInterruptedException("Retrieval of " + webDirURL + " interrupted", exception);
+            }
+            catch (IOException exception)
+            {
+                throw new ResourceException("Failed to read " + webDirURL, exception);
+            }
+        }
+
         try
         {
-            tempFile = WebRepositoryAccessor.getCachedUrl(packURL, tempFolder);
-        }
-        catch (InterruptedIOException exception)
-        {
-            throw new ResourceInterruptedException("Retrieval of " + webDirURL + " interrupted", exception);
-        }
-        catch (IOException exception)
-        {
-            throw new ResourceException("Failed to read " + webDirURL, exception);
-        }
-        try
-        {
-            URL url = new URL("jar:" + tempFile + "!/packs/pack-" + name);
+            URL url = new URL("jar:" + packLocalFile.toURI().toURL() + "!/packs/pack-" + name);
             result = url.openStream();
         }
         catch (IOException exception)
@@ -87,6 +91,5 @@ public class GUIPackResources extends AbstractPackResources
         }
         return result;
     }
-
 
 }


### PR DESCRIPTION
This change solves [IZPACK-961](https://izpack.atlassian.net/browse/IZPACK-961):

The  web installation feature does not work beginning from IzPack 5 (see https://izpack.atlassian.net/wiki/x/AgBYAQ), compiling fails:
```
Exception in thread "main" java.lang.AssertionError: java.io.IOException: Stream Closed 
at org.izpack.mojo.IzPackNewMojo.execute(IzPackNewMojo.java:184) 
at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101) 
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209) 
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153) 
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145) 
at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84) 
at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59) 
at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183) 
at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161) 
at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320) 
at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156) 
at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537) 
at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196) 
at org.apache.maven.cli.MavenCli.main(MavenCli.java:141) 
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) 
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) 
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) 
at java.lang.reflect.Method.invoke(Method.java:601) 
at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290) 
at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230) 
at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409) 
at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352) 
Caused by: java.io.IOException: Stream Closed 
at java.io.RandomAccessFile.writeBytes(Native Method) 
at java.io.RandomAccessFile.write(RandomAccessFile.java:499) 
at org.apache.tools.zip.ZipOutputStream.writeOut(ZipOutputStream.java:1027) 
at org.apache.tools.zip.ZipOutputStream.writeOut(ZipOutputStream.java:1012) 
at org.apache.tools.zip.ZipOutputStream.writeLocalFileHeader(ZipOutputStream.java:734) 
at org.apache.tools.zip.ZipOutputStream.putNextEntry(ZipOutputStream.java:520) 
at com.izforge.izpack.compiler.stream.JarOutputStream.putNextEntry(JarOutputStream.java:145) 
at com.izforge.izpack.compiler.packager.impl.Packager.writePacks(Packager.java:144) 
at com.izforge.izpack.compiler.packager.impl.PackagerBase.writeInstaller(PackagerBase.java:452) 
at com.izforge.izpack.compiler.packager.impl.PackagerBase.createInstaller(PackagerBase.java:404) 
at com.izforge.izpack.compiler.Compiler.createInstaller(Compiler.java:143) 
at com.izforge.izpack.compiler.CompilerConfig.executeCompiler(CompilerConfig.java:332) 
at org.izpack.mojo.IzPackNewMojo.execute(IzPackNewMojo.java:180) 
... 21 more 
```

This patch has been sent by Marco Meschieri (LogicalDOC). I've adapted it and sent to Github.
Thanks for this.