### PR TITLE
Fixing IZPACK-1469

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/GUIPackResources.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/GUIPackResources.java
@@ -81,7 +81,7 @@ public class GUIPackResources extends AbstractPackResources
 
         try
         {
-            URL url = new URL("jar:" + packLocalFile.toURI().toURL() + "!/packs/pack-" + name);
+            URL url = new URL("jar:" + packLocalFile.getPath() + "!/packs/pack-" + name);
             result = url.openStream();
         }
         catch (IOException exception)


### PR DESCRIPTION
This will fix IZPACK-1469.
Old variant copied directory twice so url had form like "jar:/home/usr/file:/home/usr/myFile!..."