### PR TITLE
[IZPACK-1605] Or-Condition adds conditions to id maps and leads to duplicate key exception

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -358,6 +358,7 @@ public class CompilerConfig extends Thread
         addPanels(data);
         addListeners(data);
         addPacks(data);
+        resolveConditions(); // this should happen after add packs as it adds "izpack.selected.<pack name>" conditions
         addInstallerRequirement(data);
         checkReferencedConditions();
         checkReferencedPacks();
@@ -3251,17 +3252,21 @@ public class CompilerConfig extends Thread
                                                         + e.getMessage(), e);
                 }
             }
-            try
-            {
-                rules.resolveConditions();
-            }
-            catch (Exception e)
-            {
-                throw new CompilerException("Conditions check failed: "
-                                                    + e.getMessage(), e);
-            }
         }
         notifyCompilerListener("addConditions", CompilerListener.END, data);
+    }
+
+    private void resolveConditions()
+    {
+        try
+        {
+            rules.resolveConditions();
+        }
+        catch (Exception e)
+        {
+            throw new CompilerException("Conditions check failed: "
+                    + e.getMessage(), e);
+        }
     }
 
     /**

--- a/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/RefCondition.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/rules/process/RefCondition.java
@@ -81,6 +81,9 @@ public class RefCondition extends ConditionReference
         {
             return false;
         }
+        if (condition.getInstallData() == null) {
+            condition.setInstallData(this.getInstallData());
+        }
         return condition.isTrue();
     }
 


### PR DESCRIPTION
**Root Cause**: At compile time the condition resolver was called before all the conditions are generated (especially, the pack selection conditions). At runtime, installData was null for referenced conditions and caused null pointer exception.
**Fix**: Moved condition resolver after packs are added. Added installData for referenced conditions if it is not set.