### PR TITLE
IZPACK-1467: Possible deadlock in GUI mode if Next button is locked from a panel implementation

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/DefaultNavigator.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/DefaultNavigator.java
@@ -156,7 +156,7 @@ public class DefaultNavigator implements Navigator
     @Override
     public boolean isNextEnabled()
     {
-        return panels.isNextEnabled();
+        return next.isEnabled();
     }
 
     /**
@@ -165,10 +165,9 @@ public class DefaultNavigator implements Navigator
      * @param enable if {@code true}, enable navigation, otherwise disable it
      */
     @Override
-    public void setNextEnabled(boolean enable)
+    public void setNextEnabled(final boolean enable)
     {
         configureNext = !switchPanel;
-        panels.setNextEnabled(enable);
         next.setEnabled(enable);
     }
 
@@ -213,7 +212,7 @@ public class DefaultNavigator implements Navigator
     @Override
     public boolean isPreviousEnabled()
     {
-        return panels.isPreviousEnabled();
+        return previous.isEnabled();
     }
 
     /**
@@ -225,7 +224,6 @@ public class DefaultNavigator implements Navigator
     public void setPreviousEnabled(boolean enable)
     {
         configurePrevious = !switchPanel;
-        panels.setPreviousEnabled(enable);
         previous.setEnabled(enable);
     }
 
@@ -337,19 +335,17 @@ public class DefaultNavigator implements Navigator
     public boolean next(boolean validate)
     {
         boolean result = false;
-        if (panels.isNextEnabled())
+        try
         {
-            try
-            {
-                preSwitchPanel();
-                result = panels.next(validate);
-            }
-            finally
-            {
-                postSwitchPanel();
-            }
-            configureVisibility();
+            preSwitchPanel();
+            result = panels.next(validate);
         }
+        finally
+        {
+            postSwitchPanel();
+        }
+        configureVisibility();
+
         return result;
     }
 
@@ -362,7 +358,7 @@ public class DefaultNavigator implements Navigator
     public boolean previous()
     {
         boolean result = false;
-        if (panels.isPreviousEnabled())
+        if (isPreviousEnabled())
         {
             try
             {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -893,35 +893,6 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
     }
 
     /**
-     * Check to see if there is another panel that can be navigated to next. This checks the
-     * successive panels to see if at least one can be shown based on the conditions associated with
-     * the panels.
-     *
-     * @param startPanel  The panel to check from
-     * @param visibleOnly Only check the visible panels
-     * @return The panel that we can navigate to next or -1 if there is no panel that we can
-     *         navigate next to
-     */
-    public int hasNavigateNext(int startPanel, boolean visibleOnly)
-    {
-        return panels.getNext(startPanel, visibleOnly);
-    }
-
-    /**
-     * Check to see if there is another panel that can be navigated to previous. This checks the
-     * previous panels to see if at least one can be shown based on the conditions associated with
-     * the panels.
-     *
-     * @param endingPanel The panel to check from
-     * @return The panel that we can navigate to previous or -1 if there is no panel that we can
-     *         navigate previous to
-     */
-    public int hasNavigatePrevious(int endingPanel, boolean visibleOnly)
-    {
-        return panels.getPrevious(endingPanel, visibleOnly);
-    }
-
-    /**
      * This function moves to the previous panel
      */
     @Override

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/AbstractPanels.java
@@ -201,28 +201,6 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
     }
 
     /**
-     * Determines if the next panel may be navigated to.
-     *
-     * @param enable if {@code true}, enable navigation, otherwise disable it
-     */
-    @Override
-    public void setNextEnabled(boolean enable)
-    {
-        nextEnabled = enable;
-    }
-
-    /**
-     * Determines if navigation to the next panel has been enabled.
-     * <p/>
-     * return {@code true} if navigation is enabled
-     */
-    @Override
-    public boolean isNextEnabled()
-    {
-        return nextEnabled && hasNext();
-    }
-
-    /**
      * Navigates to the next panel.
      * <br/>
      * Navigation can only occur if the current panel is valid.
@@ -260,28 +238,6 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
     }
 
     /**
-     * Determines if the previous panel may be navigated to.
-     *
-     * @param enable if {@code true}, enable navigation, otherwise disable it
-     */
-    @Override
-    public void setPreviousEnabled(boolean enable)
-    {
-        previousEnabled = enable;
-    }
-
-    /**
-     * Determines if navigation to the previous panel has been enabled.
-     * <p/>
-     * return {@code true} if navigation is enabled
-     */
-    @Override
-    public boolean isPreviousEnabled()
-    {
-        return previousEnabled && hasPrevious();
-    }
-
-    /**
      * Determines if there is panel prior to the current panel.
      *
      * @return {@code true} if there is a panel prior to the current panel
@@ -314,7 +270,7 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
     public boolean previous(int index)
     {
         boolean result = false;
-        if (isPreviousEnabled())
+        if (hasPrevious())
         {
             int newIndex = getPrevious(index, true);
             if (newIndex != -1)
@@ -491,7 +447,7 @@ public abstract class AbstractPanels<T extends AbstractPanelView<V>, V> implemen
             panel.saveData();
         }
 
-        if ((newIndex > index) && !isNextEnabled()) // NOTE: actions may change isNextEnabled() status
+        if ((newIndex > index) && !hasNext()) // NOTE: actions may change isNextEnabled() status
         {
             return false;
         }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/Panels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/panel/Panels.java
@@ -21,9 +21,9 @@
 
 package com.izforge.izpack.installer.panel;
 
-import java.util.List;
-
 import com.izforge.izpack.api.data.Panel;
+
+import java.util.List;
 
 
 /**
@@ -87,20 +87,6 @@ public interface Panels
     boolean next(boolean validate);
 
     /**
-     * Determines if the next panel may be navigated to.
-     *
-     * @param enable if {@code true}, enable navigation, otherwise disable it
-     */
-    void setNextEnabled(boolean enable);
-
-    /**
-     * Determines if navigation to the next panel has been enabled.
-     * <p/>
-     * return {@code true} if navigation is enabled
-     */
-    boolean isNextEnabled();
-
-    /**
      * Determines if there is panel prior to the current panel.
      *
      * @return {@code true} if there is a panel prior to the current panel
@@ -113,20 +99,6 @@ public interface Panels
      * @return {@code true} if the previous panel was navigated to
      */
     boolean previous();
