### PR TITLE
IZPACK-1497:  Serialize actual size of packed file data instead of the size of the original file to enable compression

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/PackFile.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/PackFile.java
@@ -116,9 +116,10 @@ public class PackFile implements Serializable
      */
     private Map additionals = null;
 
-    public String previousPackId = null;
+    private String streamResourceName;
+    private long streamOffset = -1;
 
-    public long offsetInPreviousPack = -1;
+    private PackFile linkedPackFile;
 
     /**
      * True if the file is a Jar and pack200 compression us activated.
@@ -240,10 +241,34 @@ public class PackFile implements Serializable
         return instanceId;
     }
 
-    public void setPreviousPackFileRef(String previousPackId, Long offsetInPreviousPack)
+    public PackFile getLinkedPackFile()
     {
-        this.previousPackId = previousPackId;
-        this.offsetInPreviousPack = offsetInPreviousPack;
+        return linkedPackFile;
+    }
+
+    public void setLinkedPackFile(PackFile linkedPackFile)
+    {
+        this.linkedPackFile = linkedPackFile;
+    }
+
+    public String getStreamResourceName()
+    {
+        return streamResourceName;
+    }
+
+    public void setStreamResourceName(String streamResourceName)
+    {
+        this.streamResourceName = streamResourceName;
+    }
+
+    public long getStreamOffset()
+    {
+        return streamOffset;
+    }
+
+    public void setStreamOffset(long offset)
+    {
+        this.streamOffset = offset;
     }
 
     /**
@@ -330,7 +355,7 @@ public class PackFile implements Serializable
 
     public final boolean isBackReference()
     {
-        return (previousPackId != null);
+        return (linkedPackFile != null);
     }
 
     /**

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -2423,23 +2423,21 @@ public class CompilerConfig extends Thread
         }
 
         String compressionName = compilerData.getComprFormat();
-        if (compressionName == null)
+        IXMLElement compressionElement = root.getFirstChildNamed("pack-compression-format");
+        if (compressionElement != null)
         {
-            IXMLElement compressionElement = root.getFirstChildNamed("pack-compression-format");
-            if (compressionElement != null)
+            compressionName = xmlCompilerHelper.requireContent(compressionElement);
+        }
+        if (compressionName != null)
+        {
+            PackCompression compression = PackCompression.byName(compressionName);
+            if (compression == null)
             {
-                compressionName = xmlCompilerHelper.requireContent(compressionElement);
+                throw new CompilerException("Unknown compression format: " + compressionName);
             }
+            info.setCompressionFormat(compression);
+            logger.info("Pack compression method: " + compression.toName());
         }
-        PackCompression compression = (compressionName != null) ?
-                PackCompression.byName(compressionName) :
-                PackCompression.DEFAULT;
-        if (compression == null)
-        {
-            throw new CompilerException("Unknown compression format: " + compressionName);
-        }
-        info.setCompressionFormat(compression);
-        logger.info("Pack compression method: " + compression.toName());
 
         // Add the path for the summary log file if specified
         IXMLElement slfPath = root.getFirstChildNamed("summarylogfilepath");

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/data/CompilerData.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/data/CompilerData.java
@@ -20,7 +20,6 @@
 package com.izforge.izpack.compiler.data;
 
 import com.izforge.izpack.api.data.Info;
-import com.izforge.izpack.api.data.PackCompression;
 
 import java.io.File;
 import java.util.ResourceBundle;
@@ -131,7 +130,7 @@ public class CompilerData
 
     public CompilerData(String installFile, String basedir, String output, boolean mkdirs)
     {
-        this(PackCompression.DEFAULT.toName(), installFile, basedir, output, mkdirs);
+        this(null, installFile, basedir, output, mkdirs);
     }
 
     public CompilerData(String packCompression, String kind, String installFile, String installText, String basedir,

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/Packager.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/Packager.java
@@ -32,6 +32,7 @@ import com.izforge.izpack.compiler.listener.PackagerListener;
 import com.izforge.izpack.compiler.merge.CompilerPathResolver;
 import com.izforge.izpack.merge.MergeManager;
 import com.izforge.izpack.merge.resolve.MergeableResolver;
+import com.izforge.izpack.util.NoCloseOutputStream;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorOutputStream;
@@ -129,7 +130,7 @@ public class Packager extends PackagerBase
         sendMsg("Writing " + num + " Pack" + (num > 1 ? "s" : "") + " into installer");
 
         // Map to remember pack number and bytes offsets of back references
-        Map<File, Object[]> storedFiles = new HashMap<File, Object[]>();
+        Map<File, PackFile> storedFiles = new HashMap<File, PackFile>();
 
         List<PackFile> pack200Files = new ArrayList<PackFile>();
 
@@ -147,137 +148,151 @@ public class Packager extends PackagerBase
             sendMsg("Writing Pack " + packNumber + ": " + pack.getName(), PackagerListener.MSG_VERBOSE);
 
             ZipEntry entry;
+            String streamResourceName = "packs/pack-" + pack.getName();
             JarOutputStream packJar = installerJar;
             if (packSeparateJars())
             {
                 // TODO REFACTOR : Use a mergeManager for each packages that will be added to the main merger
                 String jarFile = getInfo().getInstallerBase() + ".pack-" + pack.getName() + ".jar";
                 packJar = getJarOutputStream(new File(jarFile));
-                entry = new ZipEntry("packs/pack-" + pack.getName());
+                entry = new ZipEntry(streamResourceName);
             } else
             {
-                entry = new ZipEntry(RESOURCES_PATH + "packs/pack-" + pack.getName());
+                entry = new ZipEntry(RESOURCES_PATH + streamResourceName);
             }
 
             packJar.putNextEntry(entry);
             packJar.flush(); // flush before we start counting
 
-            CountingOutputStream dos = new CountingOutputStream(packJar);
-            ObjectOutputStream objOut = new ObjectOutputStream(dos);
+            CountingOutputStream packOutputStream = new CountingOutputStream(new NoCloseOutputStream(packJar));
 
-            for (PackFile packFile : packInfo.getPackFiles())
+            try
             {
-                boolean addFile = !pack.isLoose();
-                File file = packInfo.getFile(packFile);
-
-                boolean pack200 = packFile.isPack200Jar();
-
-                // use a back reference if file was in previous pack, and in
-                // same jar
-                Object[] info = storedFiles.get(file);
-                if (info != null && !packSeparateJars())
+                for (PackFile packFile : packInfo.getPackFiles())
                 {
-                    packFile.setPreviousPackFileRef((String) info[0], (Long) info[1]);
-                    addFile = false;
-                }
+                    boolean addFile = !pack.isLoose();
+                    File file = packInfo.getFile(packFile);
 
-                if (addFile && !packFile.isDirectory())
-                {
-                    long pos = dos.getByteCount(); // get the position
+                    boolean pack200 = packFile.isPack200Jar();
 
-                    if (pack200)
+                    // use a back reference if file was in previous pack, and in
+                    // same jar
+                    PackFile linkedPackFile = storedFiles.get(file);
+                    if (linkedPackFile != null && !packSeparateJars())
                     {
-                        /*
-                         * Warning!
-						 *
-						 * Pack200 archives must be stored in separated streams,
-						 * as the Pack200 unpacker reads the entire stream...
-						 *
-						 * See http://java.sun.com/javase/6/docs/api/java/util/jar/Pack200.Unpacker.html
-						 */
-                        pack200Files.add(packFile);
+                        // Save backreference link
+                        packFile.setLinkedPackFile(linkedPackFile);
+                        addFile = false;
                     }
