### PR TITLE
IZPACK-1440: Loose pack with zipfile and unpack="true" causes NPE

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1631,7 +1631,7 @@ public class CompilerConfig extends Thread
                     {
                         String target = targetDir + "/" + dName;
                         logAddingFile(dName + " (" + archiveName + ")", target);
-                        pack.addFile(baseDir, tempDir, target, osList, override, overrideRenameTo, blockable, additionals, condition, null);
+                        pack.addFile(baseTempDir, tempDir, target, osList, override, overrideRenameTo, blockable, additionals, condition, null);
                     }
                 }
                 else
@@ -1648,7 +1648,7 @@ public class CompilerConfig extends Thread
                         {
                             String target = targetDir + "/" + entryName;
                             logAddingFile(entryName + " (" + archiveName + ")", target);
-                            pack.addFile(baseDir, tempFile, target, osList, override, overrideRenameTo, blockable, additionals, condition, pack200Properties);
+                            pack.addFile(baseTempDir, tempFile, target, osList, override, overrideRenameTo, blockable, additionals, condition, pack200Properties);
                         }
                     }
                     finally


### PR DESCRIPTION
This is a fix for [IZPACK-1440](https://izpack.atlassian.net/browse/IZPACK-1440):

The error occurs when changing the pack in the example of [IZPACK-1258](https://izpack.atlassian.net/browse/IZPACK-1258) to:

```xml
<pack name="TestLoose" required="yes" loose="true">
      <description>Test the loose arg.</description>
      <!-- copying and extracting a zip -->
      <file src="..\..\resources\test.zip" unpack="true" targetdir="${INSTALL_PATH}\testloosepack\" />
</pack>
```

The stacktrace:
```
com.izforge.izpack.api.exception.InstallerException: Failed to unpack pack: TestLoose
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:501)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:430)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:251)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.run(UnpackerBase.java:236)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
        at java.io.File.<init>(File.java:360)
        at com.izforge.izpack.installer.unpacker.LooseFileUnpacker.unpack(LooseFileUnpacker.java:100)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.extract(UnpackerBase.java:627)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:591)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:483)
        ... 4 more
```

Setting `unpack="false"` works correctly.