### PR TITLE
IZPACK-1459: Another NPE when using validators extending PanelValidator and missing <configuration> section

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanelView.java
@@ -30,6 +30,7 @@ import com.izforge.izpack.data.PanelAction.ActionStage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -466,9 +467,13 @@ public abstract class AbstractPanelView<T> implements PanelView<T>
             Configurable configurable = getPanel().getValidatorConfiguration(index);
             if (configurable != null)
             {
-                for (String name : configurable.getNames())
+                final Set<String> names = configurable.getNames();
+                if (names != null)
                 {
-                    panelValidator.addConfigurationOption(name, configurable.getConfigurationOption(name));
+                    for (String name : names)
+                    {
+                        panelValidator.addConfigurationOption(name, configurable.getConfigurationOption(name));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This implementation fixes [IZPACK-1459](https://izpack.atlassian.net/browse/IZPACK-1459):

There is another NPE happening during the installation for validators extending the abstract `PanelValidator` class directly:
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
        at com.izforge.izpack.installer.panel.AbstractPanelView.isValid(AbstractPanelView.java:469)
        at com.izforge.izpack.installer.panel.AbstractPanelView.validateData(AbstractPanelView.java:428)
        at com.izforge.izpack.installer.gui.IzPanelView.validateData(IzPanelView.java:115)
        at com.izforge.izpack.installer.panel.AbstractPanelView.isValid(AbstractPanelView.java:258)
        at com.izforge.izpack.installer.panel.AbstractPanelView.isValid(AbstractPanelView.java:233)
        at com.izforge.izpack.installer.gui.IzPanelView.isValid(IzPanelView.java:61)
        at com.izforge.izpack.installer.panel.AbstractPanels.executeValidationActions(AbstractPanels.java:608)
        at com.izforge.izpack.installer.panel.AbstractPanels.isValid(AbstractPanels.java:178)
        at com.izforge.izpack.installer.panel.AbstractPanels.next(AbstractPanels.java:250)
        at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:345)
        at com.izforge.izpack.installer.gui.DefaultNavigator.next(DefaultNavigator.java:328)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.navigate(DefaultNavigator.java:563)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.access$100(DefaultNavigator.java:526)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler$1$1.run(DefaultNavigator.java:546)
        at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```