### PR TITLE
IZPACK-1515: unpack of 7z does not work (post-fixes)

### DIFF
--- a/izpack-compiler/pom.xml
+++ b/izpack-compiler/pom.xml
@@ -60,6 +60,14 @@
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -78,7 +78,7 @@ import com.izforge.izpack.panels.userinput.field.button.ButtonFieldReader;
 import com.izforge.izpack.util.FileUtil;
 import com.izforge.izpack.util.OsConstraintHelper;
 import com.izforge.izpack.util.PlatformModelMatcher;
-import com.izforge.izpack.util.compress.ArchiveStreamFactory;
+import com.izforge.izpack.compiler.util.compress.ArchiveStreamFactory;
 import com.izforge.izpack.util.file.DirectoryScanner;
 import com.izforge.izpack.util.helper.SpecHelper;
 import org.apache.commons.compress.archivers.ArchiveEntry;

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/util/compress/ArchiveStreamFactory.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/util/compress/ArchiveStreamFactory.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.izforge.izpack.util.compress;
+package com.izforge.izpack.compiler.util.compress;
 
+import com.izforge.izpack.util.compress.SevenZArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.tika.Tika;

--- a/izpack-util/pom.xml
+++ b/izpack-util/pom.xml
@@ -40,14 +40,6 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom2</artifactId>
             <version>2.0.5</version>


### PR DESCRIPTION
[IZPACK-1515](https://izpack.atlassian.net/browse/IZPACK-1515):

- Post-fix: Move dependency to Apache Tika to izpack-compiler (from izpack-util)

The solution for this issue pulled in a dependency to Apache Tika also to the installer, although the class making usage of Tika is only used in the compiler at the moment. Move the appropriate code and its dependencies to Apache Tika to the compiler module.