### PR TITLE
Cleanup version definition & adds filter exclusion

### DIFF
--- a/izpack-compiler/pom.xml
+++ b/izpack-compiler/pom.xml
@@ -131,8 +131,8 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>copy-test-resources</id>

--- a/izpack-dist/pom.xml
+++ b/izpack-dist/pom.xml
@@ -50,10 +50,6 @@
                 <filtering>true</filtering>
             </resource>
             <resource>
-                <directory>src/main/schema</directory>
-                <filtering>true</filtering>
-            </resource>
-            <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
             </resource>
@@ -61,6 +57,11 @@
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <nonFilteredFileExtensions>
+                        <nonFilteredFileExtension>jar</nonFilteredFileExtension>
+                    </nonFilteredFileExtensions>
+                </configuration>
                 <executions>
                     <execution>
                         <id>copy-izpack-resource</id>


### PR DESCRIPTION
- removed no longer existing schemal resource folder
- use plugins managed version
- prepare for maven resource plugin update (needs [plugin fix](https://issues.apache.org/jira/browse/MRESOURCES-301))