### PR TITLE
IZPACK-1472: Introduce customizable installer logging (continuation)

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1770,30 +1770,28 @@ public class CompilerConfig extends Thread
             Properties logConfig = null;
             for (IXMLElement configFileElement : logFiles)
             {
-                String cname = FileHandler.class.getName();
+                final String cname = FileHandler.class.getName();
                 if (logConfig == null)
                 {
                     logConfig = new Properties();
                     logConfig.setProperty("handlers", cname);
                 }
-                logConfig = logConfig;
-
-                String pattern = configFileElement.getAttribute("pattern");
+                final String pattern = configFileElement.getAttribute("pattern");
                 if (pattern != null)
                 {
                     logConfig.setProperty(cname + ".pattern", pattern);
                 }
-                String level = configFileElement.getAttribute("level");
+                final String level = configFileElement.getAttribute("level");
                 if (level != null)
                 {
                     logConfig.setProperty(cname + ".level", level);
                 }
-                String filter = configFileElement.getAttribute("filter");
+                final String filter = configFileElement.getAttribute("filter");
                 if (filter != null)
                 {
                     logConfig.setProperty(cname + ".filter", filter);
                 }
-                String encoding = configFileElement.getAttribute("encoding");
+                final String encoding = configFileElement.getAttribute("encoding");
                 if (encoding != null)
                 {
                     logConfig.setProperty(cname + ".encoding", encoding);
@@ -1803,15 +1801,20 @@ public class CompilerConfig extends Thread
                 {
                     logConfig.setProperty(cname + ".limit", limit);
                 }
-                String count = configFileElement.getAttribute("count");
+                final String count = configFileElement.getAttribute("count");
                 if (count != null)
                 {
                     logConfig.setProperty(cname + ".count", count);
                 }
-                String append = configFileElement.getAttribute("append");
+                final String append = configFileElement.getAttribute("append");
                 if (append != null)
                 {
                     logConfig.setProperty(cname + ".append", append);
+                }
+                final String mkdirs = configFileElement.getAttribute("mkdirs");
+                if (mkdirs != null)
+                {
+                    logConfig.setProperty(cname + ".mkdirs", Boolean.valueOf(mkdirs).toString());
                 }
                 logConfig.setProperty(cname + ".formatter", FileFormatter.class.getName());
             }

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -285,6 +285,7 @@
                         <xs:annotation>
                             <xs:documentation>
                                 Specifies the logging level.
+                                See http://docs.oracle.com/javase/6/docs/api/java/util/logging/FileHandler.html for details.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
@@ -292,6 +293,7 @@
                         <xs:annotation>
                             <xs:documentation>
                                 Specifies the name of a Filter class to use (defaults to no Filter).
+                                See http://docs.oracle.com/javase/6/docs/api/java/util/logging/FileHandler.html for details.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
@@ -299,6 +301,7 @@
                         <xs:annotation>
                             <xs:documentation>
                                 The name of the character set encoding to use (defaults to the default platform encoding).
+                                See http://docs.oracle.com/javase/6/docs/api/java/util/logging/FileHandler.html for details.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
@@ -306,6 +309,7 @@
                         <xs:annotation>
                             <xs:documentation>
                                 Specifies an approximate maximum amount to write (in bytes) to any one file. If this is zero, then there is no limit. (Defaults to no limit).
+                                See http://docs.oracle.com/javase/6/docs/api/java/util/logging/FileHandler.html for details.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
@@ -313,6 +317,7 @@
                         <xs:annotation>
                             <xs:documentation>
                                 Specifies how many output files to cycle through (defaults to 1).
+                                See http://docs.oracle.com/javase/6/docs/api/java/util/logging/FileHandler.html for details.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
@@ -320,6 +325,15 @@
                         <xs:annotation>
                             <xs:documentation>
                                 Specifies whether the FileHandler should append onto any existing files (defaults to false).
+                                See http://docs.oracle.com/javase/6/docs/api/java/util/logging/FileHandler.html for details.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="mkdirs" type="xs:boolean" use="optional" default="false">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Specifies whether the IzPack should recursively create the parent directory of the file
+                                resulting from the 'pattern' attribute before invoking FileHandler.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -1440,7 +1440,14 @@ public abstract class UnpackerBase implements IUnpacker
             // IzPack maintains just one log file, don't override the existing handler type of it.
             // Special use case: Command line argument -logfile "wins" over the <log-file> tag.
             // Assumption at the moment for optimization: Just FileHandler is used for configurations from install.xml.
-            LogUtils.loadConfiguration(ResourceManager.getInstallLoggingConfigurationResourceName(), variables, true);
+            try
+            {
+                LogUtils.loadConfiguration(ResourceManager.getInstallLoggingConfigurationResourceName(), variables, true);
+            }
+            catch (IOException e)
+            {
+                throw new IzPackException(e, Type.WARNING);
+            }
         }
 
         logger = Logger.getLogger(UnpackerBase.class.getName());


### PR DESCRIPTION
Enhancement of the implementation for [IZPACK-1472](https://izpack.atlassian.net/browse/IZPACK-1472):

Added `mkdirs` compile-time attribute.
Also improved the XSD inline documentation a bit.
Some bug fixes and cleanup to make it consistent with the LogManager API.