### PR TITLE
IZPACK-1507: Handling deprecation of Encoding entry

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/util/os/Unix_Shortcut.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/util/os/Unix_Shortcut.java
@@ -250,7 +250,11 @@ public class Unix_Shortcut extends Shortcut
 
         result.append("Comment=").append(description).append(N);
         result.append("Comment[").append(userLanguage).append("]=").append(description).append(N);
-        result.append("Encoding=").append(encoding).append(N);
+        if (!encoding.isEmpty()) {
+            logger.warning(String.format("using deprecated Desktop Entry key "
+                    + "Encoding with value %s", encoding));
+            result.append("Encoding=").append(encoding).append(N);
+        }
 
         // this causes too many problems
         // result.append("TryExec=" + $E_QUOT + $Exec + $E_QUOT + S + $Arguments + N);


### PR DESCRIPTION
Implementation of [IZPACK-1507](https://izpack.atlassian.net/browse/IZPACK-1507):

This avoids creation of invalid `.desktop` files assuming that GNOME's `desktop-file-utils` 0.23 is the state-of-the-art check (empty `Encoding` causes invalid file and `Encoding` is deprecated, so I added a warning).