-
-    /**
-     * Determines if the previous panel may be navigated to.
-     *
-     * @param enable if {@code true}, enable navigation, otherwise disable it
-     */
-    void setPreviousEnabled(boolean enable);
-
-    /**
-     * Determines if navigation to the previous panel has been enabled.
-     * <p/>
-     * return {@code true} if navigation is enabled
-     */
-    boolean isPreviousEnabled();
 
     /**
      * Navigates to the panel before the specified index.

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/gui/DefaultNavigatorTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/gui/DefaultNavigatorTest.java
@@ -20,19 +20,6 @@
  */
 package com.izforge.izpack.installer.gui;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.izforge.izpack.api.container.Container;
 import com.izforge.izpack.api.data.LocaleDatabase;
 import com.izforge.izpack.api.data.Panel;
@@ -50,6 +37,14 @@ import com.izforge.izpack.gui.IconsDatabase;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.panel.Panels;
 import com.izforge.izpack.util.Platforms;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the {@link DefaultNavigator}.
@@ -180,7 +175,6 @@ public class DefaultNavigatorTest
 
         // verify the next button is disabled, and that navigation is disabled
         assertFalse(navigator.isNextEnabled());
-        assertFalse(navigator.next());
         assertEquals(1, panels.getIndex());
 
         // enable the next button and verify the third panel can be navigated to
@@ -222,11 +216,6 @@ public class DefaultNavigatorTest
         assertFalse(navigator.isPreviousEnabled());
         assertFalse(navigator.previous());
         assertEquals(1, panels.getIndex());
