### PR TITLE
Set the installer frame's WM_CLASS to its title.

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -274,6 +274,8 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
         this.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         ImageIcon jframeIcon = getIcons().get("JFrameIcon");
         setIconImage(jframeIcon.getImage());
+        setWMClass(getTitle());
+
         // Prepares the glass pane to block the gui interaction when needed
         JPanel glassPane = (JPanel) getGlassPane();
         glassPane.addMouseListener(new MouseAdapter()
@@ -381,6 +383,25 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
             }
 
         });
+    }
+
+    private void setWMClass(String title) {
+
+        final Toolkit toolkit = Toolkit.getDefaultToolkit();
+        try {
+            final java.lang.reflect.Field field =
+                toolkit.getClass().getDeclaredField("awtAppClassName");
+            field.setAccessible(true);
+            field.set(toolkit, title);
+        }
+        catch (ReflectiveOperationException e) {
+            // Will only succeed on Linux.
+            log.addDebugMessage("Failed to set WM_CLASS", null, Log.PANEL_TRACE, e);
+        }
+        catch (SecurityException e) {
+            // Oh well.
+            log.addDebugMessage("Failed to set WM_CLASS", null, Log.PANEL_TRACE, e);
+        }
     }
 
     /**

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/InstallerFrame.java
@@ -44,6 +44,7 @@ import com.izforge.izpack.installer.debugger.Debugger;
 import com.izforge.izpack.installer.unpacker.IUnpacker;
 import com.izforge.izpack.util.Debug;
 import com.izforge.izpack.util.Housekeeper;
+import com.izforge.izpack.util.Platform;
 
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
@@ -274,7 +275,10 @@ public class InstallerFrame extends JFrame implements InstallerBase, InstallerVi
         this.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         ImageIcon jframeIcon = getIcons().get("JFrameIcon");
         setIconImage(jframeIcon.getImage());
-        setWMClass(getTitle());
+
+        if (installdata.getPlatform().isA(Platform.Name.LINUX)) {
+            setWMClass(getTitle());
+        }
 
         // Prepares the glass pane to block the gui interaction when needed
         JPanel glassPane = (JPanel) getGlassPane();


### PR DESCRIPTION
Use reflection to set the installer frame's WM_CLASS to its title.

This improves the appearance of the installer in application switchers on Linux desktops.