### PR TITLE
Update user-input xsd to validate omitOnAuto (IZPACK-1138)

### DIFF
--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -114,6 +114,14 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
+                        <xs:attribute name="omitFromAuto" type="xs:boolean" use="optional">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Whether to omit the field variable's value from being written to the auto-install.xml
+                                    record initiated from the FinishPanel (if used).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
@@ -377,6 +385,14 @@
                 <xs:documentation>
                     Maximal number of rows displayed in a "custom" field, before the Add button gets deactivated.
                     Used by "custom" fields.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="omitFromAuto" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether to omit the field variable's value from being written to the auto-install.xml
+                    record initiated from the FinishPanel (if used).
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -284,7 +284,7 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="omitFromAuto" type="xs:string" use="optional">
+                    <xs:attribute name="omitFromAuto" type="xs:boolean" use="optional">
                         <xs:annotation>
                             <xs:documentation>
                                 Whether to omit the field variable's value from being written to the auto-install.xml

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -114,14 +114,6 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="omitFromAuto" type="xs:boolean" use="optional">
-                            <xs:annotation>
-                                <xs:documentation>
-                                    Whether to omit the field variable's value from being written to the auto-install.xml
-                                    record initiated from the FinishPanel (if used).
-                                </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
@@ -292,6 +284,14 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
+					<xs:attribute name="omitFromAuto" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Whether to omit the field variable's value from being written to the auto-install.xml
+                                    record initiated from the FinishPanel (if used).
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
                 </xs:complexType>
             </xs:element>
             <xs:element name="os" minOccurs="0" maxOccurs="unbounded">
@@ -385,14 +385,6 @@
                 <xs:documentation>
                     Maximal number of rows displayed in a "custom" field, before the Add button gets deactivated.
                     Used by "custom" fields.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="omitFromAuto" type="xs:boolean" use="optional">
-            <xs:annotation>
-                <xs:documentation>
-                    Whether to omit the field variable's value from being written to the auto-install.xml
-                    record initiated from the FinishPanel (if used).
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
+++ b/izpack-compiler/src/main/resources/schema/5.0/izpack-userinput-5.0.xsd
@@ -284,7 +284,7 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-					<xs:attribute name="omitFromAuto" type="xs:string" use="optional">
+                    <xs:attribute name="omitFromAuto" type="xs:string" use="optional">
                         <xs:annotation>
                             <xs:documentation>
                                 Whether to omit the field variable's value from being written to the auto-install.xml


### PR DESCRIPTION
The xsd has been updated to validate the attribute "omitOnAuto".
It might have been forgotten in:
https://izpack.atlassian.net/browse/IZPACK-1138