### PR TITLE
IZPACK-1471: UiThreadingViolationException when using substance laf

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
@@ -124,19 +124,31 @@ public class InstallerGui
 	            });
 	        }
 	        
-	        if (langCode == null)
-	        {
-	          installerContainer.getComponent(LanguageDialog.class).initLangPack();
-	        }
-	        else
-	        {
-	          installerContainer.getComponent(LanguageDialog.class).propagateLocale(langCode);
-	        }
-	        if (!installerContainer.getComponent(RequirementsChecker.class).check())
-	        {
-	            logger.info("Not all installer requirements are fulfilled.");
-	            installerContainer.getComponent(Housekeeper.class).shutDown(-1);
-	        }
+                SwingUtilities.invokeAndWait(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (langCode == null)
+                        {
+                            try
+                            {
+                                installerContainer.getComponent(LanguageDialog.class).initLangPack();
+                            }
+                            catch (Exception ex)
+                            {
+                                logger.severe("The language pack couldn't be initialized.");
+                            }
+                        }
+                        else
+                        {
+                          installerContainer.getComponent(LanguageDialog.class).propagateLocale(langCode);
+                        }
+                        if (!installerContainer.getComponent(RequirementsChecker.class).check())
+                        {
+                            logger.info("Not all installer requirements are fulfilled.");
+                            installerContainer.getComponent(Housekeeper.class).shutDown(-1);
+                        }
+                    }
+                });
 	        controller.buildInstallation().launchInstallation();
 	    }
 	    catch (Exception e)


### PR DESCRIPTION
This one solves [IZPACK-1471](https://izpack.atlassian.net/browse/IZPACK-1471):

    org.pushingpixels.substance.api.UiThreadingViolationException: State tracking must be done on Event Dispatch Thread
	    at org.pushingpixels.substance.internal.animation.StateTransitionTracker$ModelStateInfo.clear(StateTransitionTracker.java:166)
	    at org.pushingpixels.substance.internal.animation.StateTransitionTracker.setModel(StateTransitionTracker.java:295)
	    at org.pushingpixels.substance.internal.utils.ButtonVisualStateTracker$2.propertyChange(ButtonVisualStateTracker.java:104)
	    at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
	    at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:327)
	    at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
	    at java.awt.Component.firePropertyChange(Component.java:8428)
	    at javax.swing.AbstractButton.setModel(AbstractButton.java:1781)
	    at org.pushingpixels.substance.internal.utils.SubstanceDropDownButton.<init>(SubstanceDropDownButton.java:70)
	    at org.pushingpixels.substance.internal.ui.SubstanceComboBoxUI.createArrowButton(SubstanceComboBoxUI.java:157)
	    at javax.swing.plaf.basic.BasicComboBoxUI.installComponents(BasicComboBoxUI.java:706)
	    at org.pushingpixels.substance.internal.ui.SubstanceComboBoxUI.__org__pushingpixels__substance__internal__ui__SubstanceComboBoxUI__installComponents(SubstanceComboBoxUI.java)
	    at org.pushingpixels.substance.internal.ui.SubstanceComboBoxUI.installComponents(SubstanceComboBoxUI.java)
	    at javax.swing.plaf.basic.BasicComboBoxUI.installUI(BasicComboBoxUI.java:270)
	    at org.pushingpixels.substance.internal.ui.SubstanceComboBoxUI.__org__pushingpixels__substance__internal__ui__SubstanceComboBoxUI__installUI(SubstanceComboBoxUI.java:109)
	    at org.pushingpixels.substance.internal.ui.SubstanceComboBoxUI.installUI(SubstanceComboBoxUI.java)
	    at javax.swing.JComponent.setUI(JComponent.java:666)
	    at javax.swing.JComboBox.setUI(JComboBox.java:257)
	    at javax.swing.JComboBox.updateUI(JComboBox.java:266)
	    at javax.swing.SwingUtilities.updateComponentTreeUI0(SwingUtilities.java:1233)
	    at javax.swing.SwingUtilities.updateComponentTreeUI0(SwingUtilities.java:1248)
	    at javax.swing.SwingUtilities.updateComponentTreeUI0(SwingUtilities.java:1248)
	    at javax.swing.SwingUtilities.updateComponentTreeUI0(SwingUtilities.java:1248)
	    at javax.swing.SwingUtilities.updateComponentTreeUI0(SwingUtilities.java:1248)
	    at javax.swing.SwingUtilities.updateComponentTreeUI(SwingUtilities.java:1224)
	    at com.izforge.izpack.installer.language.LanguageDialog.propagateLocale(LanguageDialog.java:305)
	    at com.izforge.izpack.installer.language.LanguageDialog.initLangPack(LanguageDialog.java:121)
	    at com.izforge.izpack.installer.bootstrap.InstallerGui.run(InstallerGui.java:129)
	    at com.izforge.izpack.installer.bootstrap.Installer.launchInstall(Installer.java:276)
	    at com.izforge.izpack.installer.bootstrap.Installer.start(Installer.java:220)
	    at com.izforge.izpack.installer.bootstrap.Installer.main(Installer.java:77)

occuring at every start of the installer

experienced with izpack-5.0.10-47-g43bb73a