### PR TITLE
IZPACK-1460: Misleading message "Validation failed - continuing installation"

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
@@ -201,6 +201,6 @@ file we looked for -->
     <str id="ProcessPanel.heading" txt="Probíhá"/>
 
     <str id="data.validation.error.title" txt="Ověrování selhalo"/>
-    <str id="data.validation.warning.title" txt="Ověrování selhalo - pokračuji instalaci"/>
+    <str id="data.validation.warning.title" txt="Důležité upozornění"/>
 
 </izpack:langpack>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
@@ -383,6 +383,6 @@ for each category (message/warning/error) start at 0 -->
     <str id="debug.changevariable" txt="Wert ändern"/>
 
     <str id="data.validation.error.title" txt="Überprüfung fehlgeschlagen"/>
-    <str id="data.validation.warning.title" txt="Überprüfung fehlgeschlagen - Installation wird fortgesetzt"/>
+    <str id="data.validation.warning.title" txt="Wichtiger Hinweis"/>
 
 </izpack:langpack>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -402,6 +402,6 @@ for each category (message/warning/error) start at 0 -->
     <str id="debug.changevariable" txt="modify value"/>
 
     <str id="data.validation.error.title" txt="Validation failed"/>
-    <str id="data.validation.warning.title" txt="Validation failed - continuing installation"/>
+    <str id="data.validation.warning.title" txt="Attention needed"/>
 
 </izpack:langpack>


### PR DESCRIPTION
This change fixes [IZPACK-1460](https://izpack.atlassian.net/browse/IZPACK-1460):

In a panel validator, if a filing validation should result in a warning popup window which can be quitted by the user if he wants to ignore this, the title of the messagebox appearing is odd:
"_Validation failed - continuing installation_"
It should be rather something like:
"_Risk detected"_, "_Attention needed_"
or something similar, which is shorter (no cutting of the title for shorter message texts) and does more fit the potential situation. 

Fixed the english, german and czech translation.
Feel free to send your own translations.