### PR TITLE
IZPACK-1747 Enable refPackSet to resolving packDir if refFile is absolute

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/CompilerConfig.java
@@ -999,7 +999,12 @@ public class CompilerConfig extends Thread
                 for (String file : files)
                 {
                     File refFile = new File(dir, file);
-                    File packDir = new File(baseDir, refFile.getParent());
+                    File packDir;
+                    if (refFile.isAbsolute()) {
+                        packDir = refFile.getParentFile();
+                    } else {
+                        packDir = new File(baseDir, refFile.getParent());
+                    }
 
                     // parsing ref-pack-set file
                     IXMLElement refXMLData = this.readRefPackData(packDir, refFile.getName(), false);

--- a/izpack-compiler/src/test/java/com/izforge/izpack/compiler/CompilerConfigSamplesTest.java
+++ b/izpack-compiler/src/test/java/com/izforge/izpack/compiler/CompilerConfigSamplesTest.java
@@ -76,6 +76,17 @@ public class CompilerConfigSamplesTest
                 "com/sora/panel/VimPanel.class",
                 "resource/32/help-browser.png"))));
     }
+    @Test
+    @InstallFile("samples/refpackset/izpack.xml")
+    public void installerShouldResolveRefPackSetCorrectly() throws Exception
+    {
+        compilerConfig.executeCompiler();
+        jar = testContainer.getComponent(JarFile.class);
+        assertThat((ZipFile)jar, ZipMatcher.isZipContainingFiles(
+                "com/izforge/izpack/panels/checkedhello/CheckedHelloPanel.class",
+                "resources/vars",
+                "com/izforge/izpack/img/JFrameIcon.png"));
+    }
 
 
     @Test

--- a/izpack-compiler/src/test/resources/samples/refpackincludes/izpack-module.xml
+++ b/izpack-compiler/src/test/resources/samples/refpackincludes/izpack-module.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- Template! Properties werden beim Umkopieren durch Mavens Resources-Plugin expandiert. -->
+<!-- Pro Installationsprofil wird ein solches XML-File instantiiert. Einzubinden in die globale IzPack-Konfiguration mittels <refpackset> . -->
+<izpack:installation version="5.0"
+                     xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+
+    <info>
+	<appname>IZPACK</appname>
+	<appversion>${project.version}</appversion>
+    </info>
+
+    <!-- We include every langpack -->
+    <locale>
+        <langpack iso3="eng"/>
+        <langpack iso3="fra"/>
+        <langpack iso3="deu"/>
+        <langpack iso3="ita"/>
+        <langpack iso3="jpn"/>
+        <langpack iso3="spa"/>
+        <langpack iso3="dan"/>
+        <langpack iso3="ell"/>
+        <langpack iso3="cat"/>
+        <langpack iso3="nld"/>
+        <langpack iso3="fin"/>
+        <langpack iso3="swe"/>
+        <langpack iso3="bra"/>
+        <langpack iso3="pol"/>
+        <langpack iso3="rus"/>
+        <langpack iso3="ukr"/>
+        <langpack iso3="hun"/>
+        <langpack iso3="slk"/>
+        <langpack iso3="ron"/>
+        <langpack iso3="msa"/>
+        <langpack iso3="nor"/>
+        <langpack iso3="chn"/>
+        <langpack iso3="srp"/>
+        <langpack iso3="ces"/>
+        <langpack iso3="kor"/>
+        <langpack iso3="glg"/>
+    </locale>
+
+    <panels>
+	<panel classname="" />
+    </panels>
+
+    <packs >
+        <pack name="refpackinclude" required="false">
+	    	<description>Pack for include test</description>
+        </pack>
+    </packs>
+</izpack:installation>

