### PR TITLE
IZPACK-1472: Introduce customizable installer logging

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -96,10 +96,7 @@ import java.net.URL;
 import java.text.ParseException;
 import java.util.*;
 import java.util.jar.Pack200;
-import java.util.logging.FileHandler;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.logging.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -1860,6 +1857,22 @@ public class CompilerConfig extends Thread
             return;
         }
 
+        Properties logConfig = null;
+        final String globalLevel = loggingElement.getAttribute("level", "INFO");
+        if (globalLevel != null)
+        {
+            logConfig = new Properties();
+            //logConfig.setProperty(".level", globalLevel);
+            logConfig.setProperty(ConsoleHandler.class.getName() + ".level", globalLevel);
+            if (Level.parse(globalLevel).intValue() > Level.INFO.intValue())
+            {
+                logConfig.setProperty("java.awt.level", globalLevel);
+                logConfig.setProperty("javax.swing.level", globalLevel);
+                logConfig.setProperty("sun.awt.level", globalLevel);
+                logConfig.setProperty("sun.awt.X11.level", globalLevel);
+            }
+        }
+
         List<IXMLElement> configFiles = loggingElement.getChildrenNamed("configuration-file");
         if (configFiles != null)
         {
@@ -1878,21 +1891,20 @@ public class CompilerConfig extends Thread
             {
                 assertionHelper.parseError(loggingElement, "Logging configuration by external file and log file specification cannot be mixed");
             }
-            Properties logConfig = null;
             for (IXMLElement configFileElement : logFiles)
             {
                 final String cname = FileHandler.class.getName();
                 if (logConfig == null)
                 {
                     logConfig = new Properties();
-                    logConfig.setProperty("handlers", cname);
                 }
+                logConfig.setProperty("handlers", cname);
                 final String pattern = configFileElement.getAttribute("pattern");
                 if (pattern != null)
                 {
                     logConfig.setProperty(cname + ".pattern", pattern);
                 }
-                final String level = configFileElement.getAttribute("level");
+                final String level = configFileElement.getAttribute("level", "INFO");
                 if (level != null)
                 {
                     logConfig.setProperty(cname + ".level", level);

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -295,7 +295,7 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="level" type="types:loggingLevelType" use="optional">
+                    <xs:attribute name="level" type="types:loggingLevelType" use="optional" default="INFO">
                         <xs:annotation>
                             <xs:documentation>
                                 Specifies the logging level.
@@ -355,7 +355,7 @@
                     <xs:attribute name="mkdirs" type="xs:boolean" use="optional" default="false">
                         <xs:annotation>
                             <xs:documentation>
-                                Specifies whether the IzPack should recursively create the parent directory of the file
+                                Specifies whether IzPack should recursively create the parent directory of the file
                                 resulting from the 'pattern' attribute before invoking FileHandler.
                             </xs:documentation>
                         </xs:annotation>
@@ -363,6 +363,14 @@
                 </xs:complexType>
             </xs:element>
         </xs:choice>
+        <xs:attribute name="level" type="types:loggingLevelType" use="optional" default="INFO">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the global (console) logging level.
+                    See http://docs.oracle.com/javase/6/docs/api/java/util/logging/FileHandler.html for details.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
 

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-types-5.0.xsd
@@ -270,6 +270,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
+            <xs:enumeration value="OFF"/>
             <xs:enumeration value="SEVERE"/>
             <xs:enumeration value="WARNING"/>
             <xs:enumeration value="INFO"/>
@@ -277,6 +278,7 @@
             <xs:enumeration value="FINE"/>
             <xs:enumeration value="FINER"/>
             <xs:enumeration value="FINEST"/>
+            <xs:enumeration value="ALL"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -42,6 +42,7 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Properties;
+import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -73,7 +74,6 @@ public class Installer
     {
         try
         {
-            initializeLogging();
             Installer installer = new Installer();
             installer.start(args);
         }
@@ -82,11 +82,6 @@ public class Installer
             e.printStackTrace();
         }
 
-    }
-
-    private static void initializeLogging() throws IOException
-    {
-        initializeLogging(null);
     }
 
     private static void initializeLogging(String logFileName) throws IOException
@@ -98,6 +93,8 @@ public class Installer
             props.setProperty("handlers", cname);
             props.setProperty(cname + ".pattern", FilenameUtils.normalize(logFileName));
             props.setProperty(cname + ".formatter", FileFormatter.class.getName());
+            props.setProperty(ConsoleHandler.class.getName() + ".level", "OFF");
+            props.setProperty(".level", "OFF");
             LogUtils.loadConfiguration(props);
         }
         else
@@ -225,10 +222,7 @@ public class Installer
                 }
             }
 
-            if (logFileName != null)
-            {
-                initializeLogging(logFileName);
-            }
+            initializeLogging(logFileName);
 
             logger.info("Command line arguments: " + StringTool.stringArrayToSpaceSeparatedString(args));
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -55,7 +55,6 @@ import java.net.URLClassLoader;
 import java.util.*;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -1407,19 +1406,13 @@ public abstract class UnpackerBase implements IUnpacker
 
     private void resetLogging()
     {
-        if (!LogUtils.isSamePreviousHandlerType(FileHandler.class))
+        try
         {
-            // IzPack maintains just one log file, don't override the existing handler type of it.
-            // Special use case: Command line argument -logfile "wins" over the <log-file> tag.
-            // Assumption at the moment for optimization: Just FileHandler is used for configurations from install.xml.
-            try
-            {
-                LogUtils.loadConfiguration(ResourceManager.getInstallLoggingConfigurationResourceName(), variables, true);
-            }
-            catch (IOException e)
-            {
-                throw new IzPackException(e, Type.WARNING);
-            }
+            LogUtils.loadConfiguration(ResourceManager.getInstallLoggingConfigurationResourceName(), variables);
+        }
+        catch (IOException e)
+        {
+            throw new IzPackException(e, Type.WARNING);
         }
 
         logger = Logger.getLogger(UnpackerBase.class.getName());

--- a/izpack-installer/src/main/resources/com/izforge/izpack/installer/logging/logging.base.properties
+++ b/izpack-installer/src/main/resources/com/izforge/izpack/installer/logging/logging.base.properties
@@ -1,0 +1,5 @@
+# Default excludes to avoid messy debug output
+java.awt.level=INFO
+javax.swing.level=INFO
+sun.awt.level=INFO
+sun.awt.X11.level=INFO


### PR DESCRIPTION
Post-fixes for [IZPACK-1472(https://izpack.atlassian.net/browse/IZPACK-1472):
- Allow to define a console log level (incl. muting it)
- Fixes regarding mixing of log levels between the console and file handlers