### PR TITLE
fixed property file loading

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/data/PropertyManager.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/data/PropertyManager.java
@@ -239,7 +239,7 @@ public class PropertyManager
         packagerListener.packagerMsg("Loading " + fileName,
                 PackagerListener.MSG_VERBOSE);
 
-        FileInputStream fis = new FileInputStream("");
+        FileInputStream fis = new FileInputStream(fileName);
         try
         {
             props.load(fis);


### PR DESCRIPTION
The property file configured to load in izpack.xml is not able to load with the tag:

```xml
<property file="src/main/izpack/versions.properties" />
```

So far this functionality was OK, but now some regression detected.