### PR TITLE
IZPACK-1497:  Serialize actual size of packed file data instead of the size of the original file to enable compression

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/PackFile.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/PackFile.java
@@ -194,10 +194,13 @@ public class PackFile implements Serializable
         this.overrideRenameTo = overrideRenameTo;
         this.blockable = blockable;
 
-        this.length = src.length();
-        this.size = this.length;
         this.mtime = src.lastModified();
         this.isDirectory = src.isDirectory();
+        if (!this.isDirectory())
+        {
+            this.length = src.length();
+            this.size = this.length;
+        }
         this.additionals = additionals;
         if (pack200Properties != null)
         {

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/Packager.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/Packager.java
@@ -181,6 +181,7 @@ public class Packager extends PackagerBase
                     if (linkedPackFile != null && !packSeparateJars())
                     {
                         // Save backreference link
+                        logger.fine("File " + packFile.getTargetPath() + " is a backreference, linked to " + linkedPackFile.getTargetPath());
                         packFile.setLinkedPackFile(linkedPackFile);
                         addFile = false;
                     }
@@ -251,7 +252,7 @@ public class Packager extends PackagerBase
 
                                     FileUtils.copyFile(tmpfile, packOutputStream);
 
-                                    logger.fine("File " + packFile.getTargetPath() + " compressed as "
+                                    logger.fine("File " + packFile.getTargetPath() + " added compressed as "
                                             + comprFormat.toName()
                                             + " (" + packFile.length() + " -> " + packFile.size() + " bytes)");
                                 }
@@ -267,6 +268,7 @@ public class Packager extends PackagerBase
                                 {
                                     throw new IOException("File size mismatch when reading " + file);
                                 }
+                                logger.fine("File " + packFile.getTargetPath() + " added uncompressed (" + bytesWritten + " bytes)");
                             }
                         }
 
@@ -284,10 +286,13 @@ public class Packager extends PackagerBase
 
                 // Cleanup
                 packOutputStream.flush();
+                packOutputStream.close();
                 packJar.closeEntry();
             }
             finally
             {
+                IOUtils.closeQuietly(packOutputStream);
+                packJar.flush();
                 // close pack specific jar if required
                 if (packSeparateJars())
                 {
@@ -337,7 +342,7 @@ public class Packager extends PackagerBase
 
                 FileUtils.copyFile(tmpfile, installerJar);
 
-                logger.fine("File " + pack200PackFile.getTargetPath() + " compressed as Pack 200 ("
+                logger.fine("File " + pack200PackFile.getTargetPath() + " added compressed as Pack 200 ("
                         + pack200PackFile.length() + " -> " + pack200PackFile.size() + " bytes)");
             }
             finally

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -347,9 +347,17 @@ public abstract class PackagerBase implements IPackager
     public void createInstaller() throws Exception
     {
         info.setInstallerBase(compilerData.getOutput().replaceAll(".jar", ""));
+        JarOutputStream jarOutputStream = getInstallerJar();
         sendStart();
-        writeInstaller();
-        getInstallerJar().close();
+        try
+        {
+            writeInstaller();
+        }
+        finally
+        {
+            jarOutputStream.flush();
+            jarOutputStream.close();
+        }
         sendStop();
     }
 

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/RulesEngineImpl.java
@@ -340,7 +340,6 @@ public class RulesEngineImpl implements RulesEngine
             cond.setInstallData(this.installData);
         }
         boolean value = cond.isTrue();
-        logger.fine("Condition " + cond.getId() + ": " + Boolean.toString(value));
         return value;
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
@@ -123,12 +123,13 @@ public abstract class FileUnpacker
     protected long copy(PackFile file, InputStream in, File target) throws IOException
     {
         OutputStream out = getTarget(file, target);
-
         byte[] buffer = new byte[5120];
         long bytesCopied = 0;
+        long bytesToCopy = (file.isBackReference() ? file.getLinkedPackFile().size() : file.size());
+        logger.fine("|- Copying to file system (size: " + bytesToCopy + " bytes)");
         try
         {
-            while (bytesCopied < file.length())
+            while (bytesCopied < bytesToCopy)
             {
                 if (cancellable.isCancelled())
                 {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/NoCloseInputStream.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/NoCloseInputStream.java
@@ -11,7 +11,6 @@ public class NoCloseInputStream extends FilterInputStream
     @Override
     public void close() throws IOException
     {
-        throw new IOException("Closing this input stream unexpectedly");
     }
 
     public void doClose() throws IOException {

--- a/izpack-util/src/main/java/com/izforge/izpack/util/NoCloseOutputStream.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/NoCloseOutputStream.java
@@ -13,7 +13,6 @@ public class NoCloseOutputStream extends FilterOutputStream
     @Override
     public void close() throws IOException
     {
-        throw new IOException("Closing this output stream unexpectedly");
     }
 
     public void doClose() throws IOException {


### PR DESCRIPTION
Post-fixes for [IZPACK-1497](https://izpack.atlassian.net/browse/IZPACK-1497):
- Deserialization of directories has been broken (installer failed accidentally)
- small debug log improvements