### PR TITLE
IZPACK-1472: Introduce customizable installer logging (additional changes)

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
@@ -58,6 +58,10 @@
     <str id="installer.sendReport" txt="Enviar Relatório"/>
     <str id="installer.continueQuestion" txt="Deseja Continuar?"/>
     <str id="installer.cancelled" txt="Instalação cancelada"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Isto removerá o(s) aplicativo(s) instalado(s) !"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/cat.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/cat.xml
@@ -51,6 +51,10 @@
     <str id="installer.hideDetails" txt="Hide Details"/>
     <str id="installer.copy" txt="Copy"/>
     <str id="installer.sendReport" txt="Send Report"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Això eliminarà l'aplicació instal.lada!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
@@ -58,6 +58,10 @@
     <str id="installer.sendReport" txt="Poslat report"/>
     <str id="installer.cancelled" txt="Instalace byla zrušena"/>
     <str id="installer.continueQuestion" txt="Přesto pokračovat?"/>
+    <str id="installer.started" txt="Instalace probíhá"/>
+    <str id="installer.platform" txt="Platforma: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Instalace skončila"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Tato operace odstraní nainstalovanou aplikaci !"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/chn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/chn.xml
@@ -53,6 +53,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="将卸载已安装的应用程序 !"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/dan.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/dan.xml
@@ -53,6 +53,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Dette vil fjerne installerede applikationer !"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
@@ -66,6 +66,10 @@
     <str id="installer.sendReport" txt="Report senden"/>
     <str id="installer.cancelled" txt="Installation abgebrochen"/>
     <str id="installer.continueQuestion" txt="Trotzdem fortsetzen?"/>
+    <str id="installer.started" txt="Installation gestartet"/>
+    <str id="installer.platform" txt="Plattform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation beendet"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Jetzt werden die installierten Anwendungen entfernt!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ell.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ell.xml
@@ -29,6 +29,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Θα αφαιρεθούν οι εγκατεστημένες εφαρμογές!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -89,6 +89,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="This will remove the installed application!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
@@ -86,6 +86,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Instalatutako aplikazioak ezabatuko dira!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
@@ -83,6 +83,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="این کار موجب حذف برنامه(ها)ی نصب شده می شود!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
@@ -91,6 +91,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Tämä poistaa asennetun sovelluksen/asennetut sovellukset!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
@@ -60,6 +60,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Ceci va enlever l'(es) application(s) installée(s) !"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
@@ -90,6 +90,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="¡Esto eliminará a(s) aplicación(s) instalada(s)!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
@@ -81,6 +81,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="A telepített alkalmazás eltávolítása következik !"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
@@ -85,6 +85,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Ini akan menghapus aplikasi terpasang!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
@@ -85,6 +85,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Verranno disinstallate la(e) applicazione(i) selezionate!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
@@ -107,6 +107,10 @@
     <str id="installer.step" txt="ステップ"/>
     <str id="installer.of" txt="/"/>
     <str id="installer.Message" txt="メッセージ"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="この操作は、インストール済のアプリケーションを削除します!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
@@ -54,6 +54,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="설치된 어플리케이션이 제거됩니다!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/msa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/msa.xml
@@ -53,6 +53,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Ini akan menggeluarkan applikasi yang dipasang!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
@@ -91,6 +91,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning"

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
@@ -93,6 +93,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Dette vil fjerne installerte programmer!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
@@ -98,6 +98,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- ConsolePrompt strings -->
     <str id="ConsolePrompt.okCancel" txt="Enter O for OK, C to Cancel: "/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
@@ -85,6 +85,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="A aplicação vai ser removida!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ron.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ron.xml
@@ -53,6 +53,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Aplicatiile instalate vor fi inlaturate !"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
@@ -54,6 +54,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Установленные программы будут удалены!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
@@ -91,6 +91,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Táto operácia odstráni nainštalovanú aplikáciu !"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -90,6 +90,10 @@
     <str id="installer.sendReport" txt="Enviar un informe"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="¡Se eliminarán la(s) aplicacion(es) instalada(s)!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/srp.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/srp.xml
@@ -51,6 +51,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Ово ће да избрише инсталирану/е апликацију/е!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
@@ -79,6 +79,10 @@
     <str id="installer.sendReport" txt="Skicka rapport"/>
     <str id="installer.continueQuestion" txt="Fortsätt ändå?"/>
     <str id="installer.cancelled" txt="Installationen avbryten"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Detta kommer att ta bort den installerade applikationen!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
@@ -85,6 +85,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Bu kurulmuş olan program(lar)ı kaldıracaktır!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
@@ -53,6 +53,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="將卸解已安裝的應用程式!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
@@ -86,6 +86,10 @@
     <str id="installer.sendReport" txt="Send Report"/>
     <str id="installer.continueQuestion" txt="Continue anyway?"/>
     <str id="installer.cancelled" txt="Installation cancelled"/>
