### PR TITLE
[IZPACK-1675] IzPack Ant Task fails if a file system path contains whitespace (or any other char not allowed in a URL)

### DIFF
--- a/izpack-tools/src/main/java/com/izforge/izpack/util/FileUtil.java
+++ b/izpack-tools/src/main/java/com/izforge/izpack/util/FileUtil.java
@@ -56,10 +56,19 @@ public class FileUtil
     {
         try
         {
-            URI uri = url.toURI();
-            if ("jar".equals(url.getProtocol()))
+            URI uri;
+            try
             {
-              uri = new URI(url.getPath());
+                uri = url.toURI();
+            }
+            catch (URISyntaxException e)
+            {
+                String escaped = new URI("ignore", url.toString(), null).getRawSchemeSpecificPart();
+                uri = new URI(escaped);
+            }
+            if ("jar".equals(uri.getScheme()))
+            {
+              uri = new URI(uri.getRawSchemeSpecificPart());
             }
             StringBuilder result = new StringBuilder();
             final String host = uri.getHost();
@@ -76,11 +85,7 @@ public class FileUtil
             }
             return result.toString();
         }
-        catch (final URISyntaxException e)
-        {
-            throw new RuntimeException(e);
-        }
-        catch (final UnsupportedEncodingException e)
+        catch (final URISyntaxException | UnsupportedEncodingException e)
         {
             throw new RuntimeException(e);
         }

--- a/izpack-tools/src/test/java/com/izforge/izpack/util/FileUtilTest.java
+++ b/izpack-tools/src/test/java/com/izforge/izpack/util/FileUtilTest.java
@@ -87,4 +87,11 @@ public class FileUtilTest extends AbstractPlatformTest
     URL windowsUrl = new URL("file:C:/somedirectory/somefile.txt");
     assertEquals("C:/somedirectory/somefile.txt", FileUtil.convertUrlToFilePath(windowsUrl));
   }
+
+  @Test
+  public void testSpecialCharacterInURL() throws MalformedURLException
+  {
+    URL windowsUrl = new URL("file:C:/some directory/some file.txt"); // space is special character
+    assertEquals("C:/some directory/some file.txt", FileUtil.convertUrlToFilePath(windowsUrl));
+  }
 }


### PR DESCRIPTION
**Root Cause**: ClassLoader.getResources() method returns URL without escaping special characters (e.g. space).
**Fix**: Use round about way to form URI such that the special characters are escaped, please refer to the code