### PR TITLE
IZPACK-1450: NPE when using validators extending PanelValidator and missing <configuration> section

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1712,7 +1712,9 @@ public class CompilerConfig extends Thread
                         addConfigurationOptions(validatorElement, configurable);
                         logger.finer("Validator " + validatorType.getName()
                                 + " extends the " + PanelValidator.class.getSimpleName()
-                                + "interface and adds " + configurable.getNames().size() + " parameters");
+                                + "interface and adds "
+                                + (configurable!=null&&configurable.getNames()!=null?configurable.getNames().size():"no")
+                                + " parameters");
                     }
                     logger.fine("Adding validator '" + validator + "' to panel '" + panel.getPanelId() + "'");
                     panel.addValidator(validatorType.getName(), validatorCondition, configurable);


### PR DESCRIPTION
This change fixes [IZPACK-1450](https://izpack.atlassian.net/browse/IZPACK-1450):

The following NPE happens when there is no `<configuration>` element nested to a panel validator extending the new PanelValidator abstract class instead of DataValidator interface:
```
[ERROR] Failed to execute goal org.codehaus.izpack:izpack-maven-plugin:5.0.10:izpack (default-izpack) on project sm-installer-server: Failure: NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.izpack:izpack-maven-plugin:5.0.10:izpack (default-izpack) on project sm-installer-server: Failure
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:216)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:120)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:355)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:216)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:160)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
        at java.lang.reflect.Method.invoke(Method.java:597)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Failure
        at org.izpack.mojo.IzPackNewMojo.execute(IzPackNewMojo.java:234)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
        ... 19 more
Caused by: java.lang.NullPointerException
        at com.izforge.izpack.compiler.CompilerConfig.addPanels(CompilerConfig.java:1713)
        at com.izforge.izpack.compiler.CompilerConfig.executeCompiler(CompilerConfig.java:357)
        at org.izpack.mojo.IzPackNewMojo.execute(IzPackNewMojo.java:224)
        ... 21 more
```