-                    else
-                    {
-                        PackCompression comprFormat = getInfo().getCompressionFormat();
-                        OutputStream finalStream;
-                        CountingOutputStream proxyOutputStream =  new CountingOutputStream(new CloseShieldOutputStream(objOut));
-                        if (comprFormat != PackCompression.DEFAULT)
-                        {
-                            switch (comprFormat)
-                            {
-                                case LZMA:
-                                    // LZMA as output stream supported from commons-compress 1.13 (requires JDK 1.7)
-                                    // for now create it from the Tukaani Project (tukaani.org)
-                                    finalStream = new LZMAOutputStream(proxyOutputStream, new LZMA2Options(), -1);
-                                    break;
-                                case DEFLATE:
-                                    DeflateParameters deflateParameters = new DeflateParameters();
-                                    deflateParameters.setCompressionLevel(Deflater.BEST_COMPRESSION);
-                                    new DeflateCompressorOutputStream(proxyOutputStream, deflateParameters);
-                                default:
-                                    try
-                                    {
-                                        finalStream = new CompressorStreamFactory().createCompressorOutputStream(
-                                                comprFormat.toName(),
-                                                proxyOutputStream);
-                                    }
-                                    catch (CompressorException e)
-                                    {
-                                        throw new IOException(e);
-                                    }
-                            }
 
-                            try
+                    if (addFile && !packFile.isDirectory())
+                    {
+                        if (pack200)
+                        {
+                            /*
+                             * Warning!
+                             *
+                             * Pack200 archives must be stored in separated streams,
+                             * as the Pack200 unpacker reads the entire stream...
+                             *
+                             * See http://java.sun.com/javase/6/docs/api/java/util/jar/Pack200.Unpacker.html
+                             */
+                            packFile.setStreamResourceName("packs/pack200-" + packFile.getId());
+                            packFile.setStreamOffset(0);
+                            pack200Files.add(packFile);
+                        } else
+                        {
+                            packFile.setStreamResourceName(streamResourceName);
+                            packFile.setStreamOffset(packOutputStream.getByteCount()); // get the position
+                            PackCompression comprFormat = getInfo().getCompressionFormat();
+                            if (comprFormat != PackCompression.DEFAULT)
                             {
-                                long bytesWritten = FileUtils.copyFile(file, finalStream);
-                                proxyOutputStream.flush();
-                                finalStream.close();
+                                File tmpfile = null;
+                                OutputStream finalStream = null;
+
+                                try
+                                {
+                                    tmpfile = File.createTempFile("izpack-compress", null, FileUtils.getTempDirectory());
+                                    CountingOutputStream proxyOutputStream = new CountingOutputStream(FileUtils.openOutputStream(tmpfile));
+                                    OutputStream bufferedStream = IOUtils.buffer(proxyOutputStream);
+
+                                    switch (comprFormat)
+                                    {
+                                        case LZMA:
+                                            // LZMA as output stream supported from commons-compress 1.13 (requires JDK 1.7)
+                                            // for now create it from the Tukaani Project (tukaani.org)
+                                            finalStream = new LZMAOutputStream(bufferedStream, new LZMA2Options(), -1);
+                                            break;
+                                        case DEFLATE:
+                                            DeflateParameters deflateParameters = new DeflateParameters();
+                                            deflateParameters.setCompressionLevel(Deflater.BEST_COMPRESSION);
+                                            new DeflateCompressorOutputStream(bufferedStream, deflateParameters);
+                                        default:
+                                            try
+                                            {
+                                                finalStream = new CompressorStreamFactory().createCompressorOutputStream(
+                                                        comprFormat.toName(),
+                                                        bufferedStream);
+                                            }
+                                            catch (CompressorException e)
+                                            {
+                                                throw new IOException(e);
+                                            }
+                                    }
+
+                                    long bytesWritten = FileUtils.copyFile(file, finalStream);
+                                    finalStream.flush();
+                                    finalStream.close();
+                                    if (bytesWritten != packFile.length())
+                                    {
+                                        throw new IOException("File size mismatch when reading " + file);
+                                    }
+                                    packFile.setSize(proxyOutputStream.getByteCount());
+
+                                    FileUtils.copyFile(tmpfile, packOutputStream);
+
+                                    logger.fine("File " + packFile.getTargetPath() + " compressed as "
+                                            + comprFormat.toName()
+                                            + " (" + packFile.length() + " -> " + packFile.size() + " bytes)");
+                                }
+                                finally
+                                {
+                                    IOUtils.closeQuietly(finalStream);
+                                    FileUtils.deleteQuietly(tmpfile);
+                                }
+                            } else
+                            {
+                                long bytesWritten = FileUtils.copyFile(file, packOutputStream);
                                 if (bytesWritten != packFile.length())
                                 {
                                     throw new IOException("File size mismatch when reading " + file);
                                 }
-                                packFile.setSize(proxyOutputStream.getByteCount());
-                                logger.fine("File " + packFile.getTargetPath() + " compressed from "
-                                            + packFile.length() + " to " + packFile.size());
-                            }
-                            finally
-                            {
-                                IOUtils.closeQuietly(finalStream);
-                                IOUtils.closeQuietly(proxyOutputStream);
                             }
                         }
-                        else
-                        {
-                            long bytesWritten = FileUtils.copyFile(file, objOut);
-                            if (bytesWritten != packFile.length())
-                            {
-                                throw new IOException("File size mismatch when reading " + file);
-                            }
-                        }
+
+                        storedFiles.put(file, packFile);
                     }
 
-                    // see IZPACK-799
-                    storedFiles.put(file, new Object[]{pack.getName(), pos}); // TODO
+                    // even if not written, it counts towards pack size
+                    pack.addFileSize(packFile.length());
                 }
 
-                // even if not written, it counts towards pack size
-                pack.addFileSize(packFile.length());
+                if (pack.getFileSize() > pack.getSize())
+                {
+                    pack.setSize(pack.getFileSize());
+                }
+
+                // Cleanup
+                packOutputStream.flush();
+                packJar.closeEntry();
             }
