### PR TITLE
IZPACK-1559: Fix typo 'reuseFork' in root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,7 +464,7 @@
           <configuration>
               <!-- need to always fork as ClassUtils.loadJarInSystemClassLoader() mangles the system class loader -->
               <forkCount>1</forkCount>
-              <reuseFork>false</reuseFork>
+              <reuseForks>false</reuseForks>
           </configuration>
       </plugin>
       <plugin>
@@ -761,7 +761,7 @@
             <configuration>
               <jvm>/opt/jdk/jdk1.6.0/bin/java</jvm>
               <forkCount>1</forkCount>
-              <reuseFork>false</reuseFork>
+              <reuseForks>false</reuseForks>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Implementation of  [IZPACK-1559](https://izpack.atlassian.net/browse/IZPACK-1559)