### PR TITLE
IZPACK-1648: Allow to select JDK9+ in JDKPathPanel

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanel.java
@@ -23,6 +23,7 @@
 package com.izforge.izpack.panels.jdkpath;
 
 import java.awt.Desktop;
+import java.io.File;
 import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -187,4 +188,27 @@ public class JDKPathPanel extends PathInputPanel implements HyperlinkListener
     {
         this.installData.setVariable(JDKPathPanelHelper.JDK_PATH, pathSelectionPanel.getPath());
     }
+    
+    /**
+     * Determines if required files exist relative to the specified path
+     *
+     * @return {@code true} if no files are required, or they exist
+     */
+    protected boolean checkRequiredFilesExist(String path)
+    {
+        if (existFiles == null || path == null || path.isEmpty())
+        {
+            return true;
+        }
+        for (String existFile : existFiles)
+        {
+            File file = new File(path, existFile).getAbsoluteFile();
+            if (file.exists())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelHelper.java
@@ -17,7 +17,7 @@ import java.util.StringTokenizer;
 
 public class JDKPathPanelHelper
 {
-    public static final String[] testFiles = new String[]{"lib" + File.separator + "tools.jar"};
+    public static final String[] testFiles = new String[]{"lib" + File.separator + "tools.jar", "bin" + File.separator + "javac" + (OsVersion.IS_WINDOWS ? ".exe" : "")};
     public static final String JDK_VALUE_NAME = "JavaHome";
     public static final String JDK_ROOT_KEY = "Software\\JavaSoft\\Java Development Kit";
     public static final String OSX_JDK_HOME = "/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/Home/";
@@ -175,12 +175,12 @@ public class JDKPathPanelHelper
         for (String existFile : testFiles)
         {
             File path = new File(strPath, existFile).getAbsoluteFile();
-            if (!path.exists())
+            if (path.exists())
             {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputPanel.java
@@ -328,12 +328,12 @@ public class PathInputPanel extends IzPanel implements ActionListener
         for (String existFile : existFiles)
         {
             File file = new File(path, existFile).getAbsoluteFile();
-            if (file.exists())
+            if (!file.exists())
             {
-                return true;
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/path/PathInputPanel.java
@@ -328,12 +328,12 @@ public class PathInputPanel extends IzPanel implements ActionListener
         for (String existFile : existFiles)
         {
             File file = new File(path, existFile).getAbsoluteFile();
-            if (!file.exists())
+            if (file.exists())
             {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
IZPACK-1648: Check for existance of bin/javac if no bib/tools.jar is found. This will work for JDK9+.