### PR TITLE
IZPACK-1363: <executable>: attribute "class" needed, if "type" is "jar"

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1268,7 +1268,6 @@ public class CompilerConfig extends Thread
             String conditionId = parseConditionAttribute(executableNode);
             List<OsModel> osList = OsConstraintHelper.getOsList(executableNode); // TODO: unverified
             int executionStage = ExecutableFile.NEVER, type = ExecutableFile.BIN, onFailure = ExecutableFile.ASK;
-            String mainClass = null;
             boolean keepFile;
 
             String val = executableNode.getAttribute("stage", "never");
@@ -1283,10 +1282,21 @@ public class CompilerConfig extends Thread
 
             // type of this executable
             val = executableNode.getAttribute("type", "bin");
+            String mainClass = executableNode.getAttribute("class"); // executable class
             if ("jar".equalsIgnoreCase(val))
             {
                 type = ExecutableFile.JAR;
-                mainClass = executableNode.getAttribute("class"); // executable class
+                if (mainClass == null || mainClass.isEmpty())
+                {
+                    throw new CompilerException("Attribute 'class' mandatory and must not be empty for type 'jar'");
+                }
+            }
+            else
+            {
+                if (mainClass != null)
+                {
+                    throw new CompilerException("Attribute 'class' allowed for type 'jar' only");
+                }
             }
 
             // what to do if execution fails

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-installation-5.0.xsd
@@ -947,6 +947,7 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
+        <xs:attribute name="class" type="types:fullyQualifiedClassNameType" use="optional"/>
         <xs:attribute name="failure" default="ask">
             <xs:simpleType>
                 <xs:restriction base="xs:string">


### PR DESCRIPTION
This change is a fix for [IZPACK-1363](https://izpack.atlassian.net/browse/IZPACK-1363):

If an <executable> is of type "jar", the class has to be defined mandatory.

Added this rule to the XSD for validation and added checks to CompilerConfig to avoid ambiguous usage of the `class` attribute.