### PR TITLE
New Feature for IZPACK-1619: Allow previous nav button to be disabled on ShortcutPanel

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-shortcuts-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-shortcuts-5.0.xsd
@@ -39,6 +39,7 @@
                 <xs:element name="lateShortcutInstall" minOccurs="0"/>
                 <xs:element name="programGroup" type="programGroupType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="shortcut" type="shortcutType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="previousDisabled" minOccurs="0"/>
             </xs:choice>
             <xs:attribute name="version" type="xs:string" fixed="5.0" use="required"/>
         </xs:complexType>

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConstants.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutConstants.java
@@ -50,6 +50,8 @@ public class ShortcutConstants
 
     static final String SPEC_KEY_PACKS = "createForPack";
 
+    static final String SPEC_KEY_PREVIOUS_DISABLED = "previousDisabled";
+
     // ------------------------------------------------------
     // spec file key attributes
     // ------------------------------------------------------

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanel.java
@@ -211,11 +211,24 @@ public class ShortcutPanel extends IzPanel implements ActionListener, ListSelect
     }
 
     @Override
+    public void panelDeactivate()
+    {
+        if (shortcutPanelLogic.isPreviousDisabled())
+        {
+            parent.unlockPrevButton();
+        }
+    }
+
+    @Override
     public void panelActivate()
     {
         try
         {
             shortcutPanelLogic.refreshShortcutData();
+            if (shortcutPanelLogic.isPreviousDisabled())
+            {
+                parent.lockPrevButton();
+            }
             allowDesktopShortcut.setVisible(shortcutPanelLogic.hasDesktopShortcuts());
             allowStartupShortcut.setVisible(shortcutPanelLogic.hasStartupShortcuts());
             usersPanel.setVisible(shortcutPanelLogic.isSupportingMultipleUsers());

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/shortcut/ShortcutPanelLogic.java
@@ -92,6 +92,11 @@ public class ShortcutPanelLogic implements CleanupClient
     private boolean skipIfNotSupported = false;
 
     /**
+     * Tells whether to disable previous nav button
+     */
+    private boolean previousDisabled = false;
+
+    /**
      * the one shortcut instance for reuse in many locations
      */
     private Shortcut shortcut;
@@ -456,6 +461,14 @@ public class ShortcutPanelLogic implements CleanupClient
     }
 
     /**
+     * @return <code>true</code> if previous nav button is disabled otherwise <code>false</code>
+     */
+    public boolean isPreviousDisabled()
+    {
+        return previousDisabled;
+    }
+
+    /**
      * @return <code>true</code> if shortcut creation is supported otherwise <code>false</code>
      */
     public boolean isSupported()
@@ -786,6 +799,7 @@ public class ShortcutPanelLogic implements CleanupClient
         simulateNotSupported = (spec.getFirstChildNamed(SPEC_KEY_NOT_SUPPORTED) != null);
         defaultCurrentUserFlag = (spec.getFirstChildNamed(SPEC_KEY_DEF_CUR_USER) != null);
         skipIfNotSupported = (spec.getFirstChildNamed(SPEC_KEY_SKIP_IFNOT_SUPPORTED) != null);
+        previousDisabled = (spec.getFirstChildNamed(SPEC_KEY_PREVIOUS_DISABLED) != null);
         setCreateShortcutsImmediately(spec.getFirstChildNamed(SPEC_KEY_LATE_INSTALL) == null);
 
 


### PR DESCRIPTION
We use a shortcut panel directly after a process panel. When you select the previous navigation button from the shortcut panel, you end up getting stuck at the process panel (next option is disabled).

This ticket adds a new feature where you can disable the previous navigation button for the shortcut panel by adding:
<previousDisabled/> to your shortcutSpec.xml

By default, the previous navigation button will remain enabled if no tag is present in shortcutSpec.xml

https://izpack.atlassian.net/browse/IZPACK-1619