### PR TITLE
[IZPACK-508] Only append quotes when required

### DIFF
--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelWorker.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/process/ProcessPanelWorker.java
@@ -510,7 +510,12 @@ public class ProcessPanelWorker implements Runnable
             try
             {
                 // keep the file name in quotes as per https://bugs.openjdk.java.net/browse/JDK-8136885
-                params.add("\"" + variables.replace(this.filename) + "\"");
+                String filename = variables.replace(this.filename);
+                if (!(filename.startsWith("\"") && filename.endsWith("\""))) {
+                    params.add("\"" + filename + "\"");
+                } else {
+                    params.add(filename);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This should resolve the following problem on linux (ubuntu) when doing a re-install.

`[ Starting processing ]
Starting process Remove Previously Installed Service (1/1)
I/O error:
java.io.IOException: Cannot run program ""/usr/local/app/uninstall-service.sh"": error=2, No such file or directory`

Note the double quotes in the exception, caused by a recent PR:
 https://github.com/izpack/izpack/pull/749

