### PR TITLE
IZPACK-1686: Fix NPE if the 'EstimatedSize' is not in installData.

### DIFF
--- a/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
+++ b/izpack-event/src/main/java/com/izforge/izpack/event/RegistryInstallerListener.java
@@ -622,8 +622,12 @@ public class RegistryInstallerListener extends AbstractProgressInstallerListener
         }
         
         // add the estimated size
-        long estimatedSizeInBytes = Long.parseLong(installData.getVariable(InstallData.ESTIMATED_SIZE));
-        registry.setValue(keyName, "EstimatedSize", estimatedSizeInBytes);
+        String estimatedSize = installData.getVariable(InstallData.ESTIMATED_SIZE);
+        if (estimatedSize != null && !estimatedSize.isEmpty()) 
+        {
+	        long estimatedSizeInBytes = Long.parseLong(estimatedSize);
+	        registry.setValue(keyName, "EstimatedSize", estimatedSizeInBytes);
+        }
         
         // Try to write the uninstaller icon out.
         InputStream in = null;


### PR DESCRIPTION
If found an issue in the tests running with administator rights under Windows that was caused by my previous fix for IZPACK-1686.