### PR TITLE
IZPACK-1490: ConfigurationActionListener: <variables> tag not accepted during compilation

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-configurationactions-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-configurationactions-5.0.xsd
@@ -45,9 +45,15 @@
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
 
+    <xs:complexType name="variablesType">
+        <xs:sequence>
+            <xs:element name="variable" type="types:dynamicVariableType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
     <xs:complexType name="configurationActionType">
         <xs:choice maxOccurs="unbounded">
-            <xs:element name="variable" type="types:dynamicVariableType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="variablesType" type="types:dynamicVariableType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="configurableset" type="configurableSetType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="configurable" type="configurableType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>


### PR DESCRIPTION
This PR fixes [IZPACK-1490](https://izpack.atlassian.net/browse/IZPACK-1490):

According to the [documentation|https://izpack.atlassian.net/wiki/x/2IAH] it should be possible to define nested, local variables for each configuration action:
```xml
<configuration_action_tag>
  <variables>
    <variable/>
    <variable/>
    ... 
  </variables>
</configuration_action_tag>
```

Although this is already implemented a long time, the XSD for the configuration action resource doesn't allow these variable definitions any longer since validation has been automatically activated for the compilation process.