### PR TITLE
IZPACK-1476: XML Schema does not allow uninstaller attribute in run-privileged element

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -2465,9 +2465,8 @@ public class CompilerConfig extends Thread
             if (privileged != null)
             {
                 // default behavior for uninstaller elevation: elevate if installer has to be elevated too
-                info.setRequirePrivilegedExecutionUninstaller(xmlCompilerHelper.validateYesNoAttribute(privileged,
-                                                                                                       "uninstaller",
-                                                                                                       YES));
+                info.setRequirePrivilegedExecutionUninstaller(
+                        xmlCompilerHelper.validateYesNoAttribute(privileged,"uninstaller", YES));
             }
 
             if (uninstallInfo != null)

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -128,6 +128,7 @@
 
     <xs:complexType name="runPrivilegedType">
         <xs:attribute type="xs:string" name="condition" use="optional"/>
+        <xs:attribute type="types:yesNoTrueFalseType" name="uninstaller" use="optional" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="uninstallerType">


### PR DESCRIPTION
This fixes [IZPACK-1476](https://izpack.atlassian.net/browse/IZPACK-1476):

XML Schema does not permit the use of the uninstaller="true" attribute in the run-privileged element. See [this discussion](https://groups.google.com/forum/#!topic/izpack-user/W8wJA5ihqmc) for details.