### PR TITLE
IZPACK-1466: Non-canonical paths do not work in exists condition

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ContainsCondition.java
@@ -1,25 +1,22 @@
 package com.izforge.izpack.core.rules.process;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.exception.CompilerException;
 import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.core.variable.utils.ValueUtils;
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ContainsCondition extends Condition {
 
@@ -73,7 +70,7 @@ public class ContainsCondition extends Condition {
         break;
 
     case FILE:
-        File file = new File(variables.replace(this.source));
+        File file = new File(FilenameUtils.normalize(variables.replace(this.source)));
         byte[] buffer = new byte[(int) file.length()];
         BufferedInputStream f = null;
         try

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/EmptyCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/EmptyCondition.java
@@ -22,20 +22,17 @@
 
 package com.izforge.izpack.core.rules.process;
 
-import java.io.File;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.exception.CompilerException;
 import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.core.variable.utils.ValueUtils;
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.File;
+import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * This condition checks if a certain type is empty
@@ -84,7 +81,7 @@ public class EmptyCondition extends Condition
             case FILE:
                 if (this.content != null)
                 {
-                    File file = new File(variables.replace(this.content));
+                    File file = new File(FilenameUtils.normalize(variables.replace(this.content)));
                     if (!file.exists() && file.length() == 0)
                     {
                         result = true;
@@ -95,7 +92,7 @@ public class EmptyCondition extends Condition
             case DIR:
                 if (this.content != null)
                 {
-                    File file = new File(variables.replace(this.content));
+                    File file = new File(FilenameUtils.normalize(variables.replace(this.content)));
                     if (!file.exists() || file.isDirectory() && file.listFiles().length == 0)
                     {
                         result = true;

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ExistsCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/ExistsCondition.java
@@ -22,20 +22,17 @@
 
 package com.izforge.izpack.core.rules.process;
 
-import java.io.File;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.impl.XMLElementImpl;
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.exception.CompilerException;
 import com.izforge.izpack.api.rules.Condition;
 import com.izforge.izpack.core.variable.utils.ValueUtils;
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.File;
+import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * This condition checks if a certain variable has a value. If it is not
@@ -81,7 +78,7 @@ public class ExistsCondition extends Condition
                 if (this.content != null)
                 {
                     Variables variables = getInstallData().getVariables();
-                    File file = new File(variables.replace(this.content));
+                    File file = new File(FilenameUtils.normalize(variables.replace(this.content)));
                     if (file.exists())
                     {
                         result = true;


### PR DESCRIPTION
Imagine you have property e.g. property INSTALL_PATH set to C:/test and a file test.txt exists in C: root.

When you use exists condition it is not able to create a canonical path if you set it like this
```xml
<condition type="exists" id="DoesNotWork">
  <file>${INSTALL_PATH}/../test.txt</file>
</condition>
```
it is evaluated as false.
When you set it like
```xml
<condition type="exists" id="Works">
  <file>C:/test.txt</file>
</condition>
```
it is true.
