### PR TITLE
IZPACK-1497:  Serialize actual size of packed file data instead of the size of the original file to enable compression

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/Packager.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/packager/impl/Packager.java
@@ -242,7 +242,14 @@ public class Packager extends PackagerBase
                                     }
 
                                     long bytesWritten = FileUtils.copyFile(file, finalStream);
-                                    finalStream.flush();
+                                    try
+                                    {
+                                        finalStream.flush();
+                                    }
+                                    catch (IOException ignored)
+                                    {
+                                        // some compressor output streams don't explicitly support flushing
+                                    }
                                     finalStream.close();
                                     if (bytesWritten != packFile.length())
                                     {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
@@ -125,7 +125,7 @@ public abstract class FileUnpacker
         OutputStream out = getTarget(file, target);
         byte[] buffer = new byte[5120];
         long bytesCopied = 0;
-        long bytesToCopy = (file.isBackReference() ? file.getLinkedPackFile().size() : file.size());
+        long bytesToCopy = (file.isBackReference() ? file.getLinkedPackFile().length() : file.length());
         logger.fine("|- Copying to file system (size: " + bytesToCopy + " bytes)");
         try
         {


### PR DESCRIPTION
This change contains fixes for critical bugs when using pack compression, fixes changes done along with  [IZPACK-1497](https://izpack.atlassian.net/browse/IZPACK-1497):
- Unpacking compressed files broken (wrong file size expected when writing to target file)
- Fix failure when flushing LZMA output stream