### PR TITLE
IZPACK-1481: Avoid warning: "Resource customicons.xml not defined. No custom icons available"

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/IconsProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/IconsProvider.java
@@ -63,7 +63,7 @@ public class IconsProvider implements Provider
         }
         catch (Throwable exception)
         {
-            logger.warning("Resource " + Resources.CUSTOM_ICONS_RESOURCE_NAME
+            logger.fine("Resource " + Resources.CUSTOM_ICONS_RESOURCE_NAME
                                    + " not defined. No custom icons available");
             return;
         }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/GUIPackResources.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/GUIPackResources.java
@@ -3,7 +3,6 @@ package com.izforge.izpack.installer.unpacker;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.exception.ResourceException;
 import com.izforge.izpack.api.exception.ResourceInterruptedException;
-import com.izforge.izpack.api.exception.ResourceNotFoundException;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.installer.web.WebRepositoryAccessor;
 import com.izforge.izpack.util.IoHelper;


### PR DESCRIPTION
This PR solves [IZPACK-1481](https://izpack.atlassian.net/browse/IZPACK-1481):

At the moment, each time an installer generated by IzPack is run, there is a warning shown at the console output:

_Resource customicons.xml not defined. No custom icons available._

This is not necessary, customizing installer icons is not required at all and a rare use case.
Move this to debug log level to not show this by default.