### PR TITLE
Keep links and file permissions from archive files (*.zip, *.tar.gz)

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -88,7 +88,6 @@ import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.archivers.tar.TarUtils;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipFile;
@@ -1650,6 +1649,7 @@ public class CompilerConfig extends Thread
         {
             archiveInputStream = new ArchiveStreamFactory().createArchiveInputStream(archive, uncompressedInputStream);
 
+            // file is an archive (incl. ZIP archive) - unpack recursively
             baseTempDir = com.izforge.izpack.util.file.FileUtils.createTempDirectory("izpack", TEMP_DIR);
 
             if (keepPermissions && additionals == null) {

--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -1608,14 +1608,14 @@ public class CompilerConfig extends Thread
     /**
      * Add files in an archive to a pack
      *
-     * @param archive     the archive file to unpack
-     * @param targetDir   the target directory where the content of the archive will be installed
-     * @param osList      The target OS constraints.
-     * @param override    Overriding behaviour.
-     * @param pack        Pack to be packed into
-     * @param additionals Map which contains additional data
+     * @param archive         the archive file to unpack
+     * @param targetDir       the target directory where the content of the archive will be installed
+     * @param osList          The target OS constraints.
+     * @param override        Overriding behaviour.
+     * @param pack            Pack to be packed into
+     * @param additionals     Map which contains additional data
      * @param keepPermissions Save files permissions or not
-     * @param condition   condition that must evaluate {@code} true for the file to be installed. May be {@code null}
+     * @param condition       condition that must evaluate {@code} true for the file to be installed. May be {@code null}
      */
     private void addArchiveContent(IXMLElement fileNode, File baseDir, File archive, String targetDir,
                                    List<OsModel> osList, OverrideType override, String overrideRenameTo,
@@ -1744,9 +1744,9 @@ public class CompilerConfig extends Thread
     /**
      * Collect permissions of all files from zip archive
      *
-     * @param additionals the collection which will be filled with full information about files contained in the Zip-archive
-     * @param zipArchive Zip-archive
-     * @param targetDir  the target directory
+     * @param additionals  the collection which will be filled with full information about files contained in the Zip-archive
+     * @param zipArchive   Zip-archive
+     * @param targetDir    the target directory
      * @throws IOException Description of the Exception
      */
     private void getAdditionalDataFromZipArchive(Map<String, HashMap<String, Object>> additionals, File zipArchive, String targetDir) throws IOException
@@ -1785,8 +1785,8 @@ public class CompilerConfig extends Thread
      * Collect permissions of single file from tar archive (by entry)
      *
      * @param additionals the collection which contains full information about files contained in the Zip-archive
-     * @param entry current tar entry
-     * @param targetDir the target directory
+     * @param entry       current tar entry
+     * @param targetDir   the target directory
      */
     private void getAdditionalDataFromTarArchiveByEntry(Map<String, HashMap<String, Object>> additionals, TarArchiveEntry entry, String targetDir)
     {

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
@@ -31,7 +31,6 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.*;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
@@ -149,12 +148,6 @@ public abstract class FileUnpacker
 
         postCopy(file);
 
-        if (file.getAdditionals() != null) {
-            Map fullAdditionalsMap = file.getAdditionals();
-            HashMap<String, Object> filePropertiesMap = (HashMap<String, Object>) fullAdditionalsMap.get(file.getTargetPath());
-            if (filePropertiesMap != null) setAdditionalData(target.getPath(), filePropertiesMap);
-        }
-
         return bytesCopied;
     }
 
@@ -162,7 +155,7 @@ public abstract class FileUnpacker
      * Sets the file permissions and type in accordance with the initial values.
      * MacOS not supported yet.
      *
-     * @param target the full path to file
+     * @param target      the full path to file
      * @param additionals the collection which contains full information about current file
      */
     private void setAdditionalData(String target, HashMap<String, Object> additionals)
@@ -204,15 +197,22 @@ public abstract class FileUnpacker
 
     /**
      * Invoked after copying is complete to set the last modified timestamp, and queue blockable files.
+     * If there are saved file permissions, then restore them,
      *
      * @param file the pack file meta-data
      */
     protected void postCopy(PackFile file)
     {
         setLastModified(file);
+
         if (isBlockable(file))
         {
             queue();
+        }
+
+        if (file.getAdditionals() != null) {
+            HashMap<String, Object> filePropertiesMap = (HashMap<String, Object>) file.getAdditionals().get(file.getTargetPath());
+            if (filePropertiesMap != null) setAdditionalData(target.getPath(), filePropertiesMap);
         }
     }
 

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
@@ -151,12 +151,20 @@ public abstract class FileUnpacker
 
         if (file.getAdditionals() != null) {
             Map fullAdditionalsMap = file.getAdditionals();
-            HashMap<String,Object> filePropertiesMap = (HashMap<String, Object>) fullAdditionalsMap.get(file.getTargetPath());
-            setAdditionalData(target.getPath(), filePropertiesMap);
+            HashMap<String, Object> filePropertiesMap = (HashMap<String, Object>) fullAdditionalsMap.get(file.getTargetPath());
+            if (filePropertiesMap != null) setAdditionalData(target.getPath(), filePropertiesMap);
         }
+
         return bytesCopied;
     }
 
+    /**
+     * Sets the file permissions and type in accordance with the initial values.
+     * MacOS not supported yet.
+     *
+     * @param target the the full path to file
+     * @param additionals the collection which contains full information about file
+     */
     private void setAdditionalData(String target, HashMap<String, Object> additionals)
     {
         ArrayList<String> execCommands = new ArrayList<String>();
@@ -272,7 +280,13 @@ public abstract class FileUnpacker
         }
         else
         {
-            result = FileUtils.openOutputStream(target);
+            try {
+                result = FileUtils.openOutputStream(target);
+            }
+            catch (IOException e) { //if target file cannot be opened for writing, we delete him and create new
+                    target.delete();
+                    result = FileUtils.openOutputStream(target);
+            }
         }
         return result;
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/FileUnpacker.java
@@ -30,7 +30,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
 import java.io.*;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ArrayList;
 import java.util.logging.Logger;
 
 


### PR DESCRIPTION
Hello! When we try to use that project to make installers, we face some problems:
- When we install some files using IzPack, all files permissions has been changed to default;
- All symbolic and hard links become zero-lengths files.

If archive files will be used as the source of files for the installer, then the "keeppermissions" attribute can be used while XML configuration file filling. 
For example: <file src="test.tar.gz" unpack="true" keeppermissions="true"/>

Some limitations:
- Attribute "keeppermissions" will be handled only if you don't use any "additionals";
- This attribute work with *.zip and *.tar.gz archive files only. Non-archive files permissions cannot be processed.
- Supported host platform are Windows and Linux.

I will waiting for your feedback, and ready to discuss about implementation of this functionality. In Google i found a lot of request this functionality in IzPack, so it will be great, if community can handle this solution.

