### PR TITLE
Issue: IZPACK-1656 fix file queue parameter

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/util/os/WinSetupFileQueue.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/util/os/WinSetupFileQueue.java
@@ -76,7 +76,7 @@ public class WinSetupFileQueue extends WinSetupAPIBase
      */
     public void addCopy(File sourcefile, File targetfile, boolean forceInUse) throws IOException
     {
-        int style = 0 /*SP_COPY_IN_USE_NEEDS_REBOOT*/;
+        int style = SP_COPY_IN_USE_NEEDS_REBOOT;
         if (forceInUse)
         {
             style |= SP_COPY_FORCE_IN_USE;


### PR DESCRIPTION
https://izpack.atlassian.net/browse/IZPACK-1656

Use correct parameter to prefent error wile file queue operstion: "De parameter is onjuist" or  "The parameter is incorrect"

Enqueueing moving C:\Program Files\CENSORED\CENSORED\__FQ__9356852580364207950.tmp to C:\Program Files\CENSORED\CENSORED\CENSORED.exe (0x201)

java.io.IOException: File queue operation failed due to Failed to enqueue moving C:\Program Files\CENSORED\CENSORED\__FQ__9356852580364207950.tmp to C:\Program Files\CENSORED\CENSORED\CENSORED.exe due to SetupQueueCopy returned with code 87: De parameter is onjuist.
        at com.izforge.izpack.util.os.FileQueue.execute(FileQueue.java:89)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.postUnpack(UnpackerBase.java:754)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.unpack(UnpackerBase.java:300)
        at com.izforge.izpack.installer.unpacker.UnpackerBase.run(UnpackerBase.java:241)
        at java.base/java.lang.Thread.run(Thread.java:834)