### PR TITLE
IZPACK-1510: Remove dependency and packaging of jakarta-regexp to installer

### DIFF
--- a/izpack-compiler/pom.xml
+++ b/izpack-compiler/pom.xml
@@ -31,15 +31,6 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>izpack-util</artifactId>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>izpack-test-common</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-shared-jar</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.picocontainer</groupId>
@@ -71,6 +62,11 @@
         </dependency>
 
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>izpack-test-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -78,6 +74,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-jar</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/PackagerBase.java
@@ -348,17 +348,17 @@ public abstract class PackagerBase implements IPackager
     {
         info.setInstallerBase(compilerData.getOutput().replaceAll(".jar", ""));
         JarOutputStream jarOutputStream = getInstallerJar();
-        sendStart();
         try
         {
+            sendStart();
             writeInstaller();
+            sendStop();
+            jarOutputStream.flush();
         }
         finally
         {
-            jarOutputStream.flush();
-            jarOutputStream.close();
+            IOUtils.closeQuietly(jarOutputStream);
         }
-        sendStop();
     }
 
     /**
@@ -464,7 +464,6 @@ public abstract class PackagerBase implements IPackager
         mergeManager.addResourceToMerge("com/izforge/izpack/merge/");
         mergeManager.addResourceToMerge("com/izforge/izpack/util/");
         mergeManager.addResourceToMerge("com/izforge/izpack/logging/");
-        mergeManager.addResourceToMerge("org/apache/regexp/");
         mergeManager.addResourceToMerge("com/coi/tools/");
         mergeManager.addResourceToMerge("org/apache/commons/io/");
         mergeManager.addResourceToMerge("jline/");

--- a/izpack-maven-plugin/pom.xml
+++ b/izpack-maven-plugin/pom.xml
@@ -82,12 +82,6 @@
             <artifactId>maven-compat</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugin-testing</groupId>
-            <artifactId>maven-plugin-testing-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>izpack-compiler</artifactId>
         </dependency>
@@ -108,24 +102,23 @@
             <artifactId>izpack-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>izpack-test-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>izpack-test-common</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This change fixes [IZPACK-1510](https://izpack.atlassian.net/browse/IZPACK-1510):

We are still packing the retired jakarta-regexp 1.4 (org/apache/regexp) to the installer by default, which is never used by the default at runtime any longer. We use java.util.regexp and encourage custom implementation to do the same. We can remove it to reduce the size of the installer.

Along with this, remove also the compile-time dependency of the compiler to Apache BCEL (which also refers to Apache Regex), it should has scope test only.
