### PR TITLE
Deleted useless import URLClassLoader

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/UnpackerBase.java
@@ -51,7 +51,6 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.*;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.*;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;


### PR DESCRIPTION
The import of URLClassLoader caused a Classcastexception with java 9. Already resolved https://izpack.atlassian.net/browse/IZPACK-1588. But not on Github, so anyway ...