### PR TITLE
Allow -auto argument without -defaults-file

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/core/data/AutomatedOverrides.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/data/AutomatedOverrides.java
@@ -1,0 +1,73 @@
+package com.izforge.izpack.core.data;
+
+import com.izforge.izpack.api.data.InstallData;
+import com.izforge.izpack.api.data.Overrides;
+
+import java.io.File;
+import java.io.IOException;
+
+public class AutomatedOverrides implements Overrides
+{
+    private InstallData installData;
+
+    public AutomatedOverrides(InstallData installData)
+    {
+        setInstallData(installData);
+    }
+
+    @Override
+    public String fetch(String name)
+    {
+        if (name.equals(InstallData.INSTALL_PATH))
+        {
+            String installPath = installData.getInstallPath();
+            if (installPath == null)
+            {
+                installPath = installData.getDefaultInstallPath();
+            }
+            return installPath;
+        }
+        return null;
+    }
+
+    @Override
+    public String fetch(String name, String defaultValue)
+    {
+        return null;
+    }
+
+    @Override
+    public boolean containsKey(String name)
+    {
+        return false;
+    }
+
+    @Override
+    public String remove(String name)
+    {
+        return null;
+    }
+
+    @Override
+    public int size()
+    {
+        return 0;
+    }
+
+    @Override
+    public void setInstallData(InstallData installData)
+    {
+        this.installData = installData;
+    }
+
+    @Override
+    public File getFile()
+    {
+        return null;
+    }
+
+    @Override
+    public void load() throws IOException
+    {
+    }
+}

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedPanels.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/automation/AutomatedPanels.java
@@ -23,6 +23,8 @@ package com.izforge.izpack.installer.automation;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.data.AutomatedInstallData;
+import com.izforge.izpack.api.data.Overrides;
+import com.izforge.izpack.core.data.AutomatedOverrides;
 import com.izforge.izpack.installer.panel.AbstractPanels;
 import com.izforge.izpack.installer.panel.Panels;
 
@@ -80,24 +82,27 @@ public class AutomatedPanels extends AbstractPanels<AutomatedPanelView, PanelAut
         }
         else
         {
-        	PanelAutomation view = newPanel.getView();
+            PanelAutomation view = newPanel.getView();
             newPanel.executePreActivationActions();
 
             IXMLElement xml = installData.getInstallationRecordPanelRoot(newPanel.getPanelId());
             if (xml != null)
             {
                 view.runAutomated(installData, xml);
-                installData.getVariables().registerBlockedVariableNames(newPanel.getPanel().getAffectedVariableNames(), newPanel.getPanelId());
-                result = executeValidationActions(newPanel, true);
             }
             else
             {
                 // This cannot happen for auto-install.xml
-                view.processOptions(installData, installData.getVariables().getOverrides());
-                installData.getVariables().registerBlockedVariableNames(newPanel.getPanel().getAffectedVariableNames(), newPanel.getPanelId());
-                result = executeValidationActions(newPanel, true);
+                Overrides overrides = installData.getVariables().getOverrides();
+                if (overrides == null)
+                {
+                    overrides = new AutomatedOverrides(installData);
+                }
+                view.processOptions(installData, overrides);
             }
 
+            installData.getVariables().registerBlockedVariableNames(newPanel.getPanel().getAffectedVariableNames(), newPanel.getPanelId());
+            result = executeValidationActions(newPanel, true);
         }
         return result;
     }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/bootstrap/Installer.java
@@ -227,14 +227,6 @@ public class Installer
             logger.info("Command line arguments: " + StringTool.stringArrayToSpaceSeparatedString(args));
 
             Overrides defaults = getDefaults(defaultsFile);
-            if (type == INSTALLER_AUTO && path == null && defaults == null)
-            {
-                logger.log(Level.SEVERE,
-                        "Unattended installation mode needs either a defaults file specified by '-defaults-file'" +
-                        " or an installation record XML file as argument");
-                System.exit(1);
-            }
-
             launchInstall(type, consoleAction, path, langcode, media, defaults, args);
 
         }


### PR DESCRIPTION
This change allow to use `-auto` argument without providing any `-defaults-file`. 

I'm a new user of IzPack, and the whole purpose of an installer is to build a single file for the package. But I could not run the `-auto` installation without providing an aditionnal `-defaults-file` file. I could not understand this behavior and was really frustrated to discover this limitation after spending some time to learn the framework and build the whole installer, so here's a pull request that I have tested against my installer project.

IzPack is a nice piece of software tough, I wrote again a Swing JPanel 10 years after good old times, thanks for maintaining it.