-
-            if (pack.getFileSize() > pack.getSize())
+            finally
             {
-                pack.setSize(pack.getFileSize());
-            }
-
-            // Cleanup
-            objOut.flush();
-            packJar.closeEntry();
-
-            // close pack specific jar if required
-            if (packSeparateJars())
-            {
-                packJar.close();
+                // close pack specific jar if required
+                if (packSeparateJars())
+                {
+                    packJar.close();
+                }
             }
 
             IXMLElement child = new XMLElementImpl("pack", root);
@@ -302,17 +317,38 @@ public class Packager extends PackagerBase
 
         for (PackFile pack200PackFile : pack200Files)
         {
-            Pack200.Packer packer = createPack200Packer(pack200PackFile);
-            installerJar.putNextEntry(new ZipEntry(RESOURCES_PATH + "packs/pack200-" + pack200PackFile.getId()));
-            JarFile jar = new JarFile(pack200PackFile.getFile());
+            File tmpfile = null;
+            JarFile jar = null;
+
             try
             {
-                packer.pack(jar, installerJar);
+                installerJar.putNextEntry(new ZipEntry(RESOURCES_PATH + pack200PackFile.getStreamResourceName()));
+
+                tmpfile = File.createTempFile("izpack-compress", ".pack200", FileUtils.getTempDirectory());
+                CountingOutputStream proxyOutputStream = new CountingOutputStream(FileUtils.openOutputStream(tmpfile));
+                OutputStream bufferedStream = IOUtils.buffer(proxyOutputStream);
+
+                Pack200.Packer packer = createPack200Packer(pack200PackFile);
+                jar = new JarFile(pack200PackFile.getFile());
+                packer.pack(jar, bufferedStream);
+
+                bufferedStream.flush();
+                pack200PackFile.setSize(proxyOutputStream.getByteCount());
+
+                FileUtils.copyFile(tmpfile, installerJar);
+
+                logger.fine("File " + pack200PackFile.getTargetPath() + " compressed as Pack 200 ("
+                        + pack200PackFile.length() + " -> " + pack200PackFile.size() + " bytes)");
             }
             finally
             {
-                jar.close();
+                if (jar != null)
+                {
+                    jar.close();
+                }
                 installerJar.closeEntry();
+                installerJar.flush();
+                FileUtils.deleteQuietly(tmpfile);
             }
         }
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeFileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeFileUnpacker.java
@@ -31,8 +31,8 @@ import com.izforge.izpack.util.os.FileQueue;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InterruptedIOException;
-import java.io.ObjectInputStream;
 import java.util.logging.Logger;
 
 
