### PR TITLE
IZPACK-1468: Variable references in labels, descriptions, statictext fields and field tooltips are resolved just during initialization

### DIFF
--- a/izpack-gui/src/main/java/com/izforge/izpack/gui/LabelFactory.java
+++ b/izpack-gui/src/main/java/com/izforge/izpack/gui/LabelFactory.java
@@ -193,7 +193,7 @@ public class LabelFactory implements SwingConstants
      */
     public static JLabel create(String text, Icon image, int horizontalAlignment, boolean isFullLine)
     {
-        JLabel retval = null;
+        JLabel retval;
         if (image != null && isUseLabelIcons())
         {
             if (isFullLine)

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleField.java
@@ -75,7 +75,7 @@ public abstract class ConsoleField extends AbstractFieldView
      */
     protected void printDescription()
     {
-        String description = getField().getDescription();
+        String description = getField().getDescription(true);
         if (description != null)
         {
             println(description);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/ConsoleInputField.java
@@ -59,11 +59,12 @@ public abstract class ConsoleInputField extends ConsoleField
         boolean result = false;
         printDescription();
         Field field = getField();
+        String label = field.getLabel(true);
         String initialValue = field.getInitialValue();
         
         if (isReadonly())
         {
-            println(field.getLabel() + " [" + initialValue + "] ");
+            println(label + " [" + initialValue + "] ");
             field.setValue(initialValue);
             return true;
         }
@@ -73,7 +74,7 @@ public abstract class ConsoleInputField extends ConsoleField
             {
                 initialValue = "";
             }
-            String value = getConsole().prompt(field.getLabel() + " [" + initialValue + "] ", initialValue);
+            String value = getConsole().prompt(label + " [" + initialValue + "] ", initialValue);
             if (value != null)
             {
                 ValidationStatus status = validate(value);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/staticText/ConsoleStaticText.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/staticText/ConsoleStaticText.java
@@ -53,7 +53,7 @@ public class ConsoleStaticText extends ConsoleField
     @Override
     public boolean display()
     {
-        String text = getField().getLabel();
+        String text = getField().getLabel(true);
         if (text != null)
         {
             println(text);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/title/ConsoleTitleField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/console/title/ConsoleTitleField.java
@@ -53,7 +53,7 @@ public class ConsoleTitleField extends ConsoleField
     @Override
     public boolean display()
     {
-        String title = getField().getLabel();
+        String title = getField().getLabel(true);
         if (title != null) {
             println(title);
             println("");

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Config.java
@@ -345,9 +345,6 @@ public class Config
                 // no localised message found, so use the txt attribute
                 result = element.getAttribute(TEXT);
             }
-
-            // replace any variables
-            result = installData.getVariables().replace(result);
         }
         return result;
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/field/Field.java
@@ -337,37 +337,49 @@ public abstract class Field
     }
 
     /**
-     * Returns the default value of the field.
+     * Returns the default value of the field with resolved variables.
      *
      * @return the default value. May be {@code null}
      */
     public String getDefaultValue()
     {
+        return getDefaultValue(true);
+    }
+
+    /**
+     * Returns the default value of the field.
+     *
+     * @param translated true if variable references in the text should be resolved
+     * @return the default value. May be {@code null}
+     */
+    public String getDefaultValue(boolean translated)
+    {
         String value = wrapDefaultValue(defaultValue);
-        if (value != null)
+        if (translated && value != null)
         {
             return replaceVariables(value);
         }
-        return null;
+        return value;
     }
 
     /**
      * Returns the forced value of the field.
      *
+     * @param translated true if variable references in the text should be resolved
      * @return the forced value. May be {@code null}
      */
-    private String getForcedValue()
+    private String getForcedValue(boolean translated)
     {
         String value = wrapInitialValue(initialValue);
-        if (value != null)
+        if (translated && value != null)
         {
             return replaceVariables(value);
         }
-        return null;
+        return value;
     }
 
     /**
-     * Returns the initial value to use for this field.
+     * Returns the initial value to use for this field with resolved variables.
      * <p/>
      * The following non-null value is used from the following search order
      * <ul>
@@ -380,21 +392,42 @@ public abstract class Field
      */
     public String getInitialValue()
     {
+        return getInitialValue(true);
+    }
+
+    /**
+     * Returns the initial value to use for this field.
+     * <p/>
+     * The following non-null value is used from the following search order
+     * <ul>
+     * <li>initial value (substituting variables)
+     * <li>current variable value
+     * <li>default value (substituting variables)
+     * </ul>
+     *
+     * @param translated true if variable references in the text should be resolved
+     * @return The initial value to use for this field
+     */
+    public String getInitialValue(boolean translated)
+    {
         String result = null;
         if (!installData.getVariables().isBlockedVariableName(variable))
         {
-            result = getForcedValue();
+            result = getForcedValue(translated);
         }
         if (result == null)
         {
             result = getValue();
             if (result != null)
             {
-                result = replaceVariables(result);
+                if (translated)
+                {
+                    result = replaceVariables(result);
+                }
             }
             else
             {
-                result = getDefaultValue();
+                result = getDefaultValue(translated);
             }
         }
         return result;
@@ -556,47 +589,66 @@ public abstract class Field
     }
 
     /**
-     * Returns the field label.
+     * Returns the field label with resolved variable values.
      *
      * @return the field label. May be {@code null}
      */
     public String getLabel()
     {
-        String result = null;
-        if (label != null)
-        {
-            result = replaceVariables(label);
-        }
-        return result;
+        return getLabel(false);
     }
 
     /**
-     * Returns the field description.
+     * Returns the field label.
+     *
+     * @param resolve whether the label should be returned with resolved variables
+     * @return the field label. May be {@code null}
+     */
+    public String getLabel(boolean resolve)
+    {
+        return (resolve && label != null)?replaceVariables(label):label;
+    }
+
+    /**
+     * Returns the field description with resolved variable values.
      *
      * @return the field description. May be {@code null}
      */
     public String getDescription()
     {
-        String result = null;
-        if (description != null)
-        {
-            result = replaceVariables(description);
-        }
-        return result;
+        return getDescription(false);
+    }
+
+    /**
+     * Returns the field description.
+     *
+     * @param resolve whether the description should be returned with resolved variables
+     * @return the field label. May be {@code null}
+     */
+    public String getDescription(boolean resolve)
+    {
+        return (resolve && description != null)?replaceVariables(description):description;
+    }
+
+    /**
+     * Returns the field tooltip with resolved variable values.
+     *
+     * @return the field tooltip. May be {@code null}
+     */
+    public String getTooltip()
+    {
+        return getTooltip(false);
     }
 
     /**
      * Returns the field tooltip.
      *
+     * @param resolve whether the tooltip should be returned with resolved variables
      * @return the field tooltip. May be {@code null}
      */
-    public String getTooltip() {
-        String result = null;
-        if (tooltip != null)
-        {
-            result = replaceVariables(tooltip);
-        }
-        return result;
+    public String getTooltip(boolean resolve)
+    {
+        return (resolve && tooltip != null)?replaceVariables(tooltip):tooltip;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/GUIField.java
@@ -30,10 +30,11 @@ import com.izforge.izpack.panels.userinput.field.Field;
 import com.izforge.izpack.util.HyperlinkHandler;
 
 import javax.swing.*;
-
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -54,6 +55,18 @@ public abstract class GUIField extends AbstractFieldView
      */
     private UpdateListener listener;
 
+    /**
+     * Holds static label text with variable references which must not be overridden,
+     * because the variables might change during the installation; for always showing the actual value after resolving.
+     */
+    private final Map<Integer, String> untranslatedItems;
+
+    /**
+     * Holds static tooltip text with variable references which must not be overridden,
+     * because the variables might change during the installation; for always showing the actual value after resolving.
+     */
+    private final Map<Integer, String> untranslatedTooltips;
+
 
     /**
      * Constructs a {@code GUIField}.
@@ -63,6 +76,8 @@ public abstract class GUIField extends AbstractFieldView
     public GUIField(Field field)
     {
         super(field);
+        untranslatedItems = new HashMap<Integer, String>();
+        untranslatedTooltips = new HashMap<Integer, String>();
     }
 
     /**
@@ -170,6 +185,24 @@ public abstract class GUIField extends AbstractFieldView
      */
     protected void addComponent(JComponent component, Object constraints)
     {
+        if (component instanceof JTextPane)
+        {
+            JTextPane pane = (JTextPane)component;
+            String oldText = pane.getText();
+            if (oldText != null)
+            {
+                untranslatedItems.put(Integer.valueOf(pane.hashCode()), oldText);
+            }
+        }
+        else if (component instanceof JLabel)
+        {
+            JLabel label = (JLabel)component;
+            String oldText = label.getText();
+            if (oldText != null)
+            {
+                untranslatedItems.put(Integer.valueOf(label.hashCode()), oldText);
+            }
+        }
         components.add(new Component(component, constraints));
     }
 
@@ -188,23 +221,40 @@ public abstract class GUIField extends AbstractFieldView
             {
                 JTextPane pane = (JTextPane)jc;
                 pane.setOpaque(false);
-                String oldText = pane.getText();
+                String oldText = untranslatedItems.get(Integer.valueOf(jc.hashCode()));
                 if (oldText != null)
                 {
                     String newText = replaceVariables(oldText);
-                    updated |= oldText.equals(newText);
-                    pane.setText(newText);
+                    if (!oldText.equals(newText))
+                    {
+                        updated = true;
+                        pane.setText(newText);
+                    }
                 }
             }
             else if (jc instanceof JLabel)
             {
                 JLabel label = (JLabel)jc;
-                String oldText = label.getText();
+                String oldText = untranslatedItems.get(Integer.valueOf(label.hashCode()));
                 if (oldText != null)
                 {
                     String newText = replaceVariables(oldText);
-                    updated |= oldText.equals(newText);
-                    label.setText(newText);
+                    if (!oldText.equals(newText))
+                    {
+                        updated = true;
+                        label.setText(newText);
+                    }
+                }
+            }
+
+            String tooltip = untranslatedTooltips.get(Integer.valueOf(jc.hashCode()));
+            if (tooltip != null)
+            {
+                String newText = replaceVariables(tooltip);
+                if (!tooltip.equals(newText))
+                {
+                    jc.setToolTipText(newText);
+                    updated = true;
                 }
             }
         }
@@ -221,10 +271,13 @@ public abstract class GUIField extends AbstractFieldView
         if (tooltipId != null)
         {
             String tooltip = getInstallData().getMessages().get(tooltipId);
-
-            for (Component component : components)
+            if (tooltip != null)
             {
-                component.getComponent().setToolTipText(tooltip);
+                for (Component component : components)
+                {
+                    untranslatedTooltips.put(Integer.valueOf(component.getComponent().hashCode()), tooltip);
+                    component.getComponent().setToolTipText(tooltip);
+                }
             }
         }
     }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/MultipleFileInputField.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/userinput/gui/file/MultipleFileInputField.java
@@ -21,7 +21,16 @@
 
 package com.izforge.izpack.panels.userinput.gui.file;
 
-import java.awt.Dimension;
+import com.izforge.izpack.api.GuiId;
+import com.izforge.izpack.api.resource.Messages;
+import com.izforge.izpack.gui.ButtonFactory;
+import com.izforge.izpack.installer.data.GUIInstallData;
+import com.izforge.izpack.installer.gui.InstallerFrame;
+import com.izforge.izpack.panels.userinput.field.ValidationStatus;
+import com.izforge.izpack.panels.userinput.field.file.MultipleFileField;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
@@ -31,26 +40,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.logging.Logger;
-
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.DefaultListModel;
-import javax.swing.JButton;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.ListSelectionModel;
-
-import com.izforge.izpack.api.GuiId;
-import com.izforge.izpack.api.resource.Messages;
-import com.izforge.izpack.gui.ButtonFactory;
-import com.izforge.izpack.installer.data.GUIInstallData;
-import com.izforge.izpack.installer.gui.InstallerFrame;
-import com.izforge.izpack.panels.userinput.field.ValidationStatus;
-import com.izforge.izpack.panels.userinput.field.file.MultipleFileField;
 
 
 public class MultipleFileInputField extends JPanel implements ActionListener, FocusListener
@@ -68,7 +57,6 @@ public class MultipleFileInputField extends JPanel implements ActionListener, Fo
     JButton browseBtn;
     JButton deleteBtn;
 
-    String set;
     int size;
     GUIInstallData data;
     String fileExtension;
@@ -89,7 +77,6 @@ public class MultipleFileInputField extends JPanel implements ActionListener, Fo
         this.field = field;
         this.parentFrame = parent;
         this.data = data;
-        this.set = field.getDefaultValue();
         this.size = field.getSize();
         if (size < 1)
         {


### PR DESCRIPTION
This PR solves [IZPACK-1468](https://izpack.atlassian.net/browse/IZPACK-1468):

Provided the following example:

*install.xml:*
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>

<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
  
  <info>
    <appname>Test</appname>
    <appversion>1.0</appversion>		
  </info>
  
  <guiprefs width="800" height="600" resizable="yes" />
  
  <locale>
    <langpack iso3="eng" />
  </locale>

  <resources>
    <res id="userInputSpec.xml" src="userInputSpec.xml"/>
  </resources>

  <variables>
    <variable name="p2" value="initialized" />
  </variables>
  
  <panels>
    <panel classname="TargetPanel" id="panel.target"/>
    <panel classname="UserInputPanel" id="panel.test.1"/>
    <panel classname="UserInputPanel" id="panel.test.2"/>
    <panel classname="UserInputPanel" id="panel.test.3"/>
    <panel classname="InstallPanel" id="panel.install"/>
    <panel classname="FinishPanel" id="panel.finish"/>
  </panels>
  
  <packs>
    <pack name="test" required="true">
      <description>Test for the search field.</description>
    </pack>
  </packs>
  
</izpack:installation>
```

*Resource UserInputSpec.xml:*
```xml
<?xml version="1.0" encoding="UTF-8"?>
<izpack:userinput version="5.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:izpack="http://izpack.org/schema/userinput" xsi:schemaLocation="http://izpack.org/schema/userinput http://izpack.org/schema/5.0/izpack-userinput-5.0.xsd">
  
  <panel id="panel.test.1">
    <field type="title" txt="${p2} - Search field test #1" id="title.searchfield" />
    <field type="text" variable="p1" tooltip="${p2}">
      <description txt="${p2} - A first text input field" id="description.text"/>
      <spec txt="${p2} - some text:" id="text.label" size="20" set="${p2}"/>
    </field>
    <field type="staticText" align="left" txt="${p2} - some static text." id="staticText.text"/>
  </panel>

  <panel id="panel.test.2">
    <field type="title" txt="${p2} - Search field test #2" id="title.searchfield" />
    <field type="text" variable="p2" tooltip="${p2}">
      <description txt="${p2} - A first text input field" id="description.text"/>
      <spec txt="${p2} - some text:" id="text.label" size="20"/>
    </field>
    <field type="staticText" align="left" txt="${p2} - some static text." id="staticText.text"/>
  </panel>

  <panel id="panel.test.3">
    <field type="title" txt="${p2} - Search field test #3" id="title.searchfield" />
    <field type="text" variable="p3" tooltip="${p2}">
      <description txt="${p2} - A second text input field" id="description.text"/>
      <spec txt="${p2} - some text:" id="text.label" size="20" default="${p2}"/>
    </field>
    <field type="staticText" align="left" txt="${p2} - some static text." id="staticText.text"/>
  </panel>

</izpack:userinput>
```

Regardless of how $p2 is set by the user in panel.test.2 all static labels remain with the text "initialized". The reason is the initialization when the installer is launched, where all variable references are immediately resolved and saved with the graphical elements, so they got lost.

Variable references in all static text fields (title, field description and labels, statictext user input field) should always show the actual variable values when referring to variables.
