### PR TITLE
IZPACK-1298: <executable> with <fileset> do not update executable file mode

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/util/AntPathMatcher.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/util/AntPathMatcher.java
@@ -28,7 +28,7 @@ public class AntPathMatcher {
      * according to this PathMatcher's matching strategy.
      * @param pattern the pattern to match against
      * @param path the path String to test
-     * @param caseInsensitive whether the test should be case-insensitive
+     * @param caseSensitive whether the test should be case-sensitive
      * @return <code>true</code> if the supplied <code>path</code> matched,
      * <code>false</code> if it didn't
      */
@@ -38,6 +38,7 @@ public class AntPathMatcher {
         pattern = pattern.replaceAll("\\.", "\\\\.");
         pattern = pattern.replaceAll("\\*", "[^/]*");
         pattern = pattern.replaceAll("(\\[\\^/\\]\\*){2}", ".*");
+        pattern = pattern.replaceAll("/\\.\\*", "(/.*)*");
         pattern = unifyVarReferences(pattern);
         pattern = pattern.replaceAll("\\$", "\\\\\\$");
 


### PR DESCRIPTION
This change fixes [IZPACK-1298](https://izpack.atlassian.net/browse/IZPACK-1298):

If you use something like
```xml
<executable type="bin" stage="never">
    <fileset targetdir="${INSTALL_PATH}">
        <include name="**/*.sh"/>
    </fileset>
</executable>
```
and the file expected to be marked executable is directly in `${INSTALL_PATH}` it is ignored. If the according file is in a subdirectory of `${INSTALL_PATH}` it gets included.

The reason is a bad regular expression internally built in `AntPathMatcher` for this: `${INSTALL_PATH}/.*/*.sh` which matches just files in subdirectories of the installation path.

Parsables with filesets are affected as well.