### PR TITLE
IZPACK-1593: reactivate GUI integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,9 @@ before_script:
 
 matrix:
   include:
-    - addons:
-        apt:
-          packages:
-            - openjdk-6-jdk
-      jdk: openjdk6
+    - jdk: openjdk6
       env: MVN_VERSION="3.2.5"
-    - addons:
-        apt:
-          packages:
-            - fluxbox
-            - openjdk-7-jdk
-      jdk: openjdk7
+    - jdk: openjdk7
       env: MVN_VERSION="3.3.9"
     - jdk: oraclejdk8
       env: MVN_VERSION="3.3.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,12 @@ before_script:
 
 matrix:
   include:
-    - jdk: openjdk6
+    - addons:
+        apt:
+          packages:
+            - fluxbox
+            - openjdk-6-jdk
+      jdk: openjdk6
       env: MVN_VERSION="3.2.5"
     - jdk: openjdk7
       env: MVN_VERSION="3.3.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,20 @@ install:
   - export PATH=${HOME}/mvn-home/bin:${PATH}
   - mvn -version
 
-# FIXME
-# Automatic GUI tests fail  on Travis
-# Failing command line: mvn verify -Pwith-gui-tests
-#addons:
-#  apt:
-#    packages:
-#      - fluxbox
+addons:
+  apt:
+    packages:
+      - fluxbox
 
 cache:
  directories:
    - $HOME/.m2/repository
 
-# FIXME
-# Automatic GUI tests fail on Travis
-# Failing command line: mvn verify -Pwith-gui-tests
-#before_script:
-#  - export DISPLAY=:99.0
-#  - sh -e /etc/init.d/xvfb start
-#  - fluxbox &> ~/fluxbox.log &
-#  - sleep 3
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - fluxbox &> ~/fluxbox.log &
+  - sleep 3
 
 matrix:
   include:
@@ -57,9 +51,7 @@ env:
 
 script:
   - mvn -U clean verify
-# FIXME
-# Automatic GUI tests fail on Travis
-#  - mvn verify -Pwith-gui-tests
+  - mvn verify -Pwith-gui-tests
 
 notifications:
   email: false

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/InstallationTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/InstallationTest.java
@@ -201,7 +201,7 @@ public class InstallationTest
         // Finish panel
         installerFrameFixture.button(GuiId.FINISH_PANEL_AUTO_BUTTON.id).click();
         Thread.sleep(800);
-        installerFrameFixture.fileChooser(GuiId.FINISH_PANEL_FILE_CHOOSER.id).fileNameTextBox().enterText("auto.xml");
+        installerFrameFixture.fileChooser(GuiId.FINISH_PANEL_FILE_CHOOSER.id).fileNameTextBox().setText("auto.xml");
         Thread.sleep(300);
         installerFrameFixture.fileChooser(GuiId.FINISH_PANEL_FILE_CHOOSER.id).approve();
         assertThat(new File(installPath, "auto.xml").exists(), is(true));


### PR DESCRIPTION
Hi,

This fixes the following issues :
1. first known error : javax.swing IllegalStateException
2. a test error

I've reactivated the GUI integration tests and it works fine for me, with JDK8 on macOS.
But, using the travis build on my repository to test on the other versions, the build fails on JDK6 only. 
It seems that the warning and error panels don't show up. But I can't reproduce the issue on my laptop with Windows and JDK6, launching one of the failing tests manually, It works fine...

I create this PR as someone else could have an idea about what's going on with JDK6...