### PR TITLE
IZPACK-1488: AntActionInstallerListener action fails if it contains a variable reference containing a '&' character in its value at runtime

### DIFF
--- a/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ActionBase.java
@@ -25,13 +25,12 @@ import java.io.Serializable;
 import java.util.HashSet;
 
 /**
- * Base class for action classes like AntAction.
+ * Base class for action listeners.
  *
  * @author Klaus Bartz
  */
 public class ActionBase implements Serializable
 {
-
     // --- String constants for parsing the XML specification -----------------
     // --- These definitions are placed here because the const strings are -----
     // --- used by more than one InstallerListener and UninstallerListener -----
@@ -39,125 +38,31 @@ public class ActionBase implements Serializable
 
     private static final long serialVersionUID = 3690478013149884728L;
 
-    public static final String NAME = "name";
-
-    public static final String ANTCALL_CONDITIONID_ATTR = "condition";
-
-    // Order related "symbols"
-    public static final String ORDER = "order";
-
     public static final String BEFOREPACK = "beforepack";
-
     public static final String AFTERPACK = "afterpack";
-
     public static final String BEFOREPACKS = "beforepacks";
-
     public static final String AFTERPACKS = "afterpacks";
-
-    public static final String UNINSTALL_ORDER = "uninstall_order";
-
     public static final String BEFOREDELETION = "beforedeletion";
-
     public static final String AFTERDELETION = "afterdeletion";
 
-    public static final String PROPERTY = "property";
-
-    public static final String VALUE = "value";
-
-    public static final String ANTCALL_QUIET_ATTR = "quiet";
-    public static final String ANTCALL_VERBOSE_ATTR = "verbose";
-    public static final String ANTCALL_LOGLEVEL_ATTR = "loglevel";
-    public static final String ANTCALL_LOGFILE_ATTR = "logfile";
-    public static final String ANTCALL_SEVERITY_ATTR = "severity";
-    public static final String LOGFILE_APPEND = "logfile_append";
-    public static final String ANTCALL_DIR_ATTR = "dir";
-    public static final String ANTCALL_BUILDFILE_ATTR = "buildfile";
-    public static final String ANTCALL_BUILDRESOURCE_ATTR = "buildresource";
-
-    public static final String PROPERTYFILE = "propertyfile";
-
-    public static final String PATH = "path";
-
-    public static final String SRCDIR = "srcdir";
-
-    public static final String TARGETDIR = "targetdir";
-
-    public static final String TARGET = "target";
-
-    public static final String UNINSTALL_TARGET = "uninstall_target";
-
-    public static final String ACTION = "action";
-
-    public static final String UNINSTALL_ACTION = "uninstall_action";
-
-    public static final String ONDEST = "ondestination";
-
-    public static final String COPY = "copy";
-
-    public static final String REMOVE = "remove";
-
-    public static final String REWIND = "rewind";
-
-    public static final String TOUCH = "touch";
-
-    public static final String MOVE = "move";
-
-    public static final String OVERRIDE = "override";
-
-    public static final String UPDATE = "update";
-
-    public static final String NOTHING = "nothing";
-
-    public static final String FILESET = "fileset";
-
-    public static final String ANTCALL_MESSAGEID_ATTR = "messageid";
-
-    public static final String INCLUDE = "include";
-
-    public static final String INCLUDES = "includes";
-
-    public static final String EXCLUDE = "exclude";
-
-    public static final String EXCLUDES = "excludes";
-
-    public static final String OS = "os";
-
-    public static final String FAMILY = "family";
-
-    public static final String VERSION = "version";
-
-    public static final String ARCH = "arch";
-
-    public static final String CASESENSITIVE = "casesensitive";
-
-    public static final String UNIX = "unix";
-
-    public static final String WINDOWS = "windows";
-
-    public static final String MAC = "mac";
-
-    public static final String ASKTRUE = "asktrue";
-
-    public static final String ASKFALSE = "askfalse";
+    public static final String ORDER = "order";
+    public static final String UNINSTALL_ORDER = "uninstall_order";
 
     private static final HashSet<String> installOrders = new HashSet<String>();
-
     private static final HashSet<String> uninstallOrders = new HashSet<String>();
 
-    protected String uninstallOrder = ActionBase.BEFOREDELETION;
-
+    protected String uninstallOrder = BEFOREDELETION;
     protected String order = null;
-
     protected String messageID = null;
 
     static
     {
-        installOrders.add(ActionBase.BEFOREPACK);
-        installOrders.add(ActionBase.AFTERPACK);
-        installOrders.add(ActionBase.BEFOREPACKS);
-        installOrders.add(ActionBase.AFTERPACKS);
-        uninstallOrders.add(ActionBase.BEFOREDELETION);
-        uninstallOrders.add(ActionBase.AFTERDELETION);
+        installOrders.add(BEFOREPACK);
+        installOrders.add(AFTERPACK);
+        installOrders.add(BEFOREPACKS);
+        installOrders.add(AFTERPACKS);
+        uninstallOrders.add(BEFOREDELETION);
+        uninstallOrders.add(AFTERDELETION);
     }
 
     /**

--- a/izpack-event/src/main/java/com/izforge/izpack/event/AntAction.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/AntAction.java
@@ -49,6 +49,7 @@ public class AntAction extends ActionBase
 
     private static final long serialVersionUID = 3258131345250005557L;
 
+    public static final String CONDITIONID_ATTR = "condition";
     public static final String ANTCALL = "antcall";
 
     private boolean quiet = false;

--- a/izpack-event/src/main/java/com/izforge/izpack/event/ConfigurationInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/ConfigurationInstallerListener.java
@@ -155,7 +155,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
         spec = new SpecHelper(resources);
         try
         {
-            spec.readSpec(SPEC_FILE_NAME, replacer);
+            spec.readSpec(SPEC_FILE_NAME);
         }
         catch (Exception exception)
         {
@@ -203,14 +203,13 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                 logger.fine("Found " + configActionEntries.size() + " configuration actions");
                 if (configActionEntries.size() >= 1)
                 {
-                    Iterator<IXMLElement> entriesIter = configActionEntries.iterator();
-                    while (entriesIter != null && entriesIter.hasNext())
+                    for (IXMLElement configActionEntry : configActionEntries)
                     {
-                        ConfigurationAction act = readConfigAction(entriesIter.next());
+                        ConfigurationAction act = readConfigAction(configActionEntry);
                         if (act != null)
                         {
                             logger.fine("Adding " + act.getOrder() + "configuration action with "
-                                                + act.getActionTasks().size() + " tasks");
+                                    + act.getActionTasks().size() + " tasks");
                             (packActions.get(act.getOrder())).add(act);
                         }
                     }
@@ -310,11 +309,6 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
     // -------------------------------------------------------
     protected List<ConfigurationAction> getActions(String packName, String order)
     {
-        if (actions == null)
-        {
-            return null;
-        }
-
         Map<Object, List<ConfigurationAction>> packActions = actions.get(packName);
         if (packActions == null || packActions.size() == 0)
         {
@@ -583,7 +577,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                                                     IXMLElement el, ConfigFileTask task)
             throws InstallerException
     {
-        File tofile = FileUtil.getAbsoluteFile(requireAttribute(el, "tofile"), idata.getInstallPath());
+        File tofile = FileUtil.getAbsoluteFile(replacer.substitute(requireAttribute(el, "tofile")), idata.getInstallPath());
         task.setToFile(tofile);
         task.setOldFile(FileUtil.getAbsoluteFile(getAttribute(el, "patchfile"), idata.getInstallPath()));
         File newfile = FileUtil.getAbsoluteFile(getAttribute(el, "originalfile"), idata.getInstallPath());
@@ -635,7 +629,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
 
                 case XML:
                     task = new SingleXmlFileMergeTask();
-                    File tofile = FileUtil.getAbsoluteFile(requireAttribute(el, "tofile"), idata.getInstallPath());
+                    File tofile = FileUtil.getAbsoluteFile(replacer.substitute(requireAttribute(el, "tofile")), idata.getInstallPath());
                     ((SingleXmlFileMergeTask) task).setToFile(tofile);
                     ((SingleXmlFileMergeTask) task).setPatchFile(
                             FileUtil.getAbsoluteFile(getAttribute(el, "patchfile"), idata.getInstallPath()));
@@ -663,8 +657,8 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
 
                 case REGISTRY:
                     task = new RegistryTask();
-                    ((RegistryTask) task).setFromKey(requireAttribute(el, "fromkey"));
-                    ((RegistryTask) task).setKey(requireAttribute(el, "tokey"));
+                    ((RegistryTask) task).setFromKey(replacer.substitute(requireAttribute(el, "fromkey")));
+                    ((RegistryTask) task).setKey(replacer.substitute(requireAttribute(el, "tokey")));
                     readSingleConfigurableTaskCommonAttributes(el, (SingleConfigurableTask) task);
                     break;
 
@@ -700,7 +694,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
             else if (task instanceof RegistryTask)
             {
                 entry.setSection(el.getAttribute("key"));
-                entry.setKey(el.getAttribute("value"));
+                entry.setKey(replacer.substitute(el.getAttribute("value")));
                 entry.setValue(getAttribute(el, "data"));
             }
             task.addEntry(entry);
@@ -762,7 +756,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
             }
             e.setUnit(unit);
         }
-        e.setDefault(parent.getAttribute("default"));
+        e.setDefault(replacer.substitute(parent.getAttribute("default")));
         e.setPattern(parent.getAttribute("pattern"));
         //FIXME remove?
         //filterEntryFromXML(parent, e);
@@ -775,7 +769,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
     {
         for (IXMLElement f : parent.getChildrenNamed("xpathproperty"))
         {
-            task.addProperty(requireAttribute(f, "key"), requireAttribute(f, "value"));
+            task.addProperty(requireAttribute(f, "key"), replacer.substitute(requireAttribute(f, "value")));
         }
     }
 
@@ -890,8 +884,8 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     {
                         ((GlobPatternMapper) mapper).setCaseSensitive(Boolean.parseBoolean(boolval));
                     }
-                    mapper.setFrom(requireAttribute(f, "from"));
-                    mapper.setTo(requireAttribute(f, "to"));
+                    mapper.setFrom(replacer.substitute(requireAttribute(f, "from")));
+                    mapper.setTo(replacer.substitute(requireAttribute(f, "to")));
                 }
                 else
                 {
@@ -913,7 +907,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
     {
         for (IXMLElement f : parent.getChildrenNamed("include"))
         {
-            fileset.createInclude().setName(requireAttribute(f, "name"));
+            fileset.createInclude().setName(replacer.substitute(requireAttribute(f, "name")));
         }
     }
 
@@ -922,7 +916,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
     {
         for (IXMLElement f : parent.getChildrenNamed("exclude"))
         {
-            fileset.createExclude().setName(requireAttribute(f, "name"));
+            fileset.createExclude().setName(replacer.substitute(requireAttribute(f, "name")));
         }
     }
 
@@ -981,7 +975,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     IXMLElement valueElement = var.getFirstChildNamed("value");
                     if (valueElement != null)
                     {
-                        value = valueElement.getContent();
+                        value = replacer.substitute(valueElement.getContent());
                         if (value == null)
                         {
                             parseError("Empty value element for dynamic variable " + name);
@@ -1019,7 +1013,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     }
                 }
                 // Check for value from plain config file
-                value = var.getAttribute("file");
+                value = replacer.substitute(var.getAttribute("file"));
                 if (value != null)
                 {
                     String stype = var.getAttribute("type");
@@ -1069,7 +1063,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                     }
                 }
                 // Check for value from config file entry in a jar file
-                value = var.getAttribute("jarfile");
+                value = replacer.substitute(var.getAttribute("jarfile"));
                 if (value != null)
                 {
                     String entryname = requireAttribute(var, "entry");
@@ -1120,7 +1114,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                         {
                             for (IXMLElement arg : args)
                             {
-                                String content = arg.getContent();
+                                String content = replacer.substitute(arg.getContent());
                                 if (content != null)
                                 {
                                     cmd.add(content);
@@ -1128,7 +1122,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                             }
                         }
                         String[] cmdarr = new String[cmd.size()];
-                        if (exectype.equalsIgnoreCase("process") || exectype == null)
+                        if (exectype == null || exectype.equalsIgnoreCase("process"))
                         {
                             dynamicVariable.setValue(new ExecValue(cmd.toArray(cmdarr), dir, false, stderr));
                         }
@@ -1190,7 +1184,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
                         }
                         else if (filterName.equals("location"))
                         {
-                            String basedir = filterElement.getAttribute("basedir");
+                            String basedir = replacer.substitute(filterElement.getAttribute("basedir"));
                             dynamicVariable.addFilter(new LocationFilter(basedir));
                         }
                         else if (filterName.equals("casestyle"))
@@ -1315,7 +1309,7 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
         {
             return substituteVariables(value);
         }
-        return value;
+        return null;
     }
 
     /**
@@ -1340,22 +1334,11 @@ public class ConfigurationInstallerListener extends AbstractProgressInstallerLis
         throw new InstallerException(SPEC_FILE_NAME + ":" + parent.getLineNr() + ": " + message);
     }
 
-    /**
-     * Create a parse warning with consistent messages. Includes file name and line # of parent.     *
-     *
-     * @param parent  The element in which the warning occured
-     * @param message Warning message
-     */
-    protected void parseWarn(IXMLElement parent, String message)
-    {
-        System.out.println("Warning: " + SPEC_FILE_NAME + ":" + parent.getLineNr() + ": " + message);
-    }
-
     public enum ConfigType
     {
         OPTIONS("options"), INI("ini"), XML("xml"), REGISTRY("registry");
 
-        private static Map<String, ConfigType> lookup;
+        private static final Map<String, ConfigType> lookup;
 
         private String attribute;
 

--- a/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
@@ -99,12 +99,12 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
     /**
      * The unpacker.
      */
-    private IUnpacker unpacker;
+    private final IUnpacker unpacker;
 
     /**
      * The variable substituter.
      */
-    private VariableSubstitutor substituter;
+    private final VariableSubstitutor substitutor;
 
     /**
      * The uninstallation data.
@@ -146,7 +146,7 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
      * Constructs a <tt>RegistryInstallerListener</tt>.
      *
      * @param unpacker      the unpacker
-     * @param substituter   the variable substituter
+     * @param substitutor   the variable substituter
      * @param installData   the installation data
      * @param uninstallData the uninstallation data
      * @param rules         the rules
@@ -154,13 +154,13 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
      * @param housekeeper   the housekeeper
      * @param handler       the registry handler reference
      */
-    public RegistryInstallerListener(IUnpacker unpacker, VariableSubstitutor substituter,
+    public RegistryInstallerListener(IUnpacker unpacker, VariableSubstitutor substitutor,
                                      InstallData installData, UninstallData uninstallData,
                                      Resources resources, RulesEngine rules, Housekeeper housekeeper,
                                      RegistryDefaultHandler handler)
     {
         super(installData);
-        this.substituter = substituter;
+        this.substitutor = substitutor;
         this.unpacker = unpacker;
         this.uninstallData = uninstallData;
         this.resources = resources;
@@ -200,7 +200,7 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
             try
             {
                 // need to read the spec now rather than in initialise(), in order to do variable replacement
-                spec.readSpec(SPEC_FILE_NAME, substituter);
+                spec.readSpec(SPEC_FILE_NAME);
             }
             catch (Exception exception)
             {
@@ -386,9 +386,9 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
     private void performValueSetting(IXMLElement regEntry) throws InstallerException, NativeLibException
     {
         String name = spec.getRequiredAttribute(regEntry, REG_BASENAME);
-        name = substituter.substitute(name);
+        name = substitutor.substitute(name);
         String keypath = spec.getRequiredAttribute(regEntry, REG_KEYPATH);
-        keypath = substituter.substitute(keypath);
+        keypath = substitutor.substitute(keypath);
         String root = spec.getRequiredAttribute(regEntry, REG_ROOT);
         int rootId = resolveRoot(regEntry, root);
 
@@ -411,14 +411,14 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
         String value = regEntry.getAttribute(REG_DWORD);
         if (value != null)
         { // Value type is DWord; placeholder possible.
-            value = substituter.substitute(value);
+            value = substitutor.substitute(value);
             registry.setValue(keypath, name, Long.parseLong(value));
             return;
         }
         value = regEntry.getAttribute(REG_STRING);
         if (value != null)
         { // Value type is string; placeholder possible.
-            value = substituter.substitute(value);
+            value = substitutor.substitute(value);
             registry.setValue(keypath, name, value);
             return;
         }
@@ -431,7 +431,7 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
             {
                 IXMLElement element = multiIter.next();
                 multiString[i] = spec.getRequiredAttribute(element, REG_DATA);
-                multiString[i] = substituter.substitute(multiString[i]);
+                multiString[i] = substitutor.substitute(multiString[i]);
             }
             registry.setValue(keypath, name, multiString);
             return;
@@ -453,7 +453,7 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
                     buf.append(",");
                 }
             }
-            byte[] bytes = extractBytes(regEntry, substituter.substitute(buf.toString()));
+            byte[] bytes = extractBytes(regEntry, substitutor.substitute(buf.toString()));
             registry.setValue(keypath, name, bytes);
             return;
         }
@@ -505,7 +505,7 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
     private void performKeySetting(IXMLElement regEntry) throws InstallerException, NativeLibException
     {
         String path = spec.getRequiredAttribute(regEntry, REG_KEYPATH);
-        path = substituter.substitute(path);
+        path = substitutor.substitute(path);
         String root = spec.getRequiredAttribute(regEntry, REG_ROOT);
         int rootId = resolveRoot(regEntry, root);
         registry.setRoot(rootId);
@@ -517,7 +517,7 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
 
     private int resolveRoot(IXMLElement regEntry, String root)
     {
-        String root1 = substituter.substitute(root);
+        String root1 = substitutor.substitute(root);
         Integer tmp = RegistryHandler.ROOT_KEY_MAP.get(root1);
         if (tmp != null)
         {

--- a/izpack-event/src/test/java/com/izforge/izpack/event/BSFInstallerListenerTest.java
+++ b/izpack-event/src/test/java/com/izforge/izpack/event/BSFInstallerListenerTest.java
@@ -155,8 +155,7 @@ public class BSFInstallerListenerTest
 
         UninstallData uninstallData = new UninstallData();
         ProgressNotifiers notifiers = new ProgressNotifiersImpl();
-        BSFInstallerListener listener = new BSFInstallerListener(installData, replacer, resources, uninstallData,
-                                                                 notifiers);
+        BSFInstallerListener listener = new BSFInstallerListener(installData, replacer, installData.getVariables(), resources, uninstallData, notifiers);
         listener.initialise();
 
         // Verify that when the beforePacks method is invoked, the corresponding BSF action is called.

--- a/izpack-event/src/test/java/com/izforge/izpack/event/BSFUninstallerListenerTest.java
+++ b/izpack-event/src/test/java/com/izforge/izpack/event/BSFUninstallerListenerTest.java
@@ -197,7 +197,7 @@ public class BSFUninstallerListenerTest
         Mockito.when(resources.getInputStream(BSFInstallerListener.SPEC_FILE_NAME)).thenReturn(specStream);
 
         UninstallData uninstallData = new UninstallData();
-        BSFInstallerListener listener = new BSFInstallerListener(installData, replacer, resources,
+        BSFInstallerListener listener = new BSFInstallerListener(installData, replacer, variables, resources,
                                                                  uninstallData, new ProgressNotifiersImpl());
         listener.initialise();
         Pack pack = new Pack(packName, null, null, null, null, true, true, false, null, true, 0);

--- a/izpack-util/src/main/java/com/izforge/izpack/util/helper/SpecHelper.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/helper/SpecHelper.java
@@ -21,20 +21,16 @@
 
 package com.izforge.izpack.util.helper;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLParser;
 import com.izforge.izpack.api.adaptator.impl.XMLParser;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.exception.ResourceNotFoundException;
 import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.api.substitutor.VariableSubstitutor;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class contains some helper methods to simplify handling of xml specification files.
@@ -51,7 +47,7 @@ public class SpecHelper
 
     private IXMLElement spec;
 
-    private boolean _haveSpec;
+    private boolean haveSpec;
 
     /**
      * The resources.
@@ -80,40 +76,25 @@ public class SpecHelper
      *
      * @throws Exception for any problems in reading the specification
      */
-    /*--------------------------------------------------------------------------*/
     public void readSpec(String specFileName) throws Exception
     {
-        readSpec(specFileName, null);
-    }
-
-    /*--------------------------------------------------------------------------*/
-
-    /**
-     * Reads the XML specification given by the file name. The result is stored in spec.
-     *
-     * @throws Exception for any problems in reading the specification
-     */
-    /*--------------------------------------------------------------------------*/
-    public void readSpec(String specFileName, VariableSubstitutor substitutor) throws Exception
-    {
-        // open an input stream
-        InputStream input = null;
+        InputStream input;
         try
         {
             input = getResource(specFileName);
         }
         catch (Exception exception)
         {
-            _haveSpec = false;
+            haveSpec = false;
             return;
         }
         if (input == null)
         {
-            _haveSpec = false;
+            haveSpec = false;
             return;
         }
 
-        readSpec(input, substitutor);
+        readSpec(input);
 
         // close the stream
         input.close();
@@ -130,31 +111,12 @@ public class SpecHelper
     /*--------------------------------------------------------------------------*/
     public void readSpec(InputStream input) throws Exception
     {
-        readSpec(input, null);
-    }
-
-    /*--------------------------------------------------------------------------*/
-
-    /**
-     * Reads the XML specification given by the input stream. The result is stored in spec.
-     *
-     * @throws Exception for any problems in reading the specification
-     */
-    /*--------------------------------------------------------------------------*/
-    public void readSpec(InputStream input, VariableSubstitutor substitutor) throws Exception
-    {
-        // first try to substitute the variables
-        if (substitutor != null)
-        {
-            input = substituteVariables(input, substitutor);
-        }
-
         // initialize the parser
         IXMLParser parser = new XMLParser();
 
         // get the data
         spec = parser.parse(input);
-        _haveSpec = true;
+        haveSpec = true;
     }
 
     /**
@@ -220,7 +182,7 @@ public class SpecHelper
      */
     public boolean haveSpec()
     {
-        return _haveSpec;
+        return haveSpec;
     }
 
     /**
@@ -269,7 +231,7 @@ public class SpecHelper
     private List<IXMLElement> getSubChildren(IXMLElement root, String[] childdef, int depth)
     {
         List<IXMLElement> retval = null;
-        List<IXMLElement> retval2 = null;
+        List<IXMLElement> retval2;
         List<IXMLElement> children = root != null ? root.getChildrenNamed(childdef[depth]) : null;
         if (children == null)
         {
@@ -295,36 +257,6 @@ public class SpecHelper
             return (children);
         }
         return (retval);
-    }
-
-    /**
-     * Creates an temp file in to the substitutor the substituted contents of input writes; close it
-     * and (re)open it as FileInputStream. The file will be deleted on exit.
-     *
-     * @param input       the opened input stream which contents should be substituted
-     * @param substitutor substitutor which should substitute the contents of input
-     * @return a file input stream of the created temporary file
-     * @throws Exception
-     */
-    public InputStream substituteVariables(InputStream input, VariableSubstitutor substitutor)
-            throws Exception
-    {
-        File tempFile = File.createTempFile("izpacksubs", "");
-        FileOutputStream fos = null;
-        tempFile.deleteOnExit();
-        try
-        {
-            fos = new FileOutputStream(tempFile);
-            substitutor.substitute(input, fos, null, "UTF-8");
-        }
-        finally
-        {
-            if (fos != null)
-            {
-                fos.close();
-            }
-        }
-        return new FileInputStream(tempFile);
     }
 
     /**


### PR DESCRIPTION
This PR resolves [IZPACK-1488](https://izpack.atlassian.net/browse/IZPACK-1488):

If using AntActionInstallerListener with an AntActionSpec.xml resource containing variable references, and a variable in these references has the '`&`' character as value at the listener execution time, the installer fails with this stacktrace:
```
/usr/java/jdk1.8.0_121/jre/bin/java -DSTACKTRACE=true -jar installer-1.0.0-SNAPSHOT.jar 
Logging initialized at level 'INFO'
Commandline arguments: 
Detected platform: suse_linux,version=4.9.5-2.g9bb1a8a-default,arch=x64,symbolicName=null,javaVersion=1.8.0_121
ERROR:  'The entity name must immediately follow the '&' in the entity reference.'
ERROR:  'com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: The entity name must immediately follow the '&' in the entity reference.'
Failed to read: AntActionsSpec.xml
com.izforge.izpack.api.exception.IzPackException: Failed to read: AntActionsSpec.xml
        at com.izforge.izpack.event.AntActionInstallerListener.beforePacks(AntActionInstallerListener.java:131)
        at com.izforge.izpack.installer.event.InstallerListeners.beforePacks(InstallerListeners.java:170)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.preUnpack(UnpackerBase.java:405)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:250)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.run(UnpackerBase.java:236)
        at java.lang.Thread.run(Thread.java:745)
Caused by: com.izforge.izpack.api.adaptator.XMLException: Errornull at line 136, column 52 : javax.xml.transform.TransformerException: com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: The entity name must immediately follow the '&' in the entity reference.
        at com.izforge.izpack.api.adaptator.impl.XMLParser.parseLineNrFromInputSource(XMLParser.java:183)
        at com.izforge.izpack.api.adaptator.impl.XMLParser.parse(XMLParser.java:204)
        at com.izforge.izpack.util.helper.SpecHelper.readSpec(SpecHelper.java:156)
        at com.izforge.izpack.util.helper.SpecHelper.readSpec(SpecHelper.java:116)
        at com.izforge.izpack.event.AntActionInstallerListener.beforePacks(AntActionInstallerListener.java:127)
        ... 5 more
Caused by: javax.xml.transform.TransformerException: javax.xml.transform.TransformerException: com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: The entity name must immediately follow the '&' in the entity reference.
        at com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl.transform(TransformerImpl.java:749)
        at com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl.transform(TransformerImpl.java:351)
        at com.izforge.izpack.api.adaptator.impl.XMLParser.parseLineNrFromInputSource(XMLParser.java:164)
        ... 9 more
Caused by: javax.xml.transform.TransformerException: com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: The entity name must immediately follow the '&' in the entity reference.
        at com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl.getDOM(TransformerImpl.java:578)
        at com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl.transform(TransformerImpl.java:739)
        ... 11 more
Caused by: com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: The entity name must immediately follow the '&' in the entity reference.
        at com.sun.org.apache.xalan.internal.xsltc.dom.XSLTCDTMManager.getDTM(XSLTCDTMManager.java:427)
        at com.sun.org.apache.xalan.internal.xsltc.dom.XSLTCDTMManager.getDTM(XSLTCDTMManager.java:215)
        at com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl.getDOM(TransformerImpl.java:556)
        ... 12 more
```

Furthermore there are some code optimizations in the code anyhow affected by this issue.