-
-        // enable the previous button and verify the first panel can be navigated to
-        navigator.setPreviousEnabled(true);
-        assertTrue(navigator.previous());
-        assertEquals(0, panels.getIndex());
     }
 
     /**


### PR DESCRIPTION
This change fixes [IZPACK-1464](https://izpack.atlassian.net/browse/IZPACK-1467):

This bug has been found while implementing a fix for [IZPACK-1464](https://izpack.atlassian.net/browse/IZPACK-1464).

If a panel implementation calls `com.izforge.izpack.installer.gui.InstallerFrame#lockNextButton(true)` during the execution of the `com.izforge.izpack.panels.userinput.UserInputPanel#panelActivate` event this can lead to a deadlock in GUI mode - the first panel appears empty, the Next button is disabled and the Quit button enabled. If pressing Quit this results in a stack trace:
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
        at com.izforge.izpack.installer.gui.InstallerFrame.quit(InstallerFrame.java:654)
        at com.izforge.izpack.installer.gui.DefaultNavigator.quit(DefaultNavigator.java:395)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.navigate(DefaultNavigator.java:571)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler.access$100(DefaultNavigator.java:530)
        at com.izforge.izpack.installer.gui.DefaultNavigator$NavigationHandler$1$1.run(DefaultNavigator.java:550)
        at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```
but the installer is still open (must be killed, for example by CTRL-C from the terminal).

The thread dump while hanging is:
```
Logging initialized at level 'INFO'
Commandline arguments: 
Detected platform: suse_linux,version=4.8.6-2-default,arch=x64,symbolicName=null,javaVersion=1.8.0_102
Resource customicons.xml not defined. No custom icons available
Cannot find named resource: 'userInputLang.xml' AND 'userInputLang.xml_eng'
2016-11-10 09:21:51
Full thread dump Java HotSpot(TM) 64-Bit Server VM (25.102-b14 mixed mode):

"DestroyJavaVM" #19 prio=5 os_prio=0 tid=0x00007fd428007800 nid=0x1986 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"TimerQueue" #18 daemon prio=5 os_prio=0 tid=0x00007fd39805b800 nid=0x199f waiting on condition [0x00007fd40c5d4000]
   java.lang.Thread.State: WAITING (parking)
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000005d242d7b0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
        at java.util.concurrent.DelayQueue.take(DelayQueue.java:211)
        at javax.swing.TimerQueue.run(TimerQueue.java:174)
        at java.lang.Thread.run(Thread.java:745)

"AWT-EventQueue-0" #14 prio=6 os_prio=0 tid=0x00007fd4285eb800 nid=0x199d waiting on condition [0x00007fd40d06b000]
   java.lang.Thread.State: WAITING (parking)
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000005d24360c0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
        at java.awt.EventQueue.getNextEvent(EventQueue.java:554)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:170)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

"AWT-Shutdown" #15 prio=5 os_prio=0 tid=0x00007fd4285ea000 nid=0x199c in Object.wait() [0x00007fd40d16c000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        - waiting on <0x00000005d2415e80> (a java.lang.Object)
        at java.lang.Object.wait(Object.java:502)
        at sun.awt.AWTAutoShutdown.run(AWTAutoShutdown.java:295)
        - locked <0x00000005d2415e80> (a java.lang.Object)
        at java.lang.Thread.run(Thread.java:745)

"AWT-XAWT" #13 daemon prio=6 os_prio=0 tid=0x00007fd4284b8000 nid=0x199b runnable [0x00007fd40d26d000]
   java.lang.Thread.State: RUNNABLE
        at sun.awt.X11.XToolkit.waitForEvents(Native Method)
        at sun.awt.X11.XToolkit.run(XToolkit.java:568)
        at sun.awt.X11.XToolkit.run(XToolkit.java:532)
        at java.lang.Thread.run(Thread.java:745)

"Java2D Disposer" #11 daemon prio=10 os_prio=0 tid=0x00007fd42853b800 nid=0x199a in Object.wait() [0x00007fd40d77f000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        - waiting on <0x00000005d2416030> (a java.lang.ref.ReferenceQueue$Lock)
        at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:143)
        - locked <0x00000005d2416030> (a java.lang.ref.ReferenceQueue$Lock)
        at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:164)
        at sun.java2d.Disposer.run(Disposer.java:148)
        at java.lang.Thread.run(Thread.java:745)

"Service Thread" #9 daemon prio=9 os_prio=0 tid=0x00007fd42821b800 nid=0x1997 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"C1 CompilerThread3" #8 daemon prio=9 os_prio=0 tid=0x00007fd428210800 nid=0x1996 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"C2 CompilerThread2" #7 daemon prio=9 os_prio=0 tid=0x00007fd42820e800 nid=0x1995 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"C2 CompilerThread1" #6 daemon prio=9 os_prio=0 tid=0x00007fd42820c800 nid=0x1994 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"C2 CompilerThread0" #5 daemon prio=9 os_prio=0 tid=0x00007fd428209800 nid=0x1993 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Signal Dispatcher" #4 daemon prio=9 os_prio=0 tid=0x00007fd428208000 nid=0x1992 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Finalizer" #3 daemon prio=8 os_prio=0 tid=0x00007fd4281d1000 nid=0x1991 in Object.wait() [0x00007fd40fefd000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        - waiting on <0x00000005d2416ac0> (a java.lang.ref.ReferenceQueue$Lock)
        at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:143)
        - locked <0x00000005d2416ac0> (a java.lang.ref.ReferenceQueue$Lock)
        at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:164)
        at java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:209)

"Reference Handler" #2 daemon prio=10 os_prio=0 tid=0x00007fd4281cc800 nid=0x1990 in Object.wait() [0x00007fd40fffe000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        - waiting on <0x00000005d2416ce0> (a java.lang.ref.Reference$Lock)
        at java.lang.Object.wait(Object.java:502)
        at java.lang.ref.Reference.tryHandlePending(Reference.java:191)
        - locked <0x00000005d2416ce0> (a java.lang.ref.Reference$Lock)
        at java.lang.ref.Reference$ReferenceHandler.run(Reference.java:153)

"VM Thread" os_prio=0 tid=0x00007fd4281c4800 nid=0x198f runnable 

"GC task thread#0 (ParallelGC)" os_prio=0 tid=0x00007fd42801d000 nid=0x1987 runnable 

"GC task thread#1 (ParallelGC)" os_prio=0 tid=0x00007fd42801e800 nid=0x1988 runnable 

"GC task thread#2 (ParallelGC)" os_prio=0 tid=0x00007fd428020800 nid=0x1989 runnable 

"GC task thread#3 (ParallelGC)" os_prio=0 tid=0x00007fd428022000 nid=0x198a runnable 

"GC task thread#4 (ParallelGC)" os_prio=0 tid=0x00007fd428024000 nid=0x198b runnable 

"GC task thread#5 (ParallelGC)" os_prio=0 tid=0x00007fd428025800 nid=0x198c runnable 

"GC task thread#6 (ParallelGC)" os_prio=0 tid=0x00007fd428027800 nid=0x198d runnable 

"GC task thread#7 (ParallelGC)" os_prio=0 tid=0x00007fd428029000 nid=0x198e runnable 

"VM Periodic Task Thread" os_prio=0 tid=0x00007fd42821e800 nid=0x1998 waiting on condition 

JNI global references: 373

Heap
 PSYoungGen      total 147456K, used 7681K [0x000000071b700000, 0x0000000725b80000, 0x00000007c0000000)
  eden space 126464K, 6% used [0x000000071b700000,0x000000071be80668,0x0000000723280000)
  from space 20992K, 0% used [0x0000000723280000,0x0000000723280000,0x0000000724700000)
  to   space 20992K, 0% used [0x0000000724700000,0x0000000724700000,0x0000000725b80000)
 ParOldGen       total 232448K, used 6874K [0x00000005d2400000, 0x00000005e0700000, 0x000000071b700000)
  object space 232448K, 2% used [0x00000005d2400000,0x00000005d2ab6a98,0x00000005e0700000)
 Metaspace       used 21235K, capacity 21506K, committed 21760K, reserved 1069056K
  class space    used 2677K, capacity 2784K, committed 2816K, reserved 1048576K
```