### PR TITLE
IZPACK-1548: Extract shared licence loading code into new class LicenceLoader

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/LicenceLoader.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/licence/LicenceLoader.java
@@ -1,0 +1,231 @@
+/*
+ * IzPack - Copyright 2001-2017 The IzPack project team.
+ * All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.panels.licence;
+
+import com.izforge.izpack.api.data.Panel;
+import com.izforge.izpack.api.exception.ResourceException;
+import com.izforge.izpack.api.exception.ResourceNotFoundException;
+import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.installer.util.PanelHelper;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * Provides shared licence loading logic between console and GUI panels.
+ * <p>
+ *     A licence resource file is identified by its resource name plus a suffix.
+ *     The resource name is built from the simple class name of the IzPanel class
+ *     related to the given {@code panelClass}. The suffix is built from the
+ *     identifier of the given {@code panel}, if available. Otherwise a default
+ *     suffix of {@code "licence"} is used.
+ * </p>
+ *
+ * @author Michael Aichler
+ */
+class LicenceLoader {
+
+    private final static String DEFAULT_SUFFIX = ".licence";
+
+    private final Panel panel;
+    private final Class<?> panelClass;
+    private final Resources resources;
+
+    /**
+     * Creates a new licence loader.
+     *
+     * @param panelClass The class of the concrete licence panel implementation.
+     * @param panel The panel metadata (needed for the panel identifier).
+     * @param resources The resource locator.
+     */
+    LicenceLoader(Class<?> panelClass, Panel panel, Resources resources) {
+
+        this.panel = panel;
+        this.panelClass = panelClass;
+        this.resources = resources;
+    }
+
+    /**
+     * Loads the licence as a URL.
+     *
+     * @return The URL to the resource.
+     * @throws ResourceException If the related IzPanel or the licence resource
+     *      cannot be found. The generated error message is ready to be logged.
+     */
+    URL asURL() throws ResourceException
+    {
+        Class<?> targetClass = findTargetClass(panelClass);
+
+        String resourceNamePrefix = targetClass.getSimpleName();
+        String defaultResourceName = resourceNamePrefix + DEFAULT_SUFFIX;
+        String specificResourceName = buildSpecificResourceName(resourceNamePrefix, panel);
+
+        try
+        {
+            if (null != specificResourceName)
+            {
+                return resources.getURL(specificResourceName);
+            }
+        }
+        catch (ResourceNotFoundException ignored)
+        {
+        }
+
+        try
+        {
+            return resources.getURL(defaultResourceName);
+        }
+        catch (ResourceNotFoundException ignored)
+        {
+        }
+
+        String message = buildFinalErrorMessage(resourceNamePrefix, defaultResourceName,
+                specificResourceName);
+
+        throw new ResourceNotFoundException(message);
+    }
+
+    /**
+     * Loads the licence into a string using UTF-8 as encoding.
+     *
+     * @return A string representation of the licence.
+     * @throws ResourceException If the licence could not be found or if file
+     *      content could not be converted to UTF-8.
+     */
+    String asString() throws ResourceException
+    {
+        return asString("UTF-8");
+    }
+
+    /**
+     * Loads the licence into a string with the specified {@code encoding}.
+     *
+     * @param encoding The target character encoding.
+     * @return A string representation of the licence in the specified encoding.
+     * @throws ResourceException If the licence could not be found or if file
+     *      content could not be converted to the specified {@code encoding}.
+     */
+    String asString(final String encoding) throws ResourceException
+    {
+        URL url = asURL();
+        InputStream in = null;
+
+        try
+        {
+            in = url.openStream();
+            return IOUtils.toString(in, Charsets.toCharset(encoding));
+        }
+        catch (IOException e)
+        {
+            throw new ResourceNotFoundException("Cannot convert license document from resource " +
+                    url.getFile() + " to text: " + e.getMessage());
+
+        }
+        finally
+        {
+            IOUtils.closeQuietly(in);
+        }
+    }
+
+    /**
+     * Finds the IzPanel target class for the given {@code panelClass}.
+     *
+     * @param panelClass The panel class.
+     * @return The related IzPanel class.
+     * @throws ResourceException If a related IzPanel class could not be found.
+     *
+     * @see PanelHelper#getIzPanel(String)
+     */
+    static Class<?> findTargetClass(Class<?> panelClass) throws ResourceException
+    {
+        Class<?> targetClass = PanelHelper.getIzPanel(panelClass.getName());
+
+        if (null == targetClass)
+        {
+            throw new ResourceNotFoundException("No IzPanel implementation found for " +
+                    panelClass.getSimpleName());
+        }
+
+        return targetClass;
+    }
+
+    /**
+     * Builds the resource name for a specific panel id.
+     *
+     * @param resourceNamePrefix The resource name prefix.
+     * @param panel The panel providing a specific id.
+     * @return The specific resource name or {@code null}, if the panel does not
+     *      have an identifier.
+     */
+    static String buildSpecificResourceName(String resourceNamePrefix, Panel panel)
+    {
+        if (null != panel)
+        {
+            if (panel.hasPanelId())
+            {
+                return resourceNamePrefix + '.' + panel.getPanelId();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Builds an informative error message.
+     *
+     * @param panelType The panel type.
+     * @param resourceNames The list of evaluated resource names
+     * @return The built error message.
+     */
+    static String buildFinalErrorMessage(String panelType, String... resourceNames)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Cannot open any of the possible license document resources (");
+
+        boolean isFirst = true;
+
+        for (String resourceName : resourceNames)
+        {
+            if (null != resourceName)
+            {
+                if (!isFirst)
+                {
+                    sb.append(", ");
+                }
+
+                sb.append(resourceName);
+
+                if (isFirst)
+                {
+                    isFirst = false;
+                }
+            }
+        }
+
+        sb.append(") for panel type '");
+        sb.append(panelType);
+        sb.append("'");
+
+        return sb.toString();
+    }
+}

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/licence/LicenceLoaderTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/licence/LicenceLoaderTest.java
@@ -1,0 +1,216 @@
+/*
+ * IzPack - Copyright 2001-2017 The IzPack project team.
+ * All Rights Reserved.
+ *
+ * http://izpack.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.panels.licence;
+
+import com.izforge.izpack.api.data.Panel;
+import com.izforge.izpack.api.exception.ResourceException;
+import com.izforge.izpack.api.exception.ResourceNotFoundException;
+import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.core.resource.ResourceManager;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import java.net.URL;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Michael Aichler
+ */
+public class LicenceLoaderTest {
+
+    @Rule
+    public final ExpectedException thrownException = ExpectedException.none();
+
+    private URL defaultUrl;
+    private URL specificUrl;
+    private Resources resources;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        defaultUrl = new URL("file://default");
+        specificUrl = new URL("file://specific");
+        resources = Mockito.mock(Resources.class);
+    }
+
+    @Test
+    public void asUrlShouldThrowExceptionIfPanelNotFound() throws Exception
+    {
+        LicenceLoader loader = createFor(Object.class, null);
+
+        thrownException.expect(ResourceException.class);
+        thrownException.expectMessage(containsString("No IzPanel implementation found for"));
+
+        loader.asURL();
+    }
+
+    @Test
+    public void asUrlShouldThrowExceptionIfResourcesNotFound() throws Exception
+    {
+        when(resources.getURL("LicencePanel.licence")).thenThrow(new ResourceNotFoundException(""));
+        when(resources.getURL("LicencePanel.panelId")).thenThrow(new ResourceNotFoundException(""));
+
+        Panel panel = createPanel("panelId");
+        LicenceLoader loader = createFor(LicencePanel.class, panel);
+
+        thrownException.expect(ResourceException.class);
+        thrownException.expectMessage(endsWith(" resources (LicencePanel.licence, LicencePanel.panelId)" +
+                " for panel type 'LicencePanel'"));
+
+
+        loader.asURL();
+    }
+
+    @Test
+    public void asUrlShouldUseIzPanelClassAsPrefix() throws Exception
+    {
+        when(resources.getURL("LicencePanel.licence")).thenReturn(defaultUrl);
+
+        Panel panel = createPanel(null);
+        URL url = createFor(LicenceConsolePanel.class, panel).asURL();
+
+        assertThat(url, equalTo(defaultUrl));
+    }
+
+    @Test
+    public void asUrlShouldPreferSpecificResource() throws Exception
+    {
+        when(resources.getURL("LicencePanel.somePanelId")).thenReturn(specificUrl);
+
+        Panel panel = createPanel("somePanelId");
+        URL result = createFor(LicencePanel.class, panel).asURL();
+
+        assertThat(result, equalTo(specificUrl));
+    }
+
+    @Test
+    public void asUrlShouldFallbackToDefaultResource() throws Exception
+    {
+        when(resources.getURL("LicencePanel.somePanelId")).thenThrow(new ResourceNotFoundException(""));
+        when(resources.getURL("LicencePanel.licence")).thenReturn(defaultUrl);
+
+        Panel panel = createPanel("somePanelId");
+        URL result = createFor(LicencePanel.class, panel).asURL();
+
+        assertThat(result, equalTo(defaultUrl));
+    }
+
+    @Test
+    public void asStringShouldLoadResource() throws Exception
+    {
+        ResourceManager rm = new ResourceManager();
+        rm.setResourceBasePath("/com/izforge/izpack/panels/licence/");
+
+        Panel panel = createPanel(null);
+        LicenceLoader loader = new LicenceLoader(LicenceConsolePanel.class, panel, rm);
+
+        String result = loader.asString();
+        assertThat(result, equalTo("This is a licence panel"));
+    }
+
+    @Test
+    public void buildSpecificResourceNameShouldReturnNullIfPanelIsNull()
+    {
+        String result = LicenceLoader.buildSpecificResourceName("SomePrefix", null);
+        assertThat(result, nullValue());
+    }
+
+    @Test
+    public void buildSpecificResourceNameShouldReturnNullIfPanelIdIsNull()
+    {
+        Panel panel = createPanel(null);
+
+        String result = LicenceLoader.buildSpecificResourceName("SomePrefix", panel);
+        assertThat(result, nullValue());
+    }
+
+    @Test
+    public void buildSpecificResourceNameShouldReturnPanelIdAsSuffix()
+    {
+        Panel panel = createPanel("somePanelId");
+
+        String result = LicenceLoader.buildSpecificResourceName("SomePrefix", panel);
+        assertThat(result, equalTo("SomePrefix.somePanelId"));
+    }
+
+    @Test
+    public void buildFinalErrorMessageWithMultipleResourceNames()
+    {
+        String result = LicenceLoader.buildFinalErrorMessage("LicencePanel", "foo", "bar");
+        assertThat(result, endsWith(" resources (foo, bar) for panel type 'LicencePanel'"));
+    }
+
+    @Test
+    public void buildFinalErrorMessageWithNullResourceName()
+    {
+        String result = LicenceLoader.buildFinalErrorMessage("LicencePanel", "foo", null);
+        assertThat(result, endsWith(" resources (foo) for panel type 'LicencePanel'"));
+    }
+
+    @Test
+    public void buildFinalErrorMessageWithSingleResourceName()
+    {
+        String result = LicenceLoader.buildFinalErrorMessage("LicencePanel", "foo");
+        assertThat(result, endsWith(" resources (foo) for panel type 'LicencePanel'"));
+    }
+
+    @Test
+    public void findTargetClassWithConsolePanelClass()
+    {
+        Class<?> result = LicenceLoader.findTargetClass(LicenceConsolePanel.class);
+        assertThat(result, Matchers.<Class<?>>equalTo(LicencePanel.class));
+    }
+
+    @Test
+    public void findTargetClassWithIzPanelClass()
+    {
+        Class<?> result = LicenceLoader.findTargetClass(LicencePanel.class);
+        assertThat(result, Matchers.<Class<?>>equalTo(LicencePanel.class));
+    }
+
+    /**
+     * Helper which creates a licence loader for the given {@code clazz} and a
+     * mocked instance of {@link Resources}.
+     *
+     * @param clazz The panel class for which the licence loader is to be created.
+     * @return A newly created licence loader.
+     */
+    private LicenceLoader createFor(Class<?> clazz, Panel panel)
+    {
+        return new LicenceLoader(clazz, panel, resources);
+    }
+
+    private Panel createPanel(String id)
+    {
+        Panel panel = new Panel();
+        panel.setPanelId(id);
+        return panel;
+    }
+}

--- a/izpack-panel/src/test/java/com/izforge/izpack/panels/pdflicence/PDFLicencePanelTest.java
+++ b/izpack-panel/src/test/java/com/izforge/izpack/panels/pdflicence/PDFLicencePanelTest.java
@@ -81,6 +81,25 @@ public class PDFLicencePanelTest extends AbstractPanelTest {
 	}
 
     @Test
+    public void shouldFindAndDisplayLicenceTextForPanelWithoutIdentifier() throws Exception
+    {
+        // create a panel without identifier
+        FrameFixture fixture = show(PDFLicencePanel.class);
+
+        OnePageView onePageView = fixture.robot.finder().findByType(OnePageView.class);
+        DocumentViewController controller = onePageView.getParentViewController();
+
+        Document document = controller.getDocument();
+        assertThat(document, hasProperty("numberOfPages", equalTo(1)));
+
+        PageText pageText = document.getPageText(0);
+        pageText.selectAll();
+
+        String textArea = pageText.getSelected().toString();
+        assertThat(textArea, containsString("This is a licenSe panel"));
+    }
+
+    @Test
     public void shouldSelectLicenceNoRadioByDefault() throws Exception
     {
         IzPanelView view = createPanelView(PDFLicencePanel.class);

--- a/izpack-panel/src/test/resources/com/izforge/izpack/panels/licence/LicencePanel.licence
+++ b/izpack-panel/src/test/resources/com/izforge/izpack/panels/licence/LicencePanel.licence
@@ -1,0 +1,1 @@
+This is a licence panel


### PR DESCRIPTION
Implementation of  [IZPACK-1548](https://izpack.atlassian.net/browse/IZPACK-1548)

This pull request also fixes the issue where a licence is not looked up with the default suffix of ".licence" if the panel identifier is `null`.