### PR TITLE
IZPACK-1721 Removes IzPack panel dependency

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/installer/ISummarisable.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/installer/ISummarisable.java
@@ -28,7 +28,33 @@ package com.izforge.izpack.api.installer;
  */
 public interface ISummarisable
 {
+    /**
+     * This method will be called to get the summary of this class which should be placed
+     * in the SummaryPanel. The returned text should not contain a caption of this
+     * item. The caption will be requested from the method getCaption. If <code>null</code>
+     * returns, no summary for this panel will be generated. Default behaviour is to return
+     * <code>null</code>.
+     *
+     * @return the summary for this class
+     */
     String getSummaryBody();
 
+    /**
+     * This method will be called to get the caption for this class which should be placed in
+     * the SummaryPanel. If <code>null</code> returns, no summary for this panel will be
+     * generated. Default behaviour is to return the string given by langpack for the
+     * key <code>&lt;current class name>.summaryCaption&gt;</code> if exist, else the string
+     * &quot;summaryCaption.&lt;ClassName&gt;&quot;.
+     *
+     * @return the caption for this class
+     */
     String getSummaryCaption();
+
+    /**
+     * Checks if the panel has been visited during the input process or not. This method allows
+     * the implementer to conditionally show infos within the summary panel.
+     *
+     * @return <code>true</code> if the panel was displayed, <code>false</code> otherwise
+     */
+    boolean isVisited();
 }

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/gui/IzPanel.java
@@ -559,30 +559,12 @@ public abstract class IzPanel extends JPanel implements AbstractUIHandler, Layou
 
     // ------------------- Summary stuff -------------------- START ---
 
-    /**
-     * This method will be called from the SummaryPanel to get the summary of this class which
-     * should be placed in the SummaryPanel. The returned text should not contain a caption of this
-     * item. The caption will be requested from the method getCaption. If <code>null</code>
-     * returns, no summary for this panel will be generated. Default behaviour is to return
-     * <code>null</code>.
-     *
-     * @return the summary for this class
-     */
     @Override
     public String getSummaryBody()
     {
         return null;
     }
 
-    /**
-     * This method will be called from the SummaryPanel to get the caption for this class which
-     * should be placed in the SummaryPanel. If <code>null</code> returns, no summary for this
-     * panel will be generated. Default behaviour is to return the string given by langpack for the
-     * key <code>&lt;current class name>.summaryCaption&gt;</code> if exist, else the string
-     * &quot;summaryCaption.&lt;ClassName&gt;&quot;.
-     *
-     * @return the caption for this class
-     */
     @Override
     public String getSummaryCaption()
     {
@@ -598,6 +580,12 @@ public abstract class IzPanel extends JPanel implements AbstractUIHandler, Layou
         }
 
         return (caption);
+    }
+
+    @Override
+    public boolean isVisited()
+    {
+        return getMetadata().isVisited();
     }
 
     // ------------------- Summary stuff -------------------- END ---

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/util/SummaryProcessor.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/util/SummaryProcessor.java
@@ -23,7 +23,6 @@ package com.izforge.izpack.installer.util;
 
 import com.izforge.izpack.api.installer.ISummarisable;
 import com.izforge.izpack.installer.data.GUIInstallData;
-import com.izforge.izpack.installer.gui.IzPanel;
 
 /**
  * A helper class which creates a summary from all panels. This class calls all declared panels for
@@ -74,7 +73,7 @@ public class SummaryProcessor
         buffer.append(HTML_HEADER);
         for (ISummarisable panel : idata.getPanels())
         {
-            if (((IzPanel) panel).getMetadata().isVisited())
+            if (panel.isVisited())
             {
                 String caption = panel.getSummaryCaption();
                 String msg = panel.getSummaryBody();


### PR DESCRIPTION
Extended ISummarisable intrface in order to remove the down cast from
IzPanel in order to get the visited status. This allows for other panel
implementations and more easy testing.

Signed-off-by: Patrick Reinhart <patrick@reini.net>