### PR TITLE
Fix for the IzPack exception: ResourceNotFoundException: Cannot find named resource: 'info'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ izpack-compiler/out.zip
 .metadata
 .idea
 /bin
+.recommenders/

--- a/izpack-core/src/main/java/com/izforge/izpack/core/resource/ResourceManager.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/resource/ResourceManager.java
@@ -69,7 +69,7 @@ public class ResourceManager extends AbstractResources
      */
     public ResourceManager()
     {
-        this(ClassLoader.getSystemClassLoader());
+        this(Thread.currentThread().getContextClassLoader());
     }
 
     /**


### PR DESCRIPTION
Caused by: com.izforge.izpack.api.exception.ContainerException:
com.izforge.izpack.api.exception.ResourceNotFoundException: Cannot find
named resource: 'info'

Signed-off-by: Francis ANDRE <francis.andre.kampbell@orange.com>