+    <str id="installer.started" txt="Installation started"/>
+    <str id="installer.platform" txt="Platform: {0}"/>
+    <str id="installer.version" txt="Framework: {0}"/>
+    <str id="installer.finished" txt="Installation finished"/>
 
     <!-- Uninstaller specific strings -->
     <str id="uninstaller.warning" txt="Це видалить встановлену програму!"/>

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -32,7 +32,6 @@ import com.izforge.izpack.installer.container.impl.InstallerContainer;
 import com.izforge.izpack.logging.FileFormatter;
 import com.izforge.izpack.util.Debug;
 import com.izforge.izpack.util.LogUtils;
-import com.izforge.izpack.util.Platform;
 import com.izforge.izpack.util.StringTool;
 import org.apache.commons.io.FilenameUtils;
 
@@ -323,8 +322,6 @@ public class Installer
     private void launchAutomatedInstaller(String path, String mediaDir, Overrides defaults, String[] args) throws Exception
     {
         InstallerContainer container = new AutomatedInstallerContainer();
-
-        logger.info("Detected platform: " + container.getComponent(Platform.class));
 
         if (defaults != null)
         {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerConsole.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerConsole.java
@@ -31,7 +31,6 @@ import com.izforge.izpack.installer.container.impl.InstallerContainer;
 import com.izforge.izpack.installer.language.LanguageConsoleDialog;
 import com.izforge.izpack.installer.requirement.RequirementsChecker;
 import com.izforge.izpack.util.Housekeeper;
-import com.izforge.izpack.util.Platform;
 
 import java.util.logging.Logger;
 
@@ -46,9 +45,6 @@ public class InstallerConsole
                          final String mediaPath, Overrides defaults, final String[] args)
   {
     final InstallerContainer applicationComponent = new ConsoleInstallerContainer();
-
-    logger.info("Detected platform: " + applicationComponent.getComponent(Platform.class));
-
     final Container installerContainer = applicationComponent.getComponent(Container.class);
     try
     {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/InstallerGui.java
@@ -34,7 +34,6 @@ import com.izforge.izpack.installer.gui.SplashScreen;
 import com.izforge.izpack.installer.language.LanguageDialog;
 import com.izforge.izpack.installer.requirement.RequirementsChecker;
 import com.izforge.izpack.util.Housekeeper;
-import com.izforge.izpack.util.Platform;
 
 import javax.swing.*;
 import java.util.logging.Level;
@@ -54,8 +53,6 @@ public class InstallerGui
     {
         final InstallerContainer applicationComponent = new GUIInstallerContainer();
         final Container installerContainer = applicationComponent.getComponent(Container.class);
-
-		logger.info("Detected platform: " + applicationComponent.getComponent(Platform.class));
 
 		final Object trigger = new Object();
 		// display the splash screen from AWT thread

--- a/izpack-test/src/test/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeUnpackerTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeUnpackerTest.java
@@ -21,34 +21,10 @@
 
 package com.izforge.izpack.installer.multiunpacker;
 
-import static com.izforge.izpack.test.util.TestHelper.assertFileEquals;
-import static com.izforge.izpack.test.util.TestHelper.assertFileNotExists;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-
-import org.apache.commons.io.FilenameUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.Mockito;
-
-import com.izforge.izpack.api.data.AutomatedInstallData;
-import com.izforge.izpack.api.data.Blockable;
-import com.izforge.izpack.api.data.Info;
-import com.izforge.izpack.api.data.OverrideType;
-import com.izforge.izpack.api.data.Pack;
+import com.izforge.izpack.api.data.*;
 import com.izforge.izpack.api.event.ProgressListener;
 import com.izforge.izpack.api.handler.Prompt;
+import com.izforge.izpack.api.resource.Locales;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.api.substitutor.VariableSubstitutor;
@@ -78,6 +54,25 @@ import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.Librarian;
 import com.izforge.izpack.util.PlatformModelMatcher;
 import com.izforge.izpack.util.Platforms;
+import org.apache.commons.io.FilenameUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static com.izforge.izpack.test.util.TestHelper.assertFileEquals;
+import static com.izforge.izpack.test.util.TestHelper.assertFileNotExists;
+import static org.junit.Assert.*;
 
 /**
  * Tests the {@link MultiVolumeUnpacker}.
@@ -407,6 +402,9 @@ public class MultiVolumeUnpackerTest
         installData.setInstallPath(installDir.getPath());
         installData.setMediaPath(mediaDir.getPath());
         installData.setInfo(new Info());
+        InputStream langPack = getClass().getResourceAsStream("/com/izforge/izpack/bin/langpacks/installer/eng.xml");
+        assertNotNull(langPack);
+        installData.setMessages(new LocaleDatabase(langPack, Mockito.mock(Locales.class)));
         List<Pack> packs = getPacks(resources);
         installData.setAvailablePacks(packs);
         return installData;


### PR DESCRIPTION
Additional enhancements for [IZPACK-1472](https://izpack.atlassian.net/browse/IZPACK-1472):

- Added an intro and epilog to the log when the installation actually starts and finishes to better recognize start and end of a particular session when appending to log files
- Moved the Detected Platform log entry to the install log (shown when unpacking happens)
- Added the IzPack (framework) version to the log for better analysis

Added some translations for the intro and epilog entries. At the moment there are available just english, german and czech translations, english is the fallback. In hope for contributions to translate them to more languages supported.