### PR TITLE
Fix for problem name 'reduce' is not defined

### DIFF
--- a/izpack-wrapper/src/main/resources/utils/wrappers/izpack2app/izpack2app.py
+++ b/izpack-wrapper/src/main/resources/utils/wrappers/izpack2app/izpack2app.py
@@ -21,6 +21,7 @@
 import os
 import sys
 from shutil import *
+from shutil import reduce
 
 def main():
 	base = os.path.dirname(sys.argv[0])


### PR DESCRIPTION
Traceback (most recent call last):
  File "izpack2app\izpack2app.py", line 53, in <module>
    main()
  File "izpack2app\izpack2app.py", line 43, in main
    plist_content = reduce(reducer, plist.readlines(), '').replace('__JAR__', jar_name)
NameError: name 'reduce' is not defined