### PR TITLE
IZPACK-1453: <pack> element doesn't allow the 'os' attribute by XSD, although it is implemented

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -495,6 +495,7 @@
         <xs:attribute name="excludeGroup" type="xs:string" use="optional"/>
         <xs:attribute name="parent" type="xs:string" use="optional"/>
         <xs:attribute name="group" type="xs:string" use="optional"/>
+        <xs:attribute name="os" type="types:osFamilyAttributeType" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="refpackType">


### PR DESCRIPTION
This PR fixes issue [IZPACK-1453](https://izpack.atlassian.net/browse/IZPACK-1453):

Currently, the compiler does not allow the '**os**' attribute for the `<pack>` element, like in this example:
```xml
  <packs>
    <pack name="WindowsPack" required="no" id="pack.windows" os="windows">
      <description>Windows</description>
      <fileset dir="plain/windows"/>
    </pack>
    <pack name="LinuxPack" required="no" id="pack.linux" os="unix">
      <description>Windows</description>
      <fileset dir="plain/linux"/>
    </pack>
    <pack name="Common" required="yes" id="pack.common">
      <description>Common</description>
      <fileset dir="plain/common"/>
    </pack>
  </packs>
```

which ends in:

```
ERROR: 'cvc-complex-type.3.2.2: Attribute 'os' is not allowed to appear in element 'pack'.'
ERROR: 'com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: cvc-complex-type.3.2.2: Attribute 'os' is not allowed to appear in element 'pack'.'
```

This should be enabled in the XSD, since this feature is implemented and also documented.