### PR TITLE
IZPACK-1645 enhanced size check for reading before unpack

### DIFF
--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/CompressedFileUnpacker.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/CompressedFileUnpacker.java
@@ -72,17 +72,21 @@ public class CompressedFileUnpacker extends FileUnpacker
             throws IOException, InstallerException
     {
         File tmpfile = File.createTempFile("izpack-uncompress", null, FileUtils.getTempDirectory());
+        final long fileSize = file.size();
+        final long fileLength = file.length();
+        final long backReferenceFileLength = file.isBackReference() ? file.getLinkedPackFile().size() : fileSize;
+
         OutputStream fo = null;
         InputStream finalStream = null;
 
         try
         {
             fo = IOUtils.buffer(FileUtils.openOutputStream(tmpfile));
-            final long bytesUnpacked = IOUtils.copyLarge(packInputStream, fo, 0, file.size());
+            final long bytesUnpacked = IOUtils.copyLarge(packInputStream, fo, 0, fileSize);
             fo.flush();
             fo.close();
 
-            if (bytesUnpacked != file.size())
+            if (!(bytesUnpacked == fileSize || bytesUnpacked == backReferenceFileLength))
             {
                 throw new IOException("File size mismatch when reading from pack: " + file.getRelativeSourcePath());
             }
@@ -102,7 +106,7 @@ public class CompressedFileUnpacker extends FileUnpacker
 
             final long bytesUncompressed = copy(file, finalStream, target);
 
-            if (bytesUncompressed != file.length())
+            if (bytesUncompressed != fileLength)
             {
                 throw new IOException("File size mismatch when uncompressing from pack: " + file.getRelativeSourcePath());
             }


### PR DESCRIPTION
Checks the read size against the size either defined on the current and back referenced file size if available. As there are cases where the only the back reference contains the correct size,