### PR TITLE
IZPACK-1436: Add default value mappers for reading from (or saving to the file)

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Overrides.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Overrides.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.api.data;
+
+import java.io.File;
+import java.io.IOException;
+
+/*
+ * Container for holding installer variable overrides and reading them from a file.
+ */
+public interface Overrides
+{
+    /**
+     * Get override value for variable name and resolve variable references.
+     * @param name the Izpack variable name
+     * @return the override value for the variable, if it exists
+     */
+    String fetch(String name);
+
+    /**
+     * Get override value for variable name and resolve variable references.
+     * This method accepts a fallback value in case the override hasn't been defined.
+     * @param name the Izpack variable name
+     * @param defaultValue
+     * @return the override value for the variable, if it exists, or the given default value
+     */
+    String fetch(String name, String defaultValue);
+
+    /**
+     * Returns whether an override for a given variable name exists in this container.
+     * @param name the Izpack variable name
+     * @return true if an override exists for the given name
+     */
+    boolean containsKey(String name);
+
+    /**
+     * Removes the override for a given variable name from the container.
+     * @param name the Izpack variable name
+     * @return the override value of the removed entry
+     */
+    String remove(String name);
+
+    /**
+     * Returns the overall number of overrides for variable values in this container.
+     * @return the number of overrides in the current container
+     */
+    int size();
+
+    /**
+     * Initialize the installer runtime data.
+     * @param installData the installer runtime data
+     */
+    void setInstallData(InstallData installData);
+
+    /**
+     * Returns a reference to the overrides file used to initialize this container.
+     * @return the overrides file
+     */
+    File getFile();
+
+    /**
+     * Loads the overrides from the file system.
+     * When using unresolved variables in defaults file include definitions call {@link #setInstallData(InstallData)}
+     * first.
+     * @throws IOException if an I/O error occurs during loading
+     */
+    void load() throws IOException;
+}

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/VariableMapper.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/VariableMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.api.data;
+
+public interface VariableMapper
+{
+    String map(String value) throws Exception;
+}

--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/Variables.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/Variables.java
@@ -22,7 +22,6 @@
 package com.izforge.izpack.api.data;
 
 
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.exception.InstallerException;
 
 import java.util.Properties;
@@ -174,12 +173,12 @@ public interface Variables
      *
      * @return the variables
      */
-    void setOverrides(Options overrides);
+    void setOverrides(Overrides overrides);
 
     /**
      * Return all variables overrides.
      *
      * @return the variables overrides
      */
