### PR TITLE
IZPACK-1667 - Updating Commons Compress and Pdfbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox</artifactId>
-        <version>1.8.10</version>
+        <version>1.8.16</version>
       </dependency>
 	  <dependency>
         <groupId>org.icepdf.os</groupId>
@@ -131,7 +131,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.12</version>
+        <version>1.19</version>
       </dependency>
       <dependency>
         <groupId>org.tukaani</groupId>


### PR DESCRIPTION
This fixes the following CVE reports:

commons-compress-1.12.jar (pkg:maven/org.apache.commons/commons-compress@1.12, cpe:2.3:a:apache:commons-compress:1.12:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_compress:1.12:*:*:*:*:*:*:*) : CVE-2018-11771, CVE-2018-1324
pdfbox-1.8.10.jar (pkg:maven/org.apache.pdfbox/pdfbox@1.8.10, cpe:2.3:a:apache:pdfbox:1.8.10:*:*:*:*:*:*:*) : CVE-2016-2175, CVE-2018-11797, CVE-2018-8036