### PR TITLE
[IZPACK-1751] Fixes 'inconsistent archive'

### DIFF
--- a/izpack-compiler/src/main/java/com/izforge/izpack/compiler/container/provider/JarOutputStreamProvider.java
+++ b/izpack-compiler/src/main/java/com/izforge/izpack/compiler/container/provider/JarOutputStreamProvider.java
@@ -20,13 +20,14 @@
 package com.izforge.izpack.compiler.container.provider;
 
 import com.izforge.izpack.compiler.data.CompilerData;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.picocontainer.injectors.Provider;
 
-import java.io.File;
-import java.io.FileOutputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.jar.JarOutputStream;
 import java.util.zip.Deflater;
 
@@ -37,35 +38,30 @@ import java.util.zip.Deflater;
  */
 public class JarOutputStreamProvider implements Provider
 {
-
     public JarOutputStream provide(CompilerData compilerData)
     {
-        File file = new File(compilerData.getOutput());
-        JarOutputStream jarOutputStream = null;
-        FileOutputStream fileOutputStream = null;
-        FileUtils.deleteQuietly(file);
         try
         {
+            final Path file = Paths.get(compilerData.getOutput());
             if (compilerData.isMkdirs())
             {
-                FileUtils.forceMkdirParent(file);
+                Files.createDirectories(file.getParent());
             }
-            fileOutputStream = new FileOutputStream(file);
-            jarOutputStream = new JarOutputStream(fileOutputStream);
+            JarOutputStream jarOutputStream =  new JarOutputStream(new BufferedOutputStream(Files.newOutputStream(file)));
             int level = compilerData.getComprLevel();
             if (level >= 0 && level < 10)
             {
                 jarOutputStream.setLevel(level);
-            } else
+            }
+            else
             {
                 jarOutputStream.setLevel(Deflater.BEST_COMPRESSION);
             }
+            return jarOutputStream;
         }
         catch (IOException e)
         {
-            IOUtils.closeQuietly(fileOutputStream);
+            throw new IllegalStateException(e);
         }
-
-        return jarOutputStream;
     }
 }


### PR DESCRIPTION
- Properly closing the JarInputStream after installer creation
- Using diamond operators
- Use of NIO instead old File