### PR TITLE
IZPACK-1482: ConfigurationInstallerListener - handle auto-numbered key-value-pairs also for numbers embedded into the key name (post-fix)

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/config/Options.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/config/Options.java
@@ -231,7 +231,7 @@ public class Options extends BasicOptionMap implements Persistable, Configurable
                     {
                         if (name.matches(".+\\.\\..+"))
                         {
-                            formatter.handleOption(name.replaceFirst("\\.\\.", Integer.toString(i)), value);
+                            formatter.handleOption(name.replaceFirst("\\.\\.", "." + Integer.toString(i) + "."), value);
                         }
                         else if (name.matches("(.+\\.)+"))
                         {


### PR DESCRIPTION
Post-fix for [IZPACK-1482](https://izpack.atlassian.net/browse/IZPACK-1482) solved in #566 found recently:

Options have been mapped badly during saving the target Options, for example `param.1.opt.1` -> `param1opt.1`.

Added also a unit test for avoiding this in future.