### PR TITLE
Prepare changes for java 9

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/util/CompilerClassLoader.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/util/CompilerClassLoader.java
@@ -51,7 +51,7 @@ public class CompilerClassLoader extends URLClassLoader
      */
     public CompilerClassLoader(ClassNameMapper mapper)
     {
-        this(CompilerClassLoader.class.getClassLoader(), mapper);
+        this(new URLClassLoader(new URL[0], CompilerClassLoader.class.getClassLoader()), mapper);
     }
 
     /**

--- a/izpack-core/src/main/java/com/izforge/izpack/merge/resolve/ResolveUtils.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/merge/resolve/ResolveUtils.java
@@ -169,7 +169,7 @@ public class ResolveUtils
 
     public static Set<URL> getJarUrlForPackage(String packageName)
     {
-        URLClassLoader loader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
+    	ClassLoader loader = Thread.currentThread().getContextClassLoader();
         Set<URL> result = new HashSet<URL>();
         try
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -393,10 +393,10 @@ public class TreePacksPanel extends IzPanel
      */
     private void syncCheckboxesWithModel(CheckBoxNode rootNode)
     {
-        Enumeration<CheckBoxNode> e = rootNode.children();
+        Enumeration<TreeNode> e = rootNode.children();
         while (e.hasMoreElements())
         {
-            CheckBoxNode node = e.nextElement();
+            CheckBoxNode node = (CheckBoxNode) e.nextElement();
             String nodeText = node.getId();
             Object nodePack = namesToPacks.get(nodeText);
 

--- a/izpack-test-common/src/main/java/com/izforge/izpack/test/util/ClassUtils.java
+++ b/izpack-test-common/src/main/java/com/izforge/izpack/test/util/ClassUtils.java
@@ -45,10 +45,10 @@ public class ClassUtils
     {
         try
         {
-            URLClassLoader systemClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+        	URLClassLoader urlClassLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
             Method declaredMethod = URLClassLoader.class.getDeclaredMethod("addURL", new Class[]{URL.class});
             declaredMethod.setAccessible(true);
-            declaredMethod.invoke(systemClassLoader, out.toURI().toURL());
+            declaredMethod.invoke(urlClassLoader, out.toURI().toURL());
         }
         catch (Exception e)
         {

--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.21.0</version>
           <configuration>
             <!-- <workingDirectory>${project.build.directory}</workingDirectory> -->
             <systemPropertyVariables>
@@ -638,7 +638,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.21.0</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
This will allow to build more under jdk9 and jdk8. There is still an issue with `com.izforge.izpack.test.util.ClassUtils` because `URLClassPath` is no longer available under `sun.misc` package.