### PR TITLE
IZPACK-1482: ConfigurationInstallerListener - handle auto-numbered key-value-pairs also for numbers embedded into the key name

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/config/Options.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/config/Options.java
@@ -225,11 +225,18 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
             {
                 String value = get(name, i);
 
-                if (getConfig().isAutoNumbering() && name.endsWith("."))
+                if (getConfig().isAutoNumbering() && name.matches("(.+\\.\\..+)|(.+\\.)+"))
                 {
                     if (value != null)
                     {
-                        formatter.handleOption(name + i, value);
+                        if (name.matches(".+\\.\\..+"))
+                        {
+                            formatter.handleOption(name.replaceFirst("\\.\\.", Integer.toString(i)), value);
+                        }
+                        else if (name.matches("(.+\\.)+"))
+                        {
+                            formatter.handleOption(name + i, value);
+                        }
                     }
                 }
                 else

--- a/izpack-api/src/main/java/com/izforge/izpack/api/config/spi/OptionsBuilder.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/config/spi/OptionsBuilder.java
@@ -63,11 +63,35 @@ public class OptionsBuilder implements OptionsHandler
     @Override public void handleOption(String name, String value)
     {
         String newName = name;
-        if (getConfig().isAutoNumbering() && name.matches("(.+\\.)+[\\d]+"))
+        if (getConfig().isAutoNumbering() && name.matches("(.+\\.)+[\\d]+(\\.+.*)*"))
         {
             String[] parts = name.split("\\.");
-            newName = name.substring(0, name.length() - parts[parts.length - 1].length() - 1) + ".";
-            int pos = Integer.parseInt(parts[parts.length - 1]);
+            StringBuilder sb = new StringBuilder();
+            int pos = -1;
+            for (String part : parts)
+            {
+                if (sb.length() > 0)
+                {
+                    sb.append(".");
+                }
+                if (pos != -1)
+                {
+                    sb.append(part);
+                }
+                else
+                {
+                    try
+                    {
+                        pos = Integer.parseInt(part);
+                        // The first \.\d+\. "wins"
+                    }
+                    catch (NumberFormatException nfe)
+                    {
+                        sb.append(part);
+                    }
+                }
+            }
+            newName = sb.toString();
 
             // check whether key has been added before
             if (!_options.containsKey(newName))

--- a/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/config/SingleConfigurableTask.java
@@ -464,7 +464,7 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
                 fromKeySet = ((Options) fromConfigurable).keySet();
                 for (String key : fromKeySet)
                 {
-                    if (fromConfigurable.getConfig().isAutoNumbering() && key.matches("(.+\\.)+"))
+                    if (fromConfigurable.getConfig().isAutoNumbering() && key.matches("(.+\\.\\..+)|(.+\\.)+"))
                     {
                         boolean keyFound = toKeySet.contains(key);
                         int i = 0, firstIndex = -1;
@@ -818,11 +818,35 @@ public abstract class SingleConfigurableTask implements ConfigurableTask
         {
             String newKey, newValue;
             int pos = -1;
-            if (configurable.getConfig().isAutoNumbering() && key.matches("(.+\\.)+[\\d]+"))
+            if (configurable.getConfig().isAutoNumbering() && key.matches("(.+\\.)+[\\d]+(\\.+.*)*"))
             {
                 String[] parts = key.split("\\.");
-                newKey = key.substring(0, key.length() - parts[parts.length - 1].length() - 1) + ".";
-                pos = Integer.parseInt(parts[parts.length - 1]);
+                StringBuilder sb = new StringBuilder();
+                //int pos = -1;
+                for (String part : parts)
+                {
+                    if (sb.length() > 0)
+                    {
+                        sb.append(".");
+                    }
+                    if (pos != -1)
+                    {
+                        sb.append(part);
+                    }
+                    else
+                    {
+                        try
+                        {
+                            pos = Integer.parseInt(part);
+                            // The first \.\d+\. "wins"
+                        }
+                        catch (NumberFormatException nfe)
+                        {
+                            sb.append(part);
+                        }
+                    }
+                }
+                newKey = sb.toString();
             }
             else
             {


### PR DESCRIPTION
When using the [ConfigurationInstallerListener|(https://izpack.atlassian.net/wiki/x/2IAH), it is currently able to automatically handle auto-numbered properties, which is a set of property keys beginning with the same prefix and ending on _`.<integer>`_, where _`<integer>`_ is a continuous interval of integer numbers.

Example:
```
database.cluster.host.0
database.cluster.host.1
```

If read from a property files, the prefix is taken as the property key itself and the whole set of property keys starting on it are handled as once.

This operation can be used for instance for keeping all values of the whole set or deleting them as once action in one line in ConfigurationActionSpec.xml.

Enhance the auto-numbering handling of this feature also for embedded integers, for example:
```
database.cluster.0.host
database.cluster.1.host
```
