### PR TITLE
IZPACK-1546: Nested <param> tags ignored in field validator definition

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/handler/DefaultConfigurationHandler.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/handler/DefaultConfigurationHandler.java
@@ -129,7 +129,7 @@ public abstract class DefaultConfigurationHandler implements Configurable, Seria
             }
             // Deprecated: compatibility
             List<IXMLElement> otherParams = element.getChildrenNamed("param");
-            if (!params.isEmpty())
+            if (!otherParams.isEmpty())
             {
                 logger.fine("Found deprecated nested <param> definition(s) for '" + element.getName() + "' element, please migrate them to the new <configuration> format");
                 for (IXMLElement parameter : otherParams)


### PR DESCRIPTION
Fix for [IZPACK-1546](https://izpack.atlassian.net/browse/IZPACK-1546):

Beginning with 5.1.0, if the there are field validators used in UserInputPanel, their nested legacy `<param>` definitions are ignored a resolved as 'null' at runtime in the validator code.

This breaks for example the following definition:
```xml
<field type="rule" variable="server.address" summaryKey="key.server.address">
    <spec id="text.server.address" txt="Infoserver address/port:" layout="O:15:U : N:5:5" resultFormat="displayFormat" />
    <validator class="com.izforge.izpack.panels.userinput.validator.RegularExpressionValidator" txt="Invalid address or port!" id="server.address.error">
        <param name="pattern" value="\b.*\:(6553[0-5]|655[0-2]\d|65[0-4]\d{2}|6[0-4]\d{3}|[1-5]\d{4}|[1-9]\d{0,3})\b" />
    </validator>
</field>
```

while this one is fully functional:
```xml
<field type="rule" variable="server.address" summaryKey="key.server.address">
    <spec id="text.server.address" txt="Infoserver address/port:" layout="O:15:U : N:5:5" resultFormat="displayFormat" />
    <validator class="com.izforge.izpack.panels.userinput.validator.RegularExpressionValidator" txt="Invalid address or port!" id="server.address.error">
      <configuration>
        <pattern>\b.*\:(6553[0-5]|655[0-2]\d|65[0-4]\d{2}|6[0-4]\d{3}|[1-5]\d{4}|[1-9]\d{0,3})\b</pattern>
      </configuration>
    </validator>
</field>
```

Added also an optimization - avoid duplicate code part.