### PR TITLE
Add minimal changes for Java10 build support.

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/treepacks/TreePacksPanel.java
@@ -393,10 +393,10 @@ public class TreePacksPanel extends IzPanel
      */
     private void syncCheckboxesWithModel(CheckBoxNode rootNode)
     {
-        Enumeration<CheckBoxNode> e = rootNode.children();
+        Enumeration<TreeNode> e = rootNode.children();
         while (e.hasMoreElements())
         {
-            CheckBoxNode node = e.nextElement();
+            CheckBoxNode node = (CheckBoxNode) e.nextElement();
             String nodeText = node.getId();
             Object nodePack = namesToPacks.get(nodeText);
 

--- a/pom.xml
+++ b/pom.xml
@@ -638,7 +638,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.21.0</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
When trying to compile izpack using Java 10 I found several small issues.
My changes to com.izforge.izpack.test.util.ClassUtils are not included as I don't have a final solution.