### PR TITLE
Enable snapshot deployments

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,23 +15,43 @@ jobs:
         jdk: ['8','11']
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.jdk }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.jdk }}
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Build with Maven
-      run: mvn -B -U verify
-    - name: Running Maven GUI tests
-      run: |
-        sudo apt-get install fluxbox
-        export DISPLAY=':99.0'
-        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        fluxbox &> ~/fluxbox.log &
-        mvn -B verify -Pwith-gui-tests
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn -B -U verify
+      - name: Running Maven GUI tests
+        run: |
+          sudo apt-get install fluxbox
+          export DISPLAY=':99.0'
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          fluxbox &> ~/fluxbox.log &
+          mvn -B verify -Pwith-gui-tests
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+          gpg-private-key: "${{ secrets.GPG_SIGNING_KEY }}"
+          overwrite-settings: false
+      - name: Deploy snapshot artifacts
+        run: mvn deploy --settings .github/workflows/settings.xml -DskipTests=true
+        env:
+          USERNAME: ${{ secrets.USERNAME }}
+          PASSWORD: ${{ secrets.PASSWORD }}

--- a/.github/workflows/settings.xml
+++ b/.github/workflows/settings.xml
@@ -1,0 +1,15 @@
+<settings>
+  <servers>
+    <!-- Sonatype Nexus -->
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.USERNAME}</username>
+      <password>${env.PASSWORD}</password>
+    </server>
+    <server>
+      <id>sonatype-nexus-staging</id>
+      <username>${env.USERNAME}</username>
+      <password>${env.PASSWORD}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
Deploys a SNAPSHOT to [Sonatype](https://oss.sonatype.org/content/repositories/snapshots/org/codehaus/izpack/) after each successful build of the `master` branch. 