--- a/izpack-compiler/src/test/resources/samples/refpackset/izpack.xml
+++ b/izpack-compiler/src/test/resources/samples/refpackset/izpack.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<izpack:installation version="5.0" xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
+
+    <!-- The info section -->
+    <info>
+        <appname>IzPack</appname>
+        <appversion>${project.version}</appversion>
+        <authors>
+            <author email="" name="Julien Ponge (project founder)"/>
+            <author email="" name="The fantastic IzPack developers and contributors"/>
+        </authors>
+        <url>http://izpack.org/</url>
+        <javaversion>1.5</javaversion>
+        <requiresjdk>no</requiresjdk>
+        <!--><pack200/>-->
+        <run-privileged condition="izpack.windowsinstall.vista|izpack.windowsinstall.7"/>
+        <summarylogfilepath>$INSTALL_PATH/installinfo/Summary.htm</summarylogfilepath>
+    </info>
+
+    <variables>
+        <variable name="DesktopShortcutCheckboxEnabled" value="true"/>
+        <variable name="ApplicationShortcutPath" value="ApplicationShortcuts"/>
+    </variables>
+
+    <!-- Flexible and in the screen proportions -->
+    <guiprefs height="700" resizable="yes" width="870">
+        <!-- GUI addaption for more informations see "Modifying the GUI" in the documentation -->
+        <modifier key="layoutAnchor" value="CENTER"/>
+        <modifier key="headingPanelCounter" value="progressbar"/>
+        <modifier key="headingPanelCounterPos" value="inNavigationPanel"/>
+        <modifier key="allYGap" value="4"/>
+        <modifier key="paragraphYGap" value="10"/>
+        <modifier key="filler1YGap" value="5"/>
+        <modifier key="filler3XGap" value="10"/>
+    </guiprefs>
+
+    <!-- We include every langpack -->
+    <locale>
+        <langpack iso3="eng"/>
+        <langpack iso3="fra"/>
+        <langpack iso3="deu"/>
+        <langpack iso3="ita"/>
+        <langpack iso3="jpn"/>
+        <langpack iso3="spa"/>
+        <langpack iso3="dan"/>
+        <langpack iso3="ell"/>
+        <langpack iso3="cat"/>
+        <langpack iso3="nld"/>
+        <langpack iso3="fin"/>
+        <langpack iso3="swe"/>
+        <langpack iso3="bra"/>
+        <langpack iso3="pol"/>
+        <langpack iso3="rus"/>
+        <langpack iso3="ukr"/>
+        <langpack iso3="hun"/>
+        <langpack iso3="slk"/>
+        <langpack iso3="ron"/>
+        <langpack iso3="msa"/>
+        <langpack iso3="nor"/>
+        <langpack iso3="chn"/>
+        <langpack iso3="srp"/>
+        <langpack iso3="ces"/>
+        <langpack iso3="kor"/>
+        <langpack iso3="glg"/>
+    </locale>
+
+    <!-- The listeners section for CustomActions -->
+    <listeners>
+        <listener classname="SummaryLoggerInstallerListener" stage="install"/>
+        <listener classname="RegistryInstallerListener" stage="install">
+            <os family="windows"/>
+        </listener>
+        <listener classname="RegistryUninstallerListener" stage="uninstall">
+            <os family="windows"/>
+        </listener>
+    </listeners>
+
+    <!-- The panels in a classic order -->
+    <panels>
+        <panel classname="CheckedHelloPanel" id="hellopanel"/>
+        <panel classname="HTMLInfoPanel" id="infopanel" encoding="ISO-8859-1"/>
+        <panel classname="HTMLLicencePanel" id="licensepanel"/>
+        <panel classname="TargetPanel" id="targetpanel"/>
+        <panel classname="PacksPanel" id="packspanel"/>
+        <panel classname="SummaryPanel" id="summarypanel"/>
+        <panel classname="InstallPanel" id="installpanel"/>
+        <panel classname="ShortcutPanel" id="shortcutpanel"/>
+        <panel classname="FinishPanel" id="finishpanel"/>
+    </panels>
+
+    <!-- The packs section -->
+    <packs>
+
+        <!-- The core files -->
+        <pack name="Core" required="yes">
+            <description>The IzPack core files.</description>
+        </pack>
+        <refpackset dir="../refpackincludes" includes="*.xml" />
+    </packs>
+</izpack:installation>


### PR DESCRIPTION
 Using refPackSet causes trouble when resolving packDir if refFile is absolute. In this case two absolute paths are combined, leading to "Invalid file" exception.

With this pull request absolute and relative paths are handled.

Testcase and test installer files prove the change. Running the testcase on current master will lead to:

`com.izforge.izpack.api.exception.CompilerException: Invalid file: D:\projects\izpack\izpack-compiler\target\test-classes\samples\refpackset\D:\projects\izpack\izpack-compiler\target\test-classes\samples\refpackset\..\refpackincludes\izpack-module.xml while processing refpackset refpackset
        at com.izforge.izpack.compiler.CompilerConfig.addPacksSingle(CompilerConfig.java:1018)
        at com.izforge.izpack.compiler.CompilerConfig.addPacks(CompilerConfig.java:771)
        at com.izforge.izpack.compiler.CompilerConfig.executeCompiler(CompilerConfig.java:360)
        at com.izforge.izpack.compiler.CompilerConfigSamplesTest.installerShouldResolveRefPackSetCorrectly(CompilerConfigSamplesTest.java:83)
`

For sure, path on your machine will be differnt.