### PR TITLE
IZPACK-1511 + IZPACK-1512: Update dependencies - picocontainer 2.15, Apache Ant 1.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.9.4</version>
+        <version>1.9.9</version>
       </dependency>
       <dependency>
         <groupId>bsf</groupId>
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>org.picocontainer</groupId>
         <artifactId>picocontainer</artifactId>
-        <version>2.14.1</version>
+        <version>2.15</version>
       </dependency>
 
       <!-- PDF Panel -->


### PR DESCRIPTION
This change updates some dependencies:
- [IZPACK-1511](https://izpack.atlassian.net/browse/IZPACK-1511): Update picocontainer to 2.15
Picocontainer 2.15 has been released already some time ago (since they moved from Codehaus to Github):
https://github.com/picocontainer/PicoContainer2
We should use go for it in this major release.
- [IZPACK-1512](https://izpack.atlassian.net/browse/IZPACK-1512): Update Apache Ant dependency to 1.9.9
Apache Ant is currently at 1.9.9 (which is the latest release still supporting JDK 5 and 6).
This shouldn't probably break anything but I rather mark breaking. Check your usecases or fix your old version in your local dependency management.
We should use go for it in this major release.