### PR TITLE
IZPACK-1679: Add support for <javaversion>11</javaversion> (#728)

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/Compiler.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/Compiler.java
@@ -443,9 +443,15 @@ public class Compiler extends Thread
         }
         dis.readUnsignedShort();
         int major = dis.readUnsignedShort();
-        String[] splitMinimalVersion = minimalJavaVersion.split("\\.");
         setJavaVersionExpected(major);
-        if (major > (44 + Integer.parseInt(splitMinimalVersion[1])))
+        String[] splitMinimalVersion = minimalJavaVersion.split("\\.");
+        int minimalVersion = Integer.parseInt(splitMinimalVersion[0]);
+        if (minimalVersion < 10 && splitMinimalVersion.length > 1) 
+        {
+        	minimalVersion = Integer.parseInt(splitMinimalVersion[1]);
+        }
+        
+        if (major > (44 + minimalVersion) )
         {
             setJavaVersionCorrect(false);
         }

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/CompilerConfigSamplesTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/CompilerConfigSamplesTest.java
@@ -88,5 +88,15 @@ public class CompilerConfigSamplesTest
                 "resources/Splash.image"));
     }
 
-
+    @Test
+    @InstallFile("samples/izpack-jdk11-min.xml")
+    public void installerShouldContainInstallerJdk11() throws Exception
+    {
+        compilerConfig.executeCompiler();
+        jar = testContainer.getComponent(JarFile.class);
+        assertThat((ZipFile)jar, ZipMatcher.isZipContainingFiles(
+                "com/izforge/izpack/panels/checkedhello/CheckedHelloPanel.class",
+                "resources/vars",
+                "com/izforge/izpack/img/JFrameIcon.png"));
+    }
 }

--- a/izpack-compiler/src/test/resources/samples/izpack-jdk11-min.xml
+++ b/izpack-compiler/src/test/resources/samples/izpack-jdk11-min.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+
+    <!-- The info section -->
+    <info>
+        <appname>IzPack-JDK11-Test</appname>
+        <appversion>${project.version}</appversion>
+        <authors>
+            <author email="" name="Julien Ponge (project founder)"/>
+            <author email="" name="The fantastic IzPack developers and contributors"/>
+        </authors>
+        <url>http://izpack.org/</url>
+        <javaversion>11</javaversion>
+        <requiresjdk>no</requiresjdk>
+        <!--><pack200/>-->
+        <run-privileged condition="izpack.windowsinstall.vista|izpack.windowsinstall.7"/>
+        <summarylogfilepath>$INSTALL_PATH/installinfo/Summary.htm</summarylogfilepath>
+    </info>
+
+    <variables>
+        <variable name="DesktopShortcutCheckboxEnabled" value="true"/>
+        <variable name="ApplicationShortcutPath" value="ApplicationShortcuts"/>
+    </variables>
+
+    <!-- Flexible and in the screen proportions -->
+    <guiprefs height="700" resizable="yes" width="870">
+        <!-- GUI addaption for more informations see "Modifying the GUI" in the documentation -->
+        <modifier key="layoutAnchor" value="CENTER"/>
+        <modifier key="headingPanelCounter" value="progressbar"/>
+        <modifier key="headingPanelCounterPos" value="inNavigationPanel"/>
+        <modifier key="allYGap" value="4"/>
+        <modifier key="paragraphYGap" value="10"/>
+        <modifier key="filler1YGap" value="5"/>
+        <modifier key="filler3XGap" value="10"/>
+    </guiprefs>
+
+    <!-- We include some langpack -->
+    <locale>
+        <langpack iso3="eng"/>
+        <langpack iso3="fra"/>
+        <langpack iso3="deu"/>
+        <langpack iso3="ita"/>
+    </locale>
+
+    <!-- The listeners section for CustomActions -->
+    <listeners>
+        <listener classname="SummaryLoggerInstallerListener" stage="install"/>
+        <listener classname="RegistryInstallerListener" stage="install">
+            <os family="windows"/>
+        </listener>
+        <listener classname="RegistryUninstallerListener" stage="uninstall">
+            <os family="windows"/>
+        </listener>
+    </listeners>
+
+    <!-- The panels in a classic order -->
+    <panels>
+        <panel classname="CheckedHelloPanel" id="hellopanel"/>
+        <panel classname="HTMLInfoPanel" id="infopanel" encoding="ISO-8859-1"/>
+        <panel classname="HTMLLicencePanel" id="licensepanel"/>
+        <panel classname="TargetPanel" id="targetpanel"/>
+        <panel classname="PacksPanel" id="packspanel"/>
+        <panel classname="SummaryPanel" id="summarypanel"/>
+        <panel classname="InstallPanel" id="installpanel"/>
+        <panel classname="ShortcutPanel" id="shortcutpanel"/>
+        <panel classname="FinishPanel" id="finishpanel"/>
+    </panels>
+
+    <!-- The packs section -->
+    <packs>
+
+        <!-- The core files -->
+        <pack name="Core" required="yes">
+            <description>The IzPack core files.</description>
+        </pack>
+    </packs>
+</izpack:installation>


### PR DESCRIPTION
Overtake changes for java 11 support into 5.1-branch
(cherry picked from commit ec54df009605d9455327f506cd3a145b4d99bc29)