### PR TITLE
IZPACK-1515: Unpacking 7z does not work

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1624,7 +1624,7 @@ public class CompilerConfig extends Thread
                 String entryName = entry.getName();
                 if (entry.isDirectory())
                 {
-                    String dName = entryName.substring(0, entryName.length() - 1);
+                    String dName = FilenameUtils.normalizeNoEndSeparator(entryName);
                     File tempDir = new File(baseTempDir, dName);
                     FileUtils.forceMkdir(tempDir);
                     if (hasNoFileSet)

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -78,12 +78,12 @@ import com.izforge.izpack.panels.userinput.field.button.ButtonFieldReader;
 import com.izforge.izpack.util.FileUtil;
 import com.izforge.izpack.util.OsConstraintHelper;
 import com.izforge.izpack.util.PlatformModelMatcher;
+import com.izforge.izpack.util.compress.ArchiveStreamFactory;
 import com.izforge.izpack.util.file.DirectoryScanner;
 import com.izforge.izpack.util.helper.SpecHelper;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
-import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FileUtils;
@@ -1609,7 +1609,7 @@ public class CompilerConfig extends Thread
         File baseTempDir = null;
         try
         {
-            archiveInputStream = new ArchiveStreamFactory().createArchiveInputStream(uncompressedInputStream);
+            archiveInputStream = new ArchiveStreamFactory().createArchiveInputStream(archive, uncompressedInputStream);
 
             // file is an archive (incl. ZIP archive) - unpack recursively
             baseTempDir = com.izforge.izpack.util.file.FileUtils.createTempDirectory("izpack", TEMP_DIR);

--- a/izpack-util/pom.xml
+++ b/izpack-util/pom.xml
@@ -36,6 +36,18 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom2</artifactId>
             <version>2.0.5</version>

--- a/izpack-util/src/main/java/com/izforge/izpack/util/compress/ArchiveStreamFactory.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/compress/ArchiveStreamFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.util.compress;
+
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.tika.Tika;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ArchiveStreamFactory extends org.apache.commons.compress.archivers.ArchiveStreamFactory
+{
+    private static final Logger logger = Logger.getLogger(ArchiveStreamFactory.class.getName());
+
+    public ArchiveInputStream createArchiveInputStream(File file, InputStream in) throws ArchiveException
+    {
+        try
+        {
+            final String mimeType = new Tika().detect(file);
+            if ("application/x-7z-compressed".equals(mimeType))
+            {
+                return new SevenZArchiveInputStream(file);
+            }
+        }
+        catch (final IOException e)
+        {
+            logger.log(Level.WARNING, "Could not detect mime type of or open archive " + file + ": " + e.getMessage(), e);
+        }
+
+        return super.createArchiveInputStream(in);
+    }
+}

--- a/izpack-util/src/main/java/com/izforge/izpack/util/compress/SevenZArchiveInputStream.java
+++ b/izpack-util/src/main/java/com/izforge/izpack/util/compress/SevenZArchiveInputStream.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 Julien Ponge, René Krell and the IzPack team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.util.compress;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
+import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+public class SevenZArchiveInputStream extends ArchiveInputStream
+{
+    private final SevenZFile zFile;
+
+    public SevenZArchiveInputStream(File file) throws IOException
+    {
+        this.zFile = new SevenZFile(file);
+    }
+
+    @Override
+    public ArchiveEntry getNextEntry() throws IOException
+    {
+        final SevenZArchiveEntry sevenZArchiveEntry = zFile.getNextEntry();
+
+        return new ArchiveEntry()
+        {
+            @Override
+            public String getName()
+            {
+                return sevenZArchiveEntry.getName();
+            }
+
+            @Override
+            public long getSize()
+            {
+                return sevenZArchiveEntry.getSize();
+            }
+
+            @Override
+            public boolean isDirectory()
+            {
+                return sevenZArchiveEntry.isDirectory();
+            }
+
+            @Override
+            public Date getLastModifiedDate()
+            {
+                return sevenZArchiveEntry.getLastModifiedDate();
+            }
+        };
+    }
+
+    @Override
+    public int read() throws IOException
+    {
+        return zFile.read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException
+    {
+        return zFile.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException
+    {
+        return zFile.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        zFile.close();
+    }
+
+    @Override
+    public String toString()
+    {
+        return zFile.toString();
+    }
+
+    @Override
+    public boolean canReadEntryData(ArchiveEntry archiveEntry)
+    {
+        return (archiveEntry instanceof SevenZArchiveEntry);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,16 @@
         <artifactId>xz</artifactId>
         <version>1.6</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-core</artifactId>
+        <version>1.9</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-parsers</artifactId>
+        <version>1.9</version>
+      </dependency>
 
       <!-- Maven API -->
      <dependency>


### PR DESCRIPTION
This is a fix for [IZPACK-1515](https://izpack.atlassian.net/browse/IZPACK-1515):

Adding 7z file to be unpacked gives error during compile.

```xml
<file src="some-file.7z" targetdir="${INSTALL_PATH}/${ZOOKEEPER_PATH}" override="true" unpack="true"/>
```
results in
```
Failed to execute goal org.codehaus.izpack:izpack-maven-plugin:5.1.0-RC3:izpack (default-izpack) on project our-project: Failure during compilation process: No compression or archiving format detected for file some-file.7z marked to be unpacked.
```