### PR TITLE
IZPACK-1603: fix NPE on ShortcutPanel when menu shortcut creation (checkbox) is disabled

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
@@ -130,9 +130,13 @@ public class ShortcutPanelLogic implements CleanupClient
      * If true it indicates that there are shortcuts to create. The value is set by
      * createShortcutData()
      */
-    private boolean createMenuShortcuts = false;
-
     private boolean createShortcuts = false;
+
+    private boolean createMenuShortcuts = false;
+    
+    private boolean createDesktopShortcuts = false;
+
+    private boolean createStartupShortcuts = false;
 
     /**
      * This is set to true if the shortcut spec instructs to simulate running on an operating system
@@ -149,10 +153,6 @@ public class ShortcutPanelLogic implements CleanupClient
     private final UninstallData uninstallData;
 
     private final PlatformModelMatcher matcher;
-
-    private boolean createDesktopShortcuts;
-
-    private boolean createStartupShortcuts;
 
     private boolean defaultCurrentUserFlag = false;
 
@@ -1186,7 +1186,11 @@ public class ShortcutPanelLogic implements CleanupClient
         {
             writeXDGMenuFile(startMenuShortcuts, this.groupName, programGroupIconFile, programGroupComment);
         }
-        shortcut.execPostAction();
+        
+        if (!shortcuts.isEmpty()) 
+        {
+        	shortcut.execPostAction();
+        }
 
         try
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
@@ -1189,7 +1189,7 @@ public class ShortcutPanelLogic implements CleanupClient
         
         if (!shortcuts.isEmpty()) 
         {
-        	shortcut.execPostAction();
+            shortcut.execPostAction();
         }
 
         try


### PR DESCRIPTION
Proposal of a fix for this bug which happens only on Unix, because of the Unix-specific "execPostAction" overriding which uses the Shortcut.UninstallerData.
When the user unchecks the checkbox on ShortcutPanel, no menu shortcut needs to be created, so the UninstallerData is not set. But we still call the "execPostAction", which makes no sense and throws the exception on Unix systems, because of the overriding mentioned earlier.

So this proposal consists of calling "execPostAction" only when the given shortcuts-to-create list is not empty.
I also added a little reorganization of shortcuts variables, as a comment wasn't actually assigned to the correct one.