@@ -77,7 +77,7 @@ public class MultiVolumeFileUnpacker extends FileUnpacker
      * @throws InstallerException     for any installer exception
      */
     @Override
-    public void unpack(PackFile packFile, ObjectInputStream packInputStream, File target)
+    public void unpack(PackFile packFile, InputStream packInputStream, File target)
             throws IOException, InstallerException
     {
         // read in the position of this file

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeUnpacker.java
@@ -26,6 +26,7 @@ import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.data.PackFile;
 import com.izforge.izpack.api.event.InstallerListener;
+import com.izforge.izpack.api.event.ProgressListener;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.exception.IzPackException;
 import com.izforge.izpack.api.handler.Prompt;
@@ -64,7 +65,7 @@ public class MultiVolumeUnpacker extends UnpackerBase
     /**
      * The volume locator.
      */
-    private VolumeLocator locator;
+    private final VolumeLocator locator;
 
     /**
      * The pack data volumes stream.
@@ -109,7 +110,7 @@ public class MultiVolumeUnpacker extends UnpackerBase
     /**
      * Invoked prior to unpacking.
      * <p/>
-     * This notifies the {@link #getProgressListener listener}, and any registered {@link InstallerListener listeners}.
+     * This notifies the {@link ProgressListener}, and any registered {@link InstallerListener listeners}.
      *
      * @param packs the packs to unpack
      * @throws IzPackException for any error
@@ -163,17 +164,16 @@ public class MultiVolumeUnpacker extends UnpackerBase
      * @param queue       the file queue. May be {@code null}
      * @param cancellable determines if the unpacker should be cancelled
      * @return the unpacker
-     * @throws IOException        for any I/O error
      * @throws InstallerException for any installer error
      */
     @Override
     protected FileUnpacker createFileUnpacker(PackFile file, Pack pack, FileQueue queue, Cancellable cancellable)
-            throws IOException, InstallerException
+            throws InstallerException
     {
         FileUnpacker unpacker;
         if (pack.isLoose())
         {
-            unpacker = new LooseFileUnpacker(getLoosePackFileDir(file), cancellable, queue, getPrompt());
+            unpacker = new LooseFileUnpacker(cancellable, queue, getPrompt());
         }
         else
         {
@@ -183,7 +183,7 @@ public class MultiVolumeUnpacker extends UnpackerBase
     }
 
     @Override
-    protected void skip(PackFile file, Pack pack, ObjectInputStream packInputStream) throws IOException
+    protected void skip(PackFile file, Pack pack, InputStream packInputStream) throws IOException
     {
         // this operation is a no-op for MultiVolumeUnpacker as the file is not in the pack stream
     }
@@ -199,34 +199,6 @@ public class MultiVolumeUnpacker extends UnpackerBase
     {
         super.cleanup();
         IOUtils.closeQuietly(volumes);
-    }
-
-    /**
-     * Tries to determine the source directory of a loose pack file.
-     *
-     * @param file the pack file
-     * @return the source directory
-     * @throws IOException        for any I/O error
-     * @throws InstallerException for any installer error
-     */
-    private File getLoosePackFileDir(PackFile file) throws IOException, InstallerException
-    {
-        File result = getAbsoluteInstallSource();
-        File loose = new File(result, file.getRelativeSourcePath());
-        if (!loose.exists())
-        {
-            File volume = volumes.getVolume();
-            File dir = volume.getParentFile();
-            if (dir != null)
-            {
-                loose = new File(dir, file.getRelativeSourcePath());
-                if (loose.exists())
-                {
-                    result = dir;
-                }
-            }
-        }
-        return result;
     }
 
     /**

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/DefaultFileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/DefaultFileUnpacker.java
@@ -21,13 +21,13 @@
 
 package com.izforge.izpack.installer.unpacker;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-
 import com.izforge.izpack.api.data.PackFile;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.util.os.FileQueue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 
 
 /**
@@ -59,7 +59,7 @@ public class DefaultFileUnpacker extends FileUnpacker
      * @throws InstallerException for any installer exception
      */
     @Override
-    public void unpack(PackFile file, ObjectInputStream packInputStream, File target)
+    public void unpack(PackFile file, InputStream packInputStream, File target)
             throws IOException, InstallerException
     {
         copy(file, packInputStream, target);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
@@ -61,7 +61,7 @@ public abstract class FileUnpacker
     /**
      * The file queue.
      */
-    private FileQueue queue;
+    private final FileQueue queue;
 
     /**
      * Determines if the file was queued.
@@ -95,7 +95,7 @@ public abstract class FileUnpacker
      * @throws IOException        for any I/O error
      * @throws InstallerException for any installer exception
      */
-    public abstract void unpack(PackFile file, ObjectInputStream packInputStream, File target)
+    public abstract void unpack(PackFile file, InputStream packInputStream, File target)
             throws IOException, InstallerException;
 
     /**
@@ -123,6 +123,7 @@ public abstract class FileUnpacker
     protected long copy(PackFile file, InputStream in, File target) throws IOException
     {
         OutputStream out = getTarget(file, target);
+
         byte[] buffer = new byte[5120];
         long bytesCopied = 0;
         try
@@ -141,6 +142,7 @@ public abstract class FileUnpacker
         {
             IOUtils.closeQuietly(out);
         }
+
         postCopy(file);
 
         return bytesCopied;
@@ -150,9 +152,8 @@ public abstract class FileUnpacker
      * Invoked after copying is complete to set the last modified timestamp, and queue blockable files.
      *
      * @param file the pack file meta-data
-     * @throws IOException for any I/O error
      */
-    protected void postCopy(PackFile file) throws IOException
+    protected void postCopy(PackFile file)
     {
         setLastModified(file);
 
@@ -263,10 +264,8 @@ public abstract class FileUnpacker
 
     /**
      * Queues the target file.
-     *
-     * @throws IOException
      */
-    private void queue() throws IOException
+    private void queue()
     {
         FileQueueMove move = new FileQueueMove(tmpTarget, target);
         move.setForceInUse(true);

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/LooseFileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/LooseFileUnpacker.java
@@ -21,18 +21,17 @@
 
 package com.izforge.izpack.installer.unpacker;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.util.logging.Logger;
-
 import com.izforge.izpack.api.data.Pack;
 import com.izforge.izpack.api.data.PackFile;
 import com.izforge.izpack.api.exception.InstallerException;
 import com.izforge.izpack.api.handler.Prompt;
 import com.izforge.izpack.util.os.FileQueue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Logger;
 
 
 /**
@@ -42,11 +41,6 @@ import com.izforge.izpack.util.os.FileQueue;
  */
 public class LooseFileUnpacker extends FileUnpacker
 {
-
-    /**
-     * The absolute source directory.
-     */
-    private final File sourceDir;
 
     /**
      * The prompt to warn of missing files.
@@ -61,15 +55,13 @@ public class LooseFileUnpacker extends FileUnpacker
     /**
      * Constructs a <tt>LooseFileUnpacker</tt>.
      *
-     * @param sourceDir   the absolute source directory
      * @param cancellable determines if unpacking should be cancelled
      * @param queue       the file queue. May be {@code null}
      * @param prompt      the prompt to warn of missing files
      */
-    public LooseFileUnpacker(File sourceDir, Cancellable cancellable, FileQueue queue, Prompt prompt)
+    public LooseFileUnpacker(Cancellable cancellable, FileQueue queue, Prompt prompt)
     {
         super(cancellable, queue);
-        this.sourceDir = sourceDir;
         this.prompt = prompt;
     }
 
@@ -83,7 +75,7 @@ public class LooseFileUnpacker extends FileUnpacker
      * @throws InstallerException for any installer exception
      */
     @Override
-    public void unpack(PackFile file, ObjectInputStream packInputStream, File target)
+    public void unpack(PackFile file, InputStream packInputStream, File target)
             throws IOException, InstallerException
     {
         // Old way of doing the job by using the (absolute) sourcepath.

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/Pack200FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/Pack200FileUnpacker.java
@@ -41,10 +41,6 @@ import java.util.jar.Pack200;
  */
 class Pack200FileUnpacker extends FileUnpacker
 {
-    /**
-     * The resources.
-     */
-    private final PackResources resources;
 
     /**
      * Constructs a <tt>Pack200FileUnpacker</tt>.
@@ -56,7 +52,6 @@ class Pack200FileUnpacker extends FileUnpacker
     public Pack200FileUnpacker(Cancellable cancellable, PackResources resources, FileQueue queue)
     {
         super(cancellable, queue);
-        this.resources = resources;
     }
 
     /**

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeFileUnpackerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/multiunpacker/MultiVolumeFileUnpackerTest.java
@@ -102,7 +102,7 @@ public class MultiVolumeFileUnpackerTest extends AbstractFileUnpackerTest
         PackFile file = createPackFile(baseDir, source, target, Blockable.BLOCKABLE_NONE);
         assertFalse(target.exists());
 
-        ObjectInputStream packStream = createPackStream(source);
+        InputStream packStream = createPackStream(source);
         unpacker.unpack(file, packStream, target);
         assertTrue(queue.isEmpty());  // file should not have been queued
 

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/unpacker/AbstractFileUnpackerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/unpacker/AbstractFileUnpackerTest.java
@@ -101,9 +101,8 @@ public abstract class AbstractFileUnpackerTest
         PackFile file = createPackFile(baseDir, source, target, Blockable.BLOCKABLE_NONE);
         assertFalse(target.exists());
 
-        ObjectInputStream packStream = createPackStream(source);
-
         FileUnpacker unpacker = createUnpacker(sourceDir, queue);
+        InputStream packStream = createPackStream(source);
 
         unpacker.unpack(file, packStream, target);
         assertTrue(queue.isEmpty());
@@ -158,9 +157,9 @@ public abstract class AbstractFileUnpackerTest
      * @return a new stream
      * @throws IOException for any I/O error
      */
-    protected ObjectInputStream createPackStream(File source) throws IOException
+    protected InputStream createPackStream(File source) throws IOException
     {
-        return Mockito.mock(ObjectInputStream.class);
+        return Mockito.mock(InputStream.class);
     }
 
     /**

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/unpacker/DefaultFileUnpackerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/unpacker/DefaultFileUnpackerTest.java
@@ -44,12 +44,12 @@ public class DefaultFileUnpackerTest extends AbstractFileUnpackerTest
      * @throws IOException for any I/O error
      */
     @Override
-    protected ObjectInputStream createPackStream(File source) throws IOException
+    protected InputStream createPackStream(File source) throws IOException
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.copy(new FileInputStream(source), out);
         out.close();
-        return new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()));
+        return new ByteArrayInputStream(out.toByteArray());
     }
 
     /**

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/unpacker/DefaultFileUnpackerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/unpacker/DefaultFileUnpackerTest.java
@@ -47,9 +47,8 @@ public class DefaultFileUnpackerTest extends AbstractFileUnpackerTest
     protected ObjectInputStream createPackStream(File source) throws IOException
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ObjectOutputStream objectOut = new ObjectOutputStream(out);
-        IOUtils.copy(new FileInputStream(source), objectOut);
-        objectOut.close();
+        IOUtils.copy(new FileInputStream(source), out);
+        out.close();
         return new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()));
     }
 
@@ -60,6 +59,7 @@ public class DefaultFileUnpackerTest extends AbstractFileUnpackerTest
      * @param queue     the file queue. May be {@code null}
      * @return a new unpacker
      */
+    @Override
     protected FileUnpacker createUnpacker(File sourceDir, FileQueue queue)
     {
         return new DefaultFileUnpacker(getCancellable(), queue);

--- a/izpack-installer/src/test/java/com/izforge/izpack/installer/unpacker/LooseFileUnpackerTest.java
+++ b/izpack-installer/src/test/java/com/izforge/izpack/installer/unpacker/LooseFileUnpackerTest.java
@@ -44,10 +44,11 @@ public class LooseFileUnpackerTest extends AbstractFileUnpackerTest
      * @param queue     the file queue. May be {@code null}
      * @return a new unpacker
      */
+    @Override
     protected FileUnpacker createUnpacker(File sourceDir, FileQueue queue)
     {
         Prompt prompt = Mockito.mock(Prompt.class);
-        return new LooseFileUnpacker(sourceDir, getCancellable(), queue, prompt);
+        return new LooseFileUnpacker(getCancellable(), queue, prompt);
     }
 
 }

--- a/izpack-util/src/main/java/com/izforge/izpack/util/NoCloseInputStream.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/NoCloseInputStream.java
@@ -1,0 +1,20 @@
+package com.izforge.izpack.util;
+
+import java.io.*;
+
+public class NoCloseInputStream extends FilterInputStream
+{
+    public NoCloseInputStream(InputStream in) {
+        super(in);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        throw new IOException("Closing this input stream unexpectedly");
+    }
+
+    public void doClose() throws IOException {
+        super.close();
+    }
+}

--- a/izpack-util/src/main/java/com/izforge/izpack/util/NoCloseOutputStream.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/NoCloseOutputStream.java
@@ -1,0 +1,22 @@
+package com.izforge.izpack.util;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class NoCloseOutputStream extends FilterOutputStream
+{
+    public NoCloseOutputStream(OutputStream out) {
+        super(out);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        throw new IOException("Closing this output stream unexpectedly");
+    }
+
+    public void doClose() throws IOException {
+        super.close();
+    }
+}


### PR DESCRIPTION
This is especially a fix for [IZPACK-1497](https://izpack.atlassian.net/browse/IZPACK-1497), provided as part of [IZPACK-1495](https://izpack.atlassian.net/browse/IZPACK-1495):
- Backreferences where totally broken
- Stabilized commons-compress and pack200 and mixes of them, more tests
- Fixed scope of pack compression setting
- Improved Pack200 unit test