### PR TITLE
Fix IZPACK-1566: Logging from a configuration file throws exceptions

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1889,11 +1889,14 @@ public class CompilerConfig extends Thread
             {
                 assertionHelper.parseError(loggingElement, "Logging configuration by external file may only be used once");
             }
-            IXMLElement configFileElement = configFiles.get(0);
-            String fileName = xmlCompilerHelper.requireAttribute(configFileElement, "file");
-            URL url = resourceFinder.findProjectResource(fileName, "Logging configuration from file", configFileElement);
-            packager.addResource(ResourceManager.DEFAULT_INSTALL_LOGGING_CONFIGURATION_RES, url);
-            return;
+            else if (configFiles.size() == 1)
+            {
+                IXMLElement configFileElement = configFiles.get(0);
+                String fileName = xmlCompilerHelper.requireAttribute(configFileElement, "file");
+                URL url = resourceFinder.findProjectResource(fileName, "Logging configuration from file", configFileElement);
+                packager.addResource(ResourceManager.DEFAULT_INSTALL_LOGGING_CONFIGURATION_RES, url);
+                return;
+            }
         }
 
         // ... and if not, create the logging properties ourselves

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1883,7 +1883,8 @@ public class CompilerConfig extends Thread
 
         // check if we can load the logging properties from an external file...
         List<IXMLElement> configFiles = loggingElement.getChildrenNamed("configuration-file");
-        if (configFiles != null) {
+        if (configFiles != null)
+        {
             if (configFiles.size() > 1)
             {
                 assertionHelper.parseError(loggingElement, "Logging configuration by external file may only be used once");

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1881,6 +1881,21 @@ public class CompilerConfig extends Thread
             return;
         }
 
+        // check if we can load the logging properties from an external file...
+        List<IXMLElement> configFiles = loggingElement.getChildrenNamed("configuration-file");
+        if (configFiles != null) {
+            if (configFiles.size() > 1)
+            {
+                assertionHelper.parseError(loggingElement, "Logging configuration by external file may only be used once");
+            }
+            IXMLElement configFileElement = configFiles.get(0);
+            String fileName = xmlCompilerHelper.requireAttribute(configFileElement, "file");
+            URL url = resourceFinder.findProjectResource(fileName, "Logging configuration from file", configFileElement);
+            packager.addResource(ResourceManager.DEFAULT_INSTALL_LOGGING_CONFIGURATION_RES, url);
+            return;
+        }
+
+        // ... and if not, create the logging properties ourselves
         Properties logConfig = null;
         final String globalLevel = loggingElement.getAttribute("level", "INFO");
         if (globalLevel != null)
@@ -1894,17 +1909,6 @@ public class CompilerConfig extends Thread
                 logConfig.setProperty("javax.swing.level", globalLevel);
                 logConfig.setProperty("sun.awt.level", globalLevel);
                 logConfig.setProperty("sun.awt.X11.level", globalLevel);
-            }
-        }
-
-        List<IXMLElement> configFiles = loggingElement.getChildrenNamed("configuration-file");
-        if (configFiles != null)
-        {
-            for (IXMLElement configFileElement : configFiles)
-            {
-                String fileName = xmlCompilerHelper.requireAttribute(configFileElement, "file");
-                URL url = resourceFinder.findProjectResource(fileName, "Logging configuration from file", configFileElement);
-                packager.addResource(ResourceManager.DEFAULT_INSTALL_LOGGING_CONFIGURATION_RES, url);
             }
         }
 


### PR DESCRIPTION
External configuration file is checked first. If it is found, it is used. Only if it is not found, all the other logging configuration logic is executed.