### PR TITLE
IZPACK-1604: fix warning at shortcut creation

### DIFF
--- a/izpack-dist/src/main/izpack/shortcutSpec.xml
+++ b/izpack-dist/src/main/izpack/shortcutSpec.xml
@@ -17,6 +17,7 @@
             startup="no"
             iconFile="$INSTALL_PATH\icons\izpack_wiki_32.png"
             url="https://izpack.atlassian.net/wiki/display/IZPACK/IzPack+Home"
+            type="Link"
             description="Browse the IzPack Wiki site online">
 
         <createForPack name="Core"/>


### PR DESCRIPTION
Just a easily fixable warning in console output on macOS.