### PR TITLE
IZPACK-1727, IZPACK-1728 and IZPACK-1729

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/GuiId.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/GuiId.java
@@ -26,7 +26,7 @@ public enum GuiId
 {
 
     BUTTON_NEXT("nextButton"), BUTTON_HELP("HelpButton"), BUTTON_PREV("prevButton"), BUTTON_QUIT("quitButton"),
-    BUTTON_LANG_OK("okButtonLang"), COMBO_BOX_LANG_FLAG("comboBox-lang-flag"), DIALOG_PICKER("dialogPicker"), LICENCE_NO_RADIO("LicenceNoRadio"), LICENCE_YES_RADIO("LicenceYesRadio"), FINISH_PANEL_AUTO_BUTTON("finishPanel_autoButton"), FINISH_PANEL_FILE_CHOOSER("finishPanelFileChooser"), LICENCE_TEXT_AREA("licenceTextArea"), INFO_PANEL_TEXT_AREA("InfoPanelTextArea"), SHORTCUT_CREATE_CHECK_BOX("shortcutCreateCheckBox"), HTML_INFO_PANEL_TEXT("htmlInfoPanelText"), SIMPLE_FINISH_LABEL("simpleFinishLabel"), FINISH_PANEL_LABEL("finishLabel"), HELLO_PANEL_LABEL("helloPanelLabel"), SIMPLE_FINISH_UNINSTALL_LABEL("simpleFinishUninstallLabel"),
+    BUTTON_LANG_OK("okButtonLang"), COMBO_BOX_LANG_FLAG("comboBox-lang-flag"), DIALOG_PICKER("dialogPicker"), LICENCE_NO_RADIO("LicenceNoRadio"), LICENCE_YES_RADIO("LicenceYesRadio"), FINISH_PANEL_AUTO_BUTTON("finishPanel_autoButton"), FINISH_PANEL_FILE_CHOOSER("finishPanelFileChooser"), LICENCE_TEXT_AREA("licenceTextArea"), INFO_PANEL_TEXT_AREA("InfoPanelTextArea"), XINFO_PANEL_TEXT_AREA("XInfoPanelTextArea"), SHORTCUT_CREATE_CHECK_BOX("shortcutCreateCheckBox"), HTML_INFO_PANEL_TEXT("htmlInfoPanelText"), SIMPLE_FINISH_LABEL("simpleFinishLabel"), FINISH_PANEL_LABEL("finishLabel"), HELLO_PANEL_LABEL("helloPanelLabel"), SIMPLE_FINISH_UNINSTALL_LABEL("simpleFinishUninstallLabel"),
     HELP_WINDOWS("helpWindows"), BUTTON_BROWSE("browseButton"), TARGET_PANEL_FILE_CHOOSER("targetPanelFileChooser");
 
     public String id;

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
@@ -77,7 +77,9 @@ public abstract class AbstractTextConsolePanel extends AbstractConsolePanel
         printHeadLine(installData, console);
 
         String text = getText();
-        text = installData.getVariables().replace(text);
+        if (substituteVariables()) {
+            text = installData.getVariables().replace(text);
+        }
         if (text != null)
         {
             Panel panel = getPanel();
@@ -107,6 +109,15 @@ public abstract class AbstractTextConsolePanel extends AbstractConsolePanel
      * @return the text. A <tt>null</tt> indicates failure
      */
     protected abstract String getText();
+
+    /**
+     * Returns true if variables are to be substituted in the text or else false.
+     *
+     * @return true, the default implementation
+     */
+    protected boolean substituteVariables() {
+        return true;
+    }
 
     /**
      * Helper to strip HTML from text.

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PanelHelper.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/util/PanelHelper.java
@@ -223,11 +223,22 @@ public class PanelHelper
                 key -> resources.getString(key, null) != null);
     }
 
-    private static String getPanelSpecificKey(Panel panel, String defaultSuffix, Predicate<String> predicate)
-    {
+    /**
+     * Returns panel name for the specified panel.
+     *
+     * @param panel  the panel
+     * @return the panel name.
+     */
+    public static String getPanelName(Panel panel) {
         String className = panel.getClassName();
         String panelName = className.substring(className.lastIndexOf('.') + 1);
         panelName = panelName.replaceAll("Console", "");
+        return panelName;
+    }
+
+    private static String getPanelSpecificKey(Panel panel, String defaultSuffix, Predicate<String> predicate)
+    {
+        String panelName = getPanelName(panel);
         String panelId = panel.getPanelId();
         if (panelId != null)
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/info/InfoConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/info/InfoConsolePanel.java
@@ -22,28 +22,17 @@
 package com.izforge.izpack.panels.info;
 
 import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.installer.console.AbstractTextConsolePanel;
 import com.izforge.izpack.installer.console.ConsolePanel;
 import com.izforge.izpack.installer.panel.PanelView;
-import com.izforge.izpack.installer.util.PanelHelper;
+import com.izforge.izpack.panels.xinfo.XInfoConsolePanel;
 
 /**
  * Console implementation of {@link InfoPanel}.
  *
  * @author Tim Anderson
  */
-public class InfoConsolePanel extends AbstractTextConsolePanel
+public class InfoConsolePanel extends XInfoConsolePanel
 {
-    /**
-     * The resources.
-     */
-    private final Resources resources;
-
-    /**
-     * Resource name for panel content.
-     */
-    private final String panelResourceName;
-
     /**
      * Constructs an <tt>InfoConsolePanel</tt>.
      *
@@ -52,19 +41,16 @@ public class InfoConsolePanel extends AbstractTextConsolePanel
      */
     public InfoConsolePanel(Resources resources, PanelView<ConsolePanel> panel)
     {
-        super(panel);
-        this.resources = resources;
-        panelResourceName = PanelHelper.getPanelResourceName(panel.getPanel(), "info", resources);
+        super(resources, panel);
     }
 
     /**
-     * Returns the text to display.
+     * Returns true if variables are to be substituted in the text or else false.
      *
-     * @return the text
+     * @return false, in InfoPanel we don't want variable substitution
      */
     @Override
-    protected String getText()
-    {
-        return resources.getString(panelResourceName, "Error : could not load the info text!");
+    protected boolean substituteVariables() {
+        return false;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/info/InfoPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/info/InfoPanel.java
@@ -19,38 +19,21 @@
 
 package com.izforge.izpack.panels.info;
 
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-
-import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Resources;
-import com.izforge.izpack.gui.IzPanelLayout;
-import com.izforge.izpack.gui.LabelFactory;
 import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
-import com.izforge.izpack.installer.gui.IzPanel;
-import com.izforge.izpack.installer.util.PanelHelper;
+import com.izforge.izpack.panels.xinfo.XInfoPanel;
 
 /**
- * The info panel class. Displays some raw-text informations.
+ * The info panel class. Displays some raw-text information.
  *
  * @author Julien Ponge
  */
-public class InfoPanel extends IzPanel
+public class InfoPanel extends XInfoPanel
 {
     private static final long serialVersionUID = 3833748780590905399L;
-
-    /**
-     * Resource name for panel content.
-     */
-    private final String panelResourceName;
-
-    /**
-     * The info string.
-     */
-    private String info;
 
     /**
      * Constructs an <tt>InfoPanel</tt>.
@@ -63,39 +46,16 @@ public class InfoPanel extends IzPanel
      */
     public InfoPanel(Panel panel, InstallerFrame parent, GUIInstallData installData, Resources resources, Log log)
     {
-        super(panel, parent, installData, new IzPanelLayout(log), resources);
-        panelResourceName = PanelHelper.getPanelResourceName(panel, "info", resources);
-        // We load the text.
-        loadInfo();
-        // The info label.
-        add(LabelFactory.create(getString(panelResourceName), parent.getIcons().get("edit"), LEADING), NEXT_LINE);
-        // The text area which shows the info.
-        JTextArea textArea = new JTextArea(info);
-        textArea.setName(GuiId.INFO_PANEL_TEXT_AREA.id);
-        textArea.setCaretPosition(0);
-        textArea.setEditable(false);
-        JScrollPane scroller = new JScrollPane(textArea);
-        add(scroller, NEXT_LINE);
-        // At end of layouting we should call the completeLayout method also they do nothing.
-        getLayoutHelper().completeLayout();
+        super(panel, parent, installData, resources, log);
     }
 
     /**
-     * Loads the info text.
-     */
-    private void loadInfo()
-    {
-        String defaultValue = "Error : could not load the info text !";
-        info = getResources().getString(panelResourceName, defaultValue);
-    }
-
-    /**
-     * Indicates wether the panel has been validated or not.
+     * Returns true if variables are to be substituted in the text or else false.
      *
-     * @return Always true.
+     * @return false, in InfoPanel we don't want variable substitution
      */
-    public boolean isValidated()
-    {
-        return true;
+    @Override
+    protected boolean substituteVariables() {
+        return false;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/xinfo/XInfoPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/xinfo/XInfoPanel.java
@@ -21,23 +21,20 @@
 
 package com.izforge.izpack.panels.xinfo;
 
-import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-
-import javax.swing.JLabel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-
+import com.izforge.izpack.api.GuiId;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Resources;
+import com.izforge.izpack.gui.IzPanelLayout;
 import com.izforge.izpack.gui.LabelFactory;
+import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
 import com.izforge.izpack.installer.gui.IzPanel;
-import com.izforge.izpack.installer.gui.LayoutHelper;
 import com.izforge.izpack.installer.util.PanelHelper;
+
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import java.awt.Font;
 
 /**
  * The XInfo panel class - shows some adaptative text (ie by parsing for some variables.
@@ -59,71 +56,50 @@ public class XInfoPanel extends IzPanel
     private JTextArea textArea;
 
     /**
-     * The info to display.
-     */
-    private String info;
-
-    /**
      * The constructor.
      *
      * @param panel       the panel meta-data
      * @param parent      the parent IzPack installer frame
      * @param installData the installation data
      * @param resources   the resources
+     * @param log         the log
      */
-    public XInfoPanel(Panel panel, InstallerFrame parent, GUIInstallData installData, Resources resources)
+    public XInfoPanel(Panel panel, InstallerFrame parent, GUIInstallData installData, Resources resources, Log log)
     {
-        super(panel, parent, installData, resources);
+        super(panel, parent, installData, new IzPanelLayout(log), resources);
         panelResourceName = PanelHelper.getPanelResourceName(panel, "info", resources);
+        String panelName = PanelHelper.getPanelName(panel);
 
-        // We initialize our layout
-        GridBagLayout layout = new GridBagLayout();
-        GridBagConstraints gbConstraints = new GridBagConstraints();
-        setLayout(layout);
-
-        // We add the components
-
-        JLabel infoLabel = LabelFactory.create(getString(panelResourceName),
-                                               parent.getIcons().get("edit"), LEADING);
-        LayoutHelper.buildConstraints(gbConstraints, 0, 0, 1, 1, 1.0, 0.0);
-        gbConstraints.insets = new Insets(5, 5, 5, 5);
-        gbConstraints.fill = GridBagConstraints.BOTH;
-        gbConstraints.anchor = GridBagConstraints.SOUTHWEST;
-        layout.addLayoutComponent(infoLabel, gbConstraints);
-        add(infoLabel);
-
+        // The info label.
+        add(LabelFactory.create(getString(panelResourceName), parent.getIcons().get("edit"), LEADING), NEXT_LINE);
+        // The text area which shows the info.
         textArea = new JTextArea();
+        textArea.setName(panelName.equals("XInfoPanel") ? GuiId.XINFO_PANEL_TEXT_AREA.id : GuiId.INFO_PANEL_TEXT_AREA.id);
+        textArea.setCaretPosition(0);
         textArea.setEditable(false);
-
-        String textAreaFont = installData.getVariable("XInfoPanel.font");
+        String textAreaFont = installData.getVariable(panelName + ".font");
         if (textAreaFont != null && textAreaFont.length() > 0)
         {
             Font font = Font.decode(textAreaFont);
             textArea.setFont(font);
         }
-
         JScrollPane scroller = new JScrollPane(textArea);
-        LayoutHelper.buildConstraints(gbConstraints, 0, 1, 1, 1, 1.0, 0.9);
-        gbConstraints.anchor = GridBagConstraints.CENTER;
-        layout.addLayoutComponent(scroller, gbConstraints);
-        add(scroller);
+        add(scroller, NEXT_LINE);
+        // At end of layouting we should call the completeLayout method also they do nothing.
+        getLayoutHelper().completeLayout();
     }
 
     /**
      * Loads the info text.
      */
-    private void loadInfo()
+    private String getInfoText()
     {
-        info = getResources().getString(panelResourceName, null, "Error : could not load the info text !");
-    }
-
-    /**
-     * Parses the text for special variables.
-     */
-    private void parseText()
-    {
-        // Parses the info text
-        info = installData.getVariables().replace(info);
+        String infoText = getResources().getString(panelResourceName, null, "Error : could not load the infoText text !");
+        if (substituteVariables()) {
+            // Parses the infoText text and substitute variables
+            infoText = installData.getVariables().replace(infoText);
+        }
+        return infoText;
     }
 
     /**
@@ -131,22 +107,26 @@ public class XInfoPanel extends IzPanel
      */
     public void panelActivate()
     {
-        // Text handling
-        loadInfo();
-        parseText();
-
-        // UI handling
-        textArea.setText(info);
+        textArea.setText(getInfoText());
         textArea.setCaretPosition(0);
     }
 
     /**
-     * Indicates wether the panel has been validated or not.
+     * Indicates whether the panel has been validated or not.
      *
      * @return Always true.
      */
     public boolean isValidated()
     {
+        return true;
+    }
+
+    /**
+     * Returns true if variables are to be substituted in the text or else false.
+     *
+     * @return true, the default implementation
+     */
+    protected boolean substituteVariables() {
         return true;
     }
 }

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/xinfo/XInfoPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/xinfo/XInfoPanel.java
@@ -84,7 +84,7 @@ public class XInfoPanel extends IzPanel
         // We add the components
 
         JLabel infoLabel = LabelFactory.create(getString(panelResourceName),
-                                               parent.getIcons().get("edit"), JLabel.TRAILING);
+                                               parent.getIcons().get("edit"), LEADING);
         LayoutHelper.buildConstraints(gbConstraints, 0, 0, 1, 1, 1.0, 0.0);
         gbConstraints.insets = new Insets(5, 5, 5, 5);
         gbConstraints.fill = GridBagConstraints.BOTH;


### PR DESCRIPTION
[IZPACK-1727] Variable substitution happens for InfoPanel in console mode
[IZPACK-1728] XInfoPanel title is aligned right instead of left
[IZPACK-1729] Support InfoPanel.font variable similar to XInfoPanel.font

[IZPACK-1727]: https://izpack.atlassian.net/browse/IZPACK-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IZPACK-1728]: https://izpack.atlassian.net/browse/IZPACK-1728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IZPACK-1729]: https://izpack.atlassian.net/browse/IZPACK-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