-    Options getOverrides();
+    Overrides getOverrides();
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultOverrides.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultOverrides.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.core.data;
+
+import com.izforge.izpack.api.config.Config;
+import com.izforge.izpack.api.config.Options;
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
+import com.izforge.izpack.api.exception.IzPackException;
+import com.izforge.izpack.api.data.VariableMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+
+public class DefaultOverrides extends Options implements Overrides
+{
+    public DefaultOverrides(File file) throws IOException
+    {
+        Config config = Config.getGlobal().clone();
+        config.setFileEncoding(Charset.forName("UTF-8"));
+        config.setInclude(true);
+        config.setComment(true);
+        setConfig(config);
+        setFile(file);
+        //load();
+    }
+
+    @Override
+    public String fetch(String name)
+    {
+        return processMapping(name, super.fetch(name));
+    }
+
+    @Override
+    public String fetch(String name, String defaultValue)
+    {
+        return processMapping(name, super.fetch(name, defaultValue));
+    }
+
+    @Override
+    public boolean containsKey(String name)
+    {
+        return super.containsKey(name);
+    }
+
+    @Override
+    public String remove(String name)
+    {
+        return super.remove(name);
+    }
+
+    @Override
+    public void setInstallData(InstallData installData)
+    {
+        getConfig().setInstallData(installData);
+    }
+
+    private String processMapping(String name, String value)
+    {
+        boolean isMappingMode = false;
+        if (value != null)
+        {
+            List<String> comments = getComment(name);
+            if (comments != null)
+            {
+                for (String comment : comments)
+                {
+                    if (comment != null)
+                    {
+                        comment = comment.trim();
+                        String entries[] = comment.split("(\\r?\\n)|;|,");
+                        for (String entry : entries)
+                        {
+                            entry = entry.trim();
+                            if (!entry.isEmpty())
+                            {
+                                if (entry.equals("BEGIN MAP"))
+                                {
+                                    isMappingMode = true;
+                                    continue;
+                                } else if (entry.equals("END MAP"))
+                                {
+                                    isMappingMode = false;
+                                    continue;
+                                }
+                                if (isMappingMode)
+                                {
+                                    Class<?> mapperClass = null;
+                                    VariableMapper instance = null;
+                                    try
+                                    {
+                                        mapperClass = Class.forName(entry);
+                                        instance = (VariableMapper) mapperClass.newInstance();
+                                        value = instance.map(value);
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        throw new IzPackException(
+                                                "Failure mapping override of variable '" + name
+                                                + "' defined in file " + getFile(), e);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return value;
+    }
+
+}

--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/DefaultVariables.java
@@ -22,6 +22,7 @@
 package com.izforge.izpack.core.data;
 
 import com.izforge.izpack.api.data.DynamicVariable;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.exception.IzPackException;
@@ -29,7 +30,6 @@ import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.core.substitutor.VariableSubstitutorImpl;
 import com.izforge.izpack.core.variable.utils.ValueUtils;
-import com.izforge.izpack.api.config.Options;
 
 import java.util.*;
 import java.util.logging.Level;
@@ -52,7 +52,7 @@ public class DefaultVariables implements Variables
     /**
      * The forced override values.
      */
-    private Options overrides;
+    private Overrides overrides;
 
     /**
      * The dynamic variables.
@@ -160,7 +160,7 @@ public class DefaultVariables implements Variables
     public String get(String name, String defaultValue)
     {
         final String value = properties.getProperty(name, defaultValue);
-        return containsOverride(name) ? overrides.get(name, value) : value;
+        return containsOverride(name) ? overrides.fetch(name, value) : value;
     }
 
     /**
@@ -421,13 +421,13 @@ public class DefaultVariables implements Variables
     }
 
     @Override
-    public void setOverrides(Options overrides)
+    public void setOverrides(Overrides overrides)
     {
         this.overrides = overrides;
     }
 
     @Override
-    public Options getOverrides()
+    public Overrides getOverrides()
     {
         return this.overrides;
     }

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/DefaultVariablesTest.java
@@ -21,10 +21,7 @@
 
 package com.izforge.izpack.core.data;
 
-import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.api.data.DynamicVariable;
-import com.izforge.izpack.api.data.Panel;
-import com.izforge.izpack.api.data.Variables;
+import com.izforge.izpack.api.data.*;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.core.container.DefaultContainer;
@@ -36,7 +33,6 @@ import com.izforge.izpack.core.variable.ConfigFileValue;
 import com.izforge.izpack.core.variable.PlainConfigFileValue;
 import com.izforge.izpack.core.variable.PlainValue;
 import com.izforge.izpack.util.Platforms;
-import com.izforge.izpack.api.config.Options;
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -730,20 +726,32 @@ public class DefaultVariablesTest
     }
 
     /**
-     * Tests a variable defined both static (<variables>) and dynamic (<dynamicvariables>)
+     * Tests variable overrides to be passed to the installer
      */
     @Test
     public void testOverrides()
     {
-        Options overrides = new Options();
-        overrides.put("var1", "override1");
-        variables.set("var1", "value1");
+        File file = new File("src/test/resources/com/izforge/izpack/core/data/test.defaults");
+        assertTrue("File " + file + " not found", file.exists());
+        Overrides overrides = null;
+        try
+        {
+            overrides = new DefaultOverrides(file);
+            overrides.load();
+        }
+        catch (IOException e)
+        {
+            fail(e.getMessage());
+        }
+        variables.add(createDynamic("var1", "dynamic_definition"));
         variables.setOverrides(overrides);
-        variables.add(createDynamic("var1", "dynValue"));
-
-        assertEquals("override before refresh", "override1", variables.get("var1"));
         variables.refresh();
-        assertEquals("override after refresh", "override1", variables.get("var1"));
+        assertEquals("Wrong override after refresh without explicitly setting the variable",
+                "OVERRIDE1", variables.get("var1"));
+        variables.set("var1", "explicit_value");
+        assertEquals("Explicitly set variable value not present not present after refresh"
+                        + "- user input will not override the defaults contents",
+                "explicit_value", variables.get("var1"));
     }
 
 }

--- a/izpack-core/src/test/java/com/izforge/izpack/core/data/UpperCaseTestVariableMapper.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/data/UpperCaseTestVariableMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.core.data;
+
+import com.izforge.izpack.api.data.VariableMapper;
+
+public class UpperCaseTestVariableMapper implements VariableMapper
+{
+    @Override
+    public String map(String value)
+    {
+        return value.toUpperCase();
+    }
+}

--- a/izpack-core/src/test/resources/com/izforge/izpack/core/data/test.defaults
+++ b/izpack-core/src/test/resources/com/izforge/izpack/core/data/test.defaults
@@ -1,0 +1,20 @@
+#
+# Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# BEGIN MAP
+# com.izforge.izpack.core.data.UpperCaseTestVariableMapper
+# END MAP
+var1=override1

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/PanelAutomation.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/PanelAutomation.java
@@ -23,8 +23,8 @@ package com.izforge.izpack.installer.automation;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.exception.InstallerException;
-import com.izforge.izpack.api.config.Options;
 
 /**
  * Defines the Interface that must be implemented for running Panels in automated (or "silent",
@@ -68,8 +68,8 @@ public interface PanelAutomation
      * This method is not called if an installation record exists for this panel in an auto-install.xml
      * (e.g. in this case @(see runAutomated) is launched).
      *
-     * @param installData
-     * @param options
+     * @param installData the runtime data of the installer session
+     * @param overrides the variable overrides
      */
-    void processOptions(InstallData installData, Options options);
+    void processOptions(InstallData installData, Overrides overrides);
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -21,9 +21,9 @@
 
 package com.izforge.izpack.installer.bootstrap;
 
-import com.izforge.izpack.api.config.Config;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.Overrides;
+import com.izforge.izpack.core.data.DefaultOverrides;
 import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.installer.automation.AutomatedInstaller;
 import com.izforge.izpack.installer.console.ConsoleInstallerAction;
@@ -38,7 +38,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -209,7 +208,7 @@ public class Installer
                 }
             }
 
-            Options defaults = getDefaults(defaultsFile);
+            Overrides defaults = getDefaults(defaultsFile);
             if (type == INSTALLER_AUTO && path == null && defaults == null)
             {
                 logger.log(Level.SEVERE,
@@ -228,7 +227,7 @@ public class Installer
         }
     }
 
-    public Options getDefaults(String path)
+    public Overrides getDefaults(String path) throws IOException
     {
         File overridePropFile = null;
 
@@ -254,19 +253,14 @@ public class Installer
 
         if (overridePropFile != null)
         {
-            Config config = Config.getGlobal().clone();
-            config.setFileEncoding(Charset.forName("UTF-8"));
-            config.setInclude(true);
-            Options opts = new Options(config);
-            opts.setFile(overridePropFile);
-            return opts;
+            return new DefaultOverrides(overridePropFile);
         }
 
         return null;
     }
 
     private void launchInstall(int type, ConsoleInstallerAction consoleAction, String path, String langCode,
-                               String mediaDir, Options defaults, String[] args) throws Exception
+                               String mediaDir, Overrides defaults, String[] args) throws Exception
     {
         // if headless, just use the console mode
         if (type == INSTALLER_GUI && GraphicsEnvironment.isHeadless())
@@ -301,14 +295,13 @@ public class Installer
      * @param args more command line arguments
      * @throws Exception for any error
      */
-    private void launchAutomatedInstaller(String path, String mediaDir, Options defaults, String[] args) throws Exception
+    private void launchAutomatedInstaller(String path, String mediaDir, Overrides defaults, String[] args) throws Exception
     {
         InstallerContainer container = new AutomatedInstallerContainer();
 
         if (defaults != null)
         {
-            Config config = defaults.getConfig();
-            config.setInstallData(container.getComponent(AutomatedInstallData.class));
+            defaults.setInstallData(container.getComponent(AutomatedInstallData.class));
             defaults.load();
             logger.info("Loaded " + defaults.size() + " override(s) from " + defaults.getFile());
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerConsole.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerConsole.java
@@ -19,10 +19,9 @@
 
 package com.izforge.izpack.installer.bootstrap;
 
-import com.izforge.izpack.api.config.Config;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.container.Container;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.installer.console.ConsoleInstaller;
@@ -43,7 +42,7 @@ public class InstallerConsole
   private static final Logger logger = Logger.getLogger(InstallerConsole.class.getName());
   
   public static void run(final ConsoleInstallerAction consoleAction, final String path, final String langCode,
-                         final String mediaPath, Options defaults, final String[] args)
+                         final String mediaPath, Overrides defaults, final String[] args)
   {
     final InstallerContainer applicationComponent = new ConsoleInstallerContainer();
     final Container installerContainer = applicationComponent.getComponent(Container.class);
@@ -58,8 +57,7 @@ public class InstallerConsole
 
       if (defaults != null)
       {
-        Config config = defaults.getConfig();
-        config.setInstallData(installData);
+        defaults.setInstallData(installData);
         defaults.load();
         logger.info("Loaded " + defaults.size() + " override(s) from " + defaults.getFile());
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
@@ -21,9 +21,8 @@
 
 package com.izforge.izpack.installer.bootstrap;
 
-import com.izforge.izpack.api.config.Config;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.container.Container;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.core.data.DefaultVariables;
 import com.izforge.izpack.installer.container.impl.GUIInstallerContainer;
@@ -50,7 +49,7 @@ public class InstallerGui
     private static SplashScreen splashScreen = null;
 
     
-    public static void run(final String langCode, final String mediaPath, final Options defaults) throws Exception
+    public static void run(final String langCode, final String mediaPath, final Overrides defaults) throws Exception
     {
         final InstallerContainer applicationComponent = new GUIInstallerContainer();
         final Container installerContainer = applicationComponent.getComponent(Container.class);
@@ -88,8 +87,7 @@ public class InstallerGui
 
 			if (defaults != null)
 			{
-				Config config = defaults.getConfig();
-				config.setInstallData(applicationComponent.getComponent(InstallData.class));
+				defaults.setInstallData(applicationComponent.getComponent(InstallData.class));
 				defaults.load();
 				logger.info("Loaded " + defaults.size() + " override(s) from " + defaults.getFile());
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/compile/CompilePanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/compile/CompilePanelAutomationHelper.java
@@ -23,8 +23,8 @@
 package com.izforge.izpack.panels.compile;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
@@ -148,7 +148,7 @@ public class CompilePanelAutomationHelper extends PanelAutomationHelper implemen
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 
     /**
      * Reports progress on System.out

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/defaulttarget/DefaultTargetPanelAutomationHelper.java
@@ -23,8 +23,8 @@ package com.izforge.izpack.panels.defaulttarget;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 
 /**
@@ -71,9 +71,9 @@ public class DefaultTargetPanelAutomationHelper implements PanelAutomation
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options)
+    public void processOptions(InstallData installData, Overrides overrides)
     {
-        String path = options.get(InstallData.INSTALL_PATH);
+        String path = overrides.fetch(InstallData.INSTALL_PATH);
         handleInstallPath(installData, path);
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishPanelAutomation.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/finish/FinishPanelAutomation.java
@@ -1,8 +1,8 @@
 package com.izforge.izpack.panels.finish;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 
 public class FinishPanelAutomation implements PanelAutomation
@@ -39,6 +39,6 @@ public class FinishPanelAutomation implements PanelAutomation
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/hello/HelloPanelAutomation.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/hello/HelloPanelAutomation.java
@@ -1,8 +1,8 @@
 package com.izforge.izpack.panels.hello;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 
 public class HelloPanelAutomation implements PanelAutomation
@@ -39,6 +39,6 @@ public class HelloPanelAutomation implements PanelAutomation
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/install/InstallPanelAutomationHelper.java
@@ -22,8 +22,8 @@
 package com.izforge.izpack.panels.install;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.event.ProgressListener;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.installer.automation.PanelAutomation;
@@ -70,7 +70,7 @@ public class InstallPanelAutomationHelper extends PanelAutomationHelper implemen
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options)
+    public void processOptions(InstallData installData, Overrides overrides)
     {
         unpacker.run();
         if (!unpacker.getResult())

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/installationgroup/InstallationGroupPanelAutomationHelper.java
@@ -23,8 +23,8 @@ package com.izforge.izpack.panels.installationgroup;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 
@@ -91,5 +91,5 @@ public class InstallationGroupPanelAutomationHelper implements PanelAutomation
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelAutomationHelper.java
@@ -2,8 +2,8 @@ package com.izforge.izpack.panels.jdkpath;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 import com.izforge.izpack.installer.automation.PanelAutomationHelper;
@@ -38,5 +38,5 @@ public class JDKPathPanelAutomationHelper extends PanelAutomationHelper implemen
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/packs/PacksPanelAutomationHelper.java
@@ -23,8 +23,8 @@ package com.izforge.izpack.panels.packs;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.installer.automation.PanelAutomation;
@@ -204,5 +204,5 @@ public class PacksPanelAutomationHelper implements PanelAutomation
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelAutomation.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelAutomation.java
@@ -22,8 +22,8 @@
 package com.izforge.izpack.panels.process;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.api.rules.RulesEngine;
@@ -78,7 +78,7 @@ public class ProcessPanelAutomation extends PanelAutomationHelper implements Pan
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 
     public void logOutput(String message, boolean stderr)
     {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelAutomationHelper.java
@@ -23,9 +23,9 @@
 package com.izforge.izpack.panels.shortcut;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 import com.izforge.izpack.installer.automation.PanelAutomationHelper;
@@ -104,5 +104,5 @@ public class ShortcutPanelAutomationHelper extends PanelAutomationHelper impleme
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelAutomation.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/target/TargetPanelAutomation.java
@@ -23,8 +23,8 @@ package com.izforge.izpack.panels.target;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 
@@ -68,9 +68,9 @@ public class TargetPanelAutomation implements PanelAutomation
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options)
+    public void processOptions(InstallData installData, Overrides overrides)
     {
-        String path = options.get(InstallData.INSTALL_PATH);
+        String path = overrides.fetch(InstallData.INSTALL_PATH);
         if (path != null)
         {
             handleInstallPath(installData, path);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/UserInputPanelAutomationHelper.java
@@ -24,8 +24,8 @@ package com.izforge.izpack.panels.userinput;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.installer.automation.PanelAutomation;
@@ -177,5 +177,5 @@ public class UserInputPanelAutomationHelper implements PanelAutomation
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathPanelAutomationHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userpath/UserPathPanelAutomationHelper.java
@@ -23,8 +23,8 @@ package com.izforge.izpack.panels.userpath;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
-import com.izforge.izpack.api.config.Options;
 import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
 import com.izforge.izpack.installer.automation.PanelAutomation;
 
 /**
@@ -74,5 +74,5 @@ public class UserPathPanelAutomationHelper implements PanelAutomation
     }
 
     @Override
-    public void processOptions(InstallData installData, Options options) {}
+    public void processOptions(InstallData installData, Overrides overrides) {}
 }


### PR DESCRIPTION
This is an implementation of [IZPACK-1436](https://izpack.atlassian.net/browse/IZPACK-1436):

Along with reading (and possible writing) of default values from/to a file there should be a possibility to map key names and values from the file to the installer and vice versa.

Example:
Your installer has a panel gathering a (plain) password and assigning it to the internal variable app.server.pass.plain. The key name should be more user-friendly in the defaults file and furthermore the password held as plain string in the installer should be encrypted in the defaults file, while decrypting it on the fly when reading it. Thus there should be a double mapping:

Reading defaults:
- key name: Application Password ==> app.server.pass.plain
- key value: some_encrypted_text ==> (decrypt mapper) ==> plain_password

Mapping should be done by some Java class compiled into the installer. There should be some application interfaces prepared for mapping the values. The class names should come from some text file.

The key names should be mapped directly, defined in some text file.