### PR TITLE
IZPACK-1508: Removed default quoting of Exec value with ''

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/util/os/Unix_Shortcut.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/util/os/Unix_Shortcut.java
@@ -258,10 +258,13 @@ public class Unix_Shortcut extends Shortcut
         if (!targetPath.isEmpty() || !arguments.isEmpty())
         {
             result.append("Exec=");
-            if (targetPath.contains(S))
-                result.append("'").append(targetPath).append("'");
-            else
-                result.append(targetPath);
+            result.append(targetPath);
+                //escaping needs to be handed more fine-grained (putting ''
+                //around everything after `Exec=` is not a solution because it
+                //causes invalid .desktop files (`desktop-file-validate` fails
+                //due to `error: value "'[...]'" for key "Exec" in group
+                //"Desktop Entry" contains a reserved character ''' outside of
+                //a quote`)
             if (!arguments.isEmpty())
                 result.append(S).append(arguments);
             result.append(N);

--- a/izpack-installer/src/test/java/com/izforge/izpack/util/os/Unix_ShortcutTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/util/os/Unix_ShortcutTest.java
@@ -434,7 +434,7 @@ public class Unix_ShortcutTest
       // TryExec is not used -- "causes too many problems"
       assertEquals(NOT_FOUND, getValue(result, "TryExec"));
 
-      String exec = "'" + targetPath + "'" + " " + arguments;
+      String exec = targetPath + " " + arguments;
       // since targetPath contains no spaces, it will not be quoted
       assertEquals(exec, getValue(result, "Exec"));
 


### PR DESCRIPTION
This is a fix for [IZPACK-1508](https://izpack.atlassian.net/browse/IZPACK-1508):

During shortcut creation, remove default quoting of Exec value with '' because it prevents valid .desktop files to be created; escaping should be handled by the user.