### PR TITLE
[IZPACK-1754] & [IZPACK-1755]

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bgr.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bgr.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Прочетете внимателно следната информация:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Моля, прочетете внимателно следното лицензионно споразумение:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Инсталирай този пакет"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Пакетна снимка:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Прочетете внимателно следната информация: "/>
+    <str id="InfoPanel.info" txt="Прочетете внимателно следната информация:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt=" "/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Бележка: Засивените пакети са задължителни."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Моля, прочетете внимателно следното лицензионно споразумение:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Изберете принтер за първоначално използване и тестване."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Това ще деинсталира инсталираното приложение!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Прочетете внимателно следната информация:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Съжеляваме на IzPack не поддържа създаването на преки пътища за тази операционна система. За да създаването на преки пътища се консултирайте с ръководството на вашата операционна система."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Por favor, leia a seguinte informação:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Por favor, leia o seguinte contrato de licença:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Instalar este pacote"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Visualização da tela do pacote  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Por favor, leia a seguinte informação :"/>
+    <str id="InfoPanel.info" txt="Por favor, leia a seguinte informação:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Nada]"/>
@@ -183,7 +183,7 @@
 
     <!-- LicencePanel strings -->
     <str id="LicencePanel.agree" txt="Eu concordo com este contrato de licença."/>
-    <str id="LicencePanel.info" txt="Por favor, leia o seguinte contrato de licença :"/>
+    <str id="LicencePanel.info" txt="Por favor, leia o seguinte contrato de licença:"/>
     <str id="LicencePanel.no" txt="Não"/>
     <str id="LicencePanel.notagree" txt="Eu não concordo com este contrato de licença."/>
     <str id="LicencePanel.yes" txt="Sim"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Nota: pacotes cinzas são requeridos."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Por favor, leia o seguinte contrato de licença:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Selecione a impressora para utilizar na configuração inicial e teste."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Isto removerá o(s) aplicativo(s) instalado(s) !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Por favor, leia a seguinte informação:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Desculpe, mas IzPack não pode criar atalhos neste sistema operacional. Para criar os atalhos, favor consultar o manual de seu sistema operacional."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/cat.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/cat.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Si us plau, llegiu la següent informació:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Si us plau, llegiu atentament el conveni de la llicència:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Instal.lar aquest paquet"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Nota: els paquets en gris no són opcionals."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Si us plau, llegiu atentament el conveni de la llicència:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Això eliminarà l'aplicació instal.lada!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Si us plau, llegiu la següent informació:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Ho sentim, IzPack no pot crear accessos directes en aquest sistema operatiu. Per crear-los, si us plau consulti el seu manual del sistema operatiu."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Prečtěte si nasledující informace:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Pozorně si prečetěte následující licenční podmínky:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Instalovat tento balík"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Náhled balíku  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Prečtěte si nasledující informace :"/>
+    <str id="InfoPanel.info" txt="Prečtěte si nasledující informace:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Nic]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Poznámka: zašeděné balíky jsou vyžadované."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Pozorně si prečetěte následující licenční podmínky:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Tato operace odstraní nainstalovanou aplikaci !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Prečtěte si nasledující informace:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Litujeme, ale IzPack nepodporuje vytvoření zástupců pro tento operační systém. Vytvořit zástupce musíte sami."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/chn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/chn.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="请阅读以下信息:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="请仔细阅读以下许可协议:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" 安装该包"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="包快照  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="请阅读以下信息 :"/>
+    <str id="InfoPanel.info" txt="请阅读以下信息:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Nothing]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="注意: 灰色选项是必选的."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="请仔细阅读以下许可协议:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="将卸载已安装的应用程序 !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="请阅读以下信息:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="很遗憾IzPack不支持在当前操作系统上创建快捷方式. 创建快捷方式，请参考操作系统手册."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/dan.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/dan.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Læs venligst den følgende information:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Læs venligst følgende licensaftale omhyggeligt:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Installer denne pakke"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Pakke øjebliksbillede  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Læs venligst den følgende information :"/>
+    <str id="InfoPanel.info" txt="Læs venligst den følgende information:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Ingenting]"/>
@@ -183,7 +183,7 @@
 
     <!-- LicencePanel strings -->
     <str id="LicencePanel.agree" txt="Jeg accepterer vilkårene i licensaftalen."/>
-    <str id="LicencePanel.info" txt="LÃ?s venligst den følgende licensaftale:"/>
+    <str id="LicencePanel.info" txt="Læs venligst følgende licensaftale omhyggeligt:"/>
     <str id="LicencePanel.no" txt="Nej"/>
     <str id="LicencePanel.notagree" txt="Jeg accepterer IKKE vilkårene i licensaftalen."/>
     <str id="LicencePanel.yes" txt="Ja"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="OBS: grå pakker skal installeres."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Læs venligst følgende licensaftale omhyggeligt:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Dette vil fjerne installerede applikationer !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Læs venligst den følgende information:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Vi beklager men IzPack understøtter ikke oprettelse af genveje på din operativ system. For at oprette en genvej, læs venligst din operativ system manual."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Bitte lesen Sie die folgenden Informationen:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Bitte lesen Sie die folgenden Lizenzvereinbarungen durch:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Installiere dieses Paket"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Hinweis: Die grau markierten Pakete können nicht optional ausgewählt werden."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Bitte lesen Sie die folgenden Lizenzvereinbarungen durch:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Wählen Sie den Drucker für die erste Einrichtung und Prüfung."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Jetzt werden die installierten Anwendungen entfernt!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Bitte lesen Sie die folgenden Informationen:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Leider wird die Erzeugung von Verknüpfungen durch IzPack unter diesem Betriebssystem noch nicht unterstützt. Bitte ziehen Sie das Handbuch Ihres Betriebssystems zu Rate, um manuell Verknüpfungen zu erstellen."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ell.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ell.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Παρακαλώ διαβάστε την ακόλουθη πληροφορία:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Παρακαλώ διαβάστε προσεκτικά την επόμενη άδεια χρήσης:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Εγκατάσταση αυτού του πακέτου"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Στιγμιότυπο πακέτου:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Παρακαλώ διαβάστε την ακόλουθη πληροφορία: "/>
+    <str id="InfoPanel.info" txt="Παρακαλώ διαβάστε την ακόλουθη πληροφορία:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Τίποτε]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Σημείωση: τα γκριζαρισμένα πακέτα είναι απαιτούμενα."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Παρακαλώ διαβάστε προσεκτικά την επόμενη άδεια χρήσης:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Θα αφαιρεθούν οι εγκατεστημένες εφαρμογές!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Παρακαλώ διαβάστε την ακόλουθη πληροφορία:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Ζητούμε συγγνώμη αλλά το IzPack δεν υποστηρίζει την κατασκευή συντομεύσεων σε αυτό το λειτουργικό σύστημα. Για να κατασκευάσετε τις συντομεύσεις παρακαλώ συμβουλευτείτε το βιβλίο οδηγιών του λειτουργικού σας συστήματος."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Mesedez, hurrengoa irakurri:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Mesedez, irakurri hurrengo lizentzia akordioa:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Pakete hau instalatu"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Pantailaren uneko argazkia:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Mesedez, hurrengoa irakurri: "/>
+    <str id="InfoPanel.info" txt="Mesedez, hurrengoa irakurri:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt=" [Hasi gabe]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Nota: Pakete grisak beharrezkoak dira."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Mesedez, irakurri hurrengo lizentzia akordioa:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Aukeratu aurreneko instalazio eta frogetarako imprimagailua."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Instalatutako aplikazioak ezabatuko dira!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Mesedez, hurrengoa irakurri:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Barkatu baina Sistema Eragile honetan, ezin dira laburbiderik sortu ."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="لطفاً اطلاعات زیر را مطالعه نمایید:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="لطفاً توافقنامۀ کاربر را به دقت مطالعه نمایید:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" این بسته نصب شود"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="توجه:  نصب بسته های خاکستری شده اجباری است."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="لطفاً توافقنامۀ کاربر را به دقت مطالعه نمایید:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="یک چاپگر برای نصب و آزمون مقدماتی انتخاب کنید."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="این کار موجب حذف برنامه(ها)ی نصب شده می شود!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="لطفاً اطلاعات زیر را مطالعه نمایید:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="متأسفانه IzPack قادر نیست در این محیط میانبر بسازد! به راهنمای سیستم عامل مراجعه کنید."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Ole hyvä ja lue seuraavat tiedotteet:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Ole hyvä ja lue huolellisesti seuraava käyttöoikeussopimus:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Asenna tämä paketti"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Pakettinäkymä:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Ole hyvä ja lue seuraavat tiedotteet: "/>
+    <str id="InfoPanel.info" txt="Ole hyvä ja lue seuraavat tiedotteet:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Ei toimenpiteitä]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Huomaa: harmaa valintaruutu tarkoittaa, että paketti on pakollinen."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Ole hyvä ja lue huolellisesti seuraava käyttöoikeussopimus:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Valitse kirjoitin asennukseen ja testaukseen."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Tämä poistaa asennetun sovelluksen/asennetut sovellukset!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Ole hyvä ja lue seuraavat tiedotteet:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Valitettavasti IzPack ei tue pikalinkkien tekemistä tässä käyttöjärjestelmässä. Pikalinkkien tekemiseksi tutustu käyttöjärjestelmäsi käyttöohjeeseen."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Veuillez lire les informations suivantes:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Veuillez lire attentivement l'accord de licence suivant:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Installer ce paquetage"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Capture d'écran associée :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Veuillez lire les informations suivantes :"/>
+    <str id="InfoPanel.info" txt="Veuillez lire les informations suivantes:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Rien]"/>
@@ -183,7 +183,7 @@
 
     <!-- LicencePanel strings -->
     <str id="LicencePanel.agree" txt="J'accepte les termes de cet accord de licence"/>
-    <str id="LicencePanel.info" txt="Veuillez lire attentivement l'accord de licence suivant :"/>
+    <str id="LicencePanel.info" txt="Veuillez lire attentivement l'accord de licence suivant:"/>
     <str id="LicencePanel.no" txt="Non"/>
     <str id="LicencePanel.notagree" txt="Je n'accepte pas les termes de cet accord de licence"/>
     <str id="LicencePanel.yes" txt="Oui"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Note : les paquetages grisés ne sont pas optionnels."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Veuillez lire attentivement l'accord de licence suivant:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Sélectionner l'imprimante à utiliser durant l'installation et les tests."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Ceci va enlever l'(es) application(s) installée(s) !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Veuillez lire les informations suivantes:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Désolé, mais IzPack ne supporte pas la création de raccourcis pour ce système d'exploitation. Veuillez vous référer à son manuel pour créer des raccourcis."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Por favor, lea a seguinte información:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Por favor, lea atentamente o convenio de licenza:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Instalar este paquete"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Nota: os paquetes en gris non son opcionais."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Por favor, lea atentamente o convenio de licenza:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Seleccione a impresora a usar na configuración inicial e probas."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="¡Esto eliminará a(s) aplicación(s) instalada(s)!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Por favor, lea a seguinte información:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Sentímolo, IzPack non pode crea-los atallos neste sistema operativo. Para crealos, por favor consulte o manual do seu sistema operativo."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" telepítésekor !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Kérem olvassa el a következő információt:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Kérem olvassa el a következő licence megállapodást:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" A csomag telepítése"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Csomag snapshot  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Kérem olvassa el a következő információt :"/>
+    <str id="InfoPanel.info" txt="Kérem olvassa el a következő információt:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Nincs megkezdve]"/>
@@ -183,7 +183,7 @@
 
     <!-- LicencePanel strings -->
     <str id="LicencePanel.agree" txt="Elfogadja a licence feltételeit ?"/>
-    <str id="LicencePanel.info" txt="Kérem olvassa el a következő licence megállapodást :"/>
+    <str id="LicencePanel.info" txt="Kérem olvassa el a következő licence megállapodást:"/>
     <str id="LicencePanel.no" txt="Nem"/>
     <str id="LicencePanel.notagree" txt="NEM fogadom el a megadott licence feltételeit."/>
     <str id="LicencePanel.yes" txt="Igen"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Megjegyzés: a szürke csomagok telepítése elengedhetetlen."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Kérem olvassa el a következő licence megállapodást:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="A telepített alkalmazás eltávolítása következik !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Kérem olvassa el a következő információt:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Sajnos az IzPack nem támogatja parancsikon lértehozását az Ön operációs rendszerén! Parancsikon készítésének módjáról tájékozódjon az operációs rendszer kézikönyvéből!"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Silakan baca informasi berikut:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Silakan baca perjanjian lisensi berikut dengan seksama:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Pasang paket berikut"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Gambaran paket:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Silakan baca informasi berikut: "/>
+    <str id="InfoPanel.info" txt="Silakan baca informasi berikut:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Tidak ada]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Catatan: paket-paket yang berwarna kelabu diperlukan."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Silakan baca perjanjian lisensi berikut dengan seksama:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Pilihlah printer yang digunakan untuk pemasangan awal dan pengetesan."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Ini akan menghapus aplikasi terpasang!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Silakan baca informasi berikut:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Kami minta maaf karena IzPack tidak mendukung pembuatan jalan pintas di sistem operasi ini. Untuk membuat jalan pintas, silakan lihat petunjuk sistem operasi Anda."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Leggere attentamente le seguenti informazioni:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Leggere attentamente l'accordo di licenza:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Installa questo componente"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Elenco componenti: "/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Leggere attentamente le seguenti informazioni: "/>
+    <str id="InfoPanel.info" txt="Leggere attentamente le seguenti informazioni:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt=" "/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Nota: i componenti in grigio sono obbligatori."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Leggere attentamente l'accordo di licenza:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Selezionare la stampante da usare per la configurazione iniziale e le prove."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Verranno disinstallate la(e) applicazione(i) selezionate!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Leggere attentamente le seguenti informazioni:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="IzPack non supporta la creazione di collegamenti in questo sistema operativo. Per crearli manualmente consultare la guida in linea del sistema operativo."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="のインストールへようこそ !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="以下の情報をお読みください:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="以下のライセンス利用許諾をお読みください:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" この項目をインストール"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="パッケージのスナップショット  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="以下の情報をお読みください :"/>
+    <str id="InfoPanel.info" txt="以下の情報をお読みください:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[未インストール]"/>
@@ -183,7 +183,7 @@
 
     <!-- LicencePanel strings -->
     <str id="LicencePanel.agree" txt="ライセンス利用許諾に同意します"/>
-    <str id="LicencePanel.info" txt="以下のライセンス利用許諾をお読みください :"/>
+    <str id="LicencePanel.info" txt="以下のライセンス利用許諾をお読みください:"/>
     <str id="LicencePanel.no" txt="いいえ"/>
     <str id="LicencePanel.notagree" txt="ライセンス利用許諾に同意しません"/>
     <str id="LicencePanel.yes" txt="はい"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="注意: 灰色で表示されている項目は、必須項目です。"/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="以下のライセンス利用許諾をお読みください:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="初期設定およびテストに使用するプリンタを選択してください。"/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="この操作は、インストール済のアプリケーションを削除します!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="以下の情報をお読みください:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="IzPackでは、お使いのオペレーティングシステムでのショートカットの作成をサポートしていません。ショートカットを作成するには、お使いのオペレーティングシステムのマニュアルを参照してください。"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="다음 정보를 확인하십시오:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="다음 라이센스 정보를 주의깊게 확인하십시오:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" 이 꾸러미 설치"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="꾸러미 스냅샷:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="다음 정보를 확인하십시오: "/>
+    <str id="InfoPanel.info" txt="다음 정보를 확인하십시오:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[없음]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="주의: 회색으로 표시된 꾸러미는 필수입니다."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="다음 라이센스 정보를 주의깊게 확인하십시오:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="설치된 어플리케이션이 제거됩니다!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="다음 정보를 확인하십시오:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="IzPack은 이 운영체제를 위한 단축 아이콘 생성을 지원하지 않습니다. 단축아이콘을 생성하려면 해당 운영체제 설명서를 참조하십시오."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/msa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/msa.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Sila baca arahan berikut:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Sila baca syarat perjanjian yang berikut dengan teliti:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Pasang modul ini"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Gambaran mengenai pakej  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Sila baca arahan berikut :"/>
+    <str id="InfoPanel.info" txt="Sila baca arahan berikut:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Tiada]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Perhatian: Modul yang kelabu diperlukan."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Sila baca syarat perjanjian yang berikut dengan teliti:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Ini akan menggeluarkan applikasi yang dipasang!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Sila baca arahan berikut:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Kami minta maaf tetapi Izpak tidak menyokong pembuatan shortcut pada sistem operasi ini. Untuk mencipta shortcut sila rujuk kepada panduan untuk sistem operasi ini."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Lees a.u.b. de volgende informatie:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Lees a.u.b. de volgende licentie overeenkomst:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Installeer dit pakket"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Pakket schermafdruk:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Lees a.u.b. de volgende informatie :"/>
+    <str id="InfoPanel.info" txt="Lees a.u.b. de volgende informatie:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Niks]"/>
@@ -183,7 +183,7 @@
 
     <!-- LicencePanel strings -->
     <str id="LicencePanel.agree" txt="Ik accepteer de voorwaarden van deze licentie"/>
-    <str id="LicencePanel.info" txt="Lees a.u.b. de volgende licentie overeenkomst :"/>
+    <str id="LicencePanel.info" txt="Lees a.u.b. de volgende licentie overeenkomst:"/>
     <str id="LicencePanel.no" txt="Nee"/>
     <str id="LicencePanel.notagree" txt="Ik accepteer de voorwaarden van deze licentie niet"/>
     <str id="LicencePanel.yes" txt="Ja"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="NB: Uitgegrijsde pakketten zijn verplicht."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Lees a.u.b. de volgende licentie overeenkomst:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Selecteer een printer."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Dit zal de geïnstalleerde programma(s) verwijderen !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Lees a.u.b. de volgende informatie:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Helaas ondersteunt IzPack het maken van snelkoppelingen op dit besturingssysteem niet. Raadpleeg de handleiding van uw besturingssysteem voor het aanmaken van de snelkoppelingen."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Les følgende informasjon:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Les gjennom følgende lisensavtale:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Installer denne pakken"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Merk: Utgråede pakker må installeres."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Les gjennom følgende lisensavtale:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Velg hvilken skriver som skal benyttes for initielt oppsett og testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Dette vil fjerne installerte programmer!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Les følgende informasjon:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Vi beklager men IzPack støtter ikke opprettelse av snarvei på operativsystemet ditt. For å opprette en snarvei, les gjennom ditt operativsystems brukermanual."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Proszę przeczytać poniższe informacje:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Proszę uważnie przeczytać poniższą umowę licencyjną:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Instaluj ten pakiet"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Szczegóły pakietu:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Proszę przeczytać poniższe informacje: "/>
+    <str id="InfoPanel.info" txt="Proszę przeczytać poniższe informacje:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt=" "/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Uwaga: Pakiety oznaczone szarym kolorem są wymagane."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Proszę uważnie przeczytać poniższą umowę licencyjną:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Wybierz drukarkę na potrzeby wstępnej konfiguracji i testów."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Umożliwia usunięcie zainstalowanego oprogramowania!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Proszę przeczytać poniższe informacje:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Niestety, program instalacyjny IzPack nie wspiera tworzenia skrótów w Twoim systemie operacyjnym. Aby utworzyć skróty, proszę skorzystać z pomocy Twojego systemu operacyjnego."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Por favor, leia atentamente a seguinte informação:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Por favor, leia atentamente o seguinte contrato de licença:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Instalar pacote"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Visualização do pacote:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Por favor, leia atentamente a seguinte informação: "/>
+    <str id="InfoPanel.info" txt="Por favor, leia atentamente a seguinte informação:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt=" "/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Nota: Os pacotes a cinza são necessários."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Por favor, leia atentamente o seguinte contrato de licença:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Selecione a impressora para utilizar na configuração inicial e testes."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="A aplicação vai ser removida!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Por favor, leia atentamente a seguinte informação:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Desculpe, mas o IzPack não pode criar atalhos neste sistema operativo. Para criar atalhos, consulte o manual do seu sistema operativo."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ron.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ron.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Va rugam cititi urmatoarele informatii:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Va rugam cititi cu atentie informatiile prinvind licenta softului:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Instalare pachet"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Imagine pachet  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Va rugam cititi urmatoarele informatii :"/>
+    <str id="InfoPanel.info" txt="Va rugam cititi urmatoarele informatii:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Nimic]"/>
@@ -183,7 +183,7 @@
 
     <!-- LicencePanel strings -->
     <str id="LicencePanel.agree" txt="Sunt de acord cu conditiile privind licenta softului."/>
-    <str id="LicencePanel.info" txt="Va rugam cititi cu atentie informatiile prinvind licenta softului :"/>
+    <str id="LicencePanel.info" txt="Va rugam cititi cu atentie informatiile prinvind licenta softului:"/>
     <str id="LicencePanel.no" txt="Nu"/>
     <str id="LicencePanel.notagree" txt="Nu sunt de acord cu conditiile privind licenta softului."/>
     <str id="LicencePanel.yes" txt="Da"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Nota: pachetele care sunt selectate implicit si nu pot fi deselectate sunt obligatorii."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Va rugam cititi cu atentie informatiile prinvind licenta softului:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Aplicatiile instalate vor fi inlaturate !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Va rugam cititi urmatoarele informatii:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Ne pare rau dar IzPack nu suporta crearea scurtaturilor(shortcuts) pe acest sistem de operare. Pentru a crea scurtaturi(shortcuts) consultati manualul sistemului de operare."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Пожалуйста, прочитайте следующую информацию:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Пожалуйста, внимательно прочитайте лицензию:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Установить набор"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Примечание: неактивные модули обязательны к установке."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Пожалуйста, внимательно прочитайте лицензию:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Укажите принтер для установки и тестовой печати."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Установленные программы будут удалены!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Пожалуйста, прочитайте следующую информацию:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="К сожалению, программа установки не поддерживает создание ярлыков в этой операционной системе.  Чтобы создать ярлыки, обратитесь к руководству по вашей операционной системе."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Prečítajte si nasledujuce informácie:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Pozorne si prečítajte nasledovné licenčné podmienky:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Inštalovať tento balík"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Náhľad na balík  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Prečítajte si nasledujuce informácie :"/>
+    <str id="InfoPanel.info" txt="Prečítajte si nasledujuce informácie:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Nič]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Poznámka: zašedené balíky su vyžadované."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Pozorne si prečítajte nasledovné licenčné podmienky:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Vyberte tlačiareň pre inštaláciu."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Táto operácia odstráni nainštalovanú aplikáciu !"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Prečítajte si nasledujuce informácie:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Ľutujeme ale IzPack nepodporuje vytvorenie zástupcov pre tento operačný systém. Vytvoriť zástupcov musite sami."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt=" !"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Por favor, lea la siguiente información:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Por favor, lea atentamente el acuerdo de licencia:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Instalar este paquete"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Nota: los paquetes en gris son obligatorios."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Por favor, lea atentamente el acuerdo de licencia:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Seleccione la impresora a usar para configuración inicial y pruebas."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="¡Se eliminarán la(s) aplicacion(es) instalada(s)!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Por favor, lea la siguiente información:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Lo sentimos, IzPack no puede crear accesos directos en este sistema operativo. Para crearlos, por favor consulte el manual de su sistema operativo."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/srp.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/srp.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Молим Вас, прочитајте следеће информације:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Молим Вас, прочитајте пажљиво следећи уговор о лиценци:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Инсталирај овај пакет"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Напомена: осенчени пакети су обавезни."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Молим Вас, прочитајте пажљиво следећи уговор о лиценци:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Ово ће да избрише инсталирану/е апликацију/е!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Молим Вас, прочитајте следеће информације:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Жао нам је, али IzPack не подржава прављење пречица на овом оперативном систему. Да бисте направили пречице, консултујте упутство за Ваш оперативни систем."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Vänligen läs följande information:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Vänligen läs följande licensavtal:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Installera detta paket"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Paket granskning:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Vänligen läs följande information: "/>
+    <str id="InfoPanel.info" txt="Vänligen läs följande information:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Inget]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Obs: gråade paket är obligatoriska."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Vänligen läs följande licensavtal:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Detta kommer att ta bort den installerade applikationen!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Vänligen läs följande information:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Vi ber om ursäkt men IzPack har inte stöd för skapandet av genvägar på det här operativsystemet. För att skapa genvägar, vänligen se handboken till ditt operativsystem."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/tur.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Lütfen aşağıdaki bilgileri okuyunuz:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Lütfen aşağıdaki lisans anlaşmasını dikkatlice okuyunuz:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Bu paketi kur"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Paket enstantenesi(snapshot):"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Lütfen aşağıdaki bilgileri okuyunuz: "/>
+    <str id="InfoPanel.info" txt="Lütfen aşağıdaki bilgileri okuyunuz:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Hiçbir şey]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Not: Gri paketlerin kurulması gereklidir."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Lütfen aşağıdaki lisans anlaşmasını dikkatlice okuyunuz:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Bu kurulmuş olan program(lar)ı kaldıracaktır!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Lütfen aşağıdaki bilgileri okuyunuz:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Üzgünüz, ama IzPack bu işletim sistemi üzerinde kısayol yaratmayı desteklemiyor. Kısayol oluşturmak için, lütfen işletim sisteminizin kılavuzuna başvurun."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="請閱讀以下資訊:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="請仔細閱讀以下許可權限:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" 安裝該套件"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="套件快照  :"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="請閱讀以下資訊 :"/>
+    <str id="InfoPanel.info" txt="請閱讀以下資訊:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt="[Nothing]"/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="注意: 灰色選項是必選的."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="請仔細閱讀以下許可權限:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Select the printer to use for initial setup and testing."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="將卸解已安裝的應用程式!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="請閱讀以下資訊:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="很遺憾IzPack不支援在當前作業系統上建立捷徑方式. 建立捷徑方式，請參考作業系統手冊."/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
@@ -135,10 +135,10 @@
     <str id="HelloPanel.welcome2" txt="!"/>
 
     <!-- HTMLInfoPanel strings -->
-    <str id="HTMLInfoPanel.info" txt="Please read the following information:"/>
+    <str id="HTMLInfoPanel.info" txt="Прочитайте, будь ласка, цю інформацію:"/>
 
     <!-- HTMLLicencePanel strings -->
-    <str id="HTMLLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="HTMLLicencePanel.info" txt="Уважно прочитайте ліцензійні умови, будь ласка:"/>
 
     <!-- ImgPacksPanel strings -->
     <str id="ImgPacksPanel.checkbox" txt=" Встановити"/>
@@ -147,7 +147,7 @@
     <str id="ImgPacksPanel.snap" txt="Знімок пакунку:"/>
 
     <!-- InfoPanel strings -->
-    <str id="InfoPanel.info" txt="Прочитайте, будь ласка, цю інформацію: "/>
+    <str id="InfoPanel.info" txt="Прочитайте, будь ласка, цю інформацію:"/>
 
     <!-- InstallPanel strings -->
     <str id="InstallPanel.begin" txt=" "/>
@@ -214,7 +214,7 @@
     <str id="PacksPanel.tip" txt="Примітка: сірі пакунки є обов’язковими."/>
 
     <!-- PDFLicencePanel strings -->
-    <str id="PDFLicencePanel.info" txt="Please read the following license agreement carefully:"/>
+    <str id="PDFLicencePanel.info" txt="Уважно прочитайте ліцензійні умови, будь ласка:"/>
 
     <!-- PrinterSelect Panel strings -->
     <str id="PrinterSelectPanel.select_printer" txt="Вкажіть прінтер для налаштування та тестового друку."/>
@@ -265,7 +265,7 @@
     <str id="uninstaller.warning" txt="Це видалить встановлену програму!"/>
 
     <!-- XInfoPanel strings -->
-    <str id="XInfoPanel.info" txt="Please read the following information:"/>
+    <str id="XInfoPanel.info" txt="Прочитайте, будь ласка, цю інформацію:"/>
 
     <!-- ShortcutPanel strings -->
     <str id="ShortcutPanel.alternate.apology" txt="Вибачте, але IzPack не може створити посилання в цій операційній системі. Щоб створити посилання зверніться до інструкцій вашої операційної системи."/>

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/console/AbstractTextConsolePanel.java
@@ -20,6 +20,7 @@ import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.rules.RulesEngine;
 import com.izforge.izpack.installer.panel.PanelView;
+import com.izforge.izpack.installer.util.PanelHelper;
 import com.izforge.izpack.util.Console;
 
 import java.io.IOException;
@@ -76,6 +77,12 @@ public abstract class AbstractTextConsolePanel extends AbstractConsolePanel
     {
         printHeadLine(installData, console);
 
+        String panelLabel = getPanelLabel(installData);
+        if (panelLabel != null)
+        {
+            console.println(panelLabel);
+        }
+
         String text = getText();
         if (substituteVariables()) {
             text = installData.getVariables().replace(text);
@@ -101,6 +108,17 @@ public abstract class AbstractTextConsolePanel extends AbstractConsolePanel
             logger.warning("No text to display");
         }
         return promptEndPanel(installData, console);
+    }
+
+    /**
+     * Returns the panel label to display.
+     *
+     * @param installData the installation data
+     * @return the panel label. A <tt>null</tt> indicates no panel label to display
+     */
+    protected String getPanelLabel(InstallData installData) {
+        String titleMessageKey = PanelHelper.getPanelTitleMessageKey(getPanel(), "info", installData);
+        return installData.getMessages().get(titleMessageKey);
     }
 
     /**

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/htmlinfo/HTMLInfoConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/htmlinfo/HTMLInfoConsolePanel.java
@@ -59,7 +59,8 @@ public class HTMLInfoConsolePanel extends AbstractTextConsolePanel
     public boolean run(InstallData installData, Console console)
     {
         super.run(installData, console);
-        console.println(installData.getMessages().get(panelResourceName));
+        String titleMessageKey = PanelHelper.getPanelTitleMessageKey(getPanel(), "info", installData);
+        console.println(installData.getMessages().get(titleMessageKey));
         return true;
     }
 

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/htmlinfo/HTMLInfoConsolePanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/htmlinfo/HTMLInfoConsolePanel.java
@@ -47,24 +47,6 @@ public class HTMLInfoConsolePanel extends AbstractTextConsolePanel
     }
 
     /**
-     * Runs the panel using the specified console.
-     * <p/>
-     * If there is no text to display, the panel will return {@code false}.
-     *
-     * @param installData the installation data
-     * @param console     the console
-     * @return {@code true} if the panel ran successfully, otherwise {@code false}
-     */
-    @Override
-    public boolean run(InstallData installData, Console console)
-    {
-        super.run(installData, console);
-        String titleMessageKey = PanelHelper.getPanelTitleMessageKey(getPanel(), "info", installData);
-        console.println(installData.getMessages().get(titleMessageKey));
-        return true;
-    }
-
-    /**
      * Returns the text to display.
      *
      * @return the text. A {@code null} indicates failure

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/htmlinfo/HTMLInfoPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/htmlinfo/HTMLInfoPanel.java
@@ -92,8 +92,9 @@ public class HTMLInfoPanel extends IzPanel
 
         // We add the components
         if (showInfoLabelFlag)
-        {  //flag is set; add label above content
-            add(LabelFactory.create(getString(panelResourceName), parent.getIcons().get("edit"), LEADING), NEXT_LINE);
+        {   //flag is set; add label above content
+            String titleMessageKey = PanelHelper.getPanelTitleMessageKey(panel, "info", installData);
+            add(LabelFactory.create(getString(titleMessageKey), parent.getIcons().get("edit"), LEADING), NEXT_LINE);
         }
         try
         {

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/xinfo/XInfoPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/xinfo/XInfoPanel.java
@@ -71,7 +71,8 @@ public class XInfoPanel extends IzPanel
         String panelName = PanelHelper.getPanelName(panel);
 
         // The info label.
-        add(LabelFactory.create(getString(panelResourceName), parent.getIcons().get("edit"), LEADING), NEXT_LINE);
+        String titleMessageKey = PanelHelper.getPanelTitleMessageKey(panel, "info", installData);
+        add(LabelFactory.create(getString(titleMessageKey), parent.getIcons().get("edit"), LEADING), NEXT_LINE);
         // The text area which shows the info.
         textArea = new JTextArea();
         textArea.setName(panelName.equals("XInfoPanel") ? GuiId.XINFO_PANEL_TEXT_AREA.id : GuiId.INFO_PANEL_TEXT_AREA.id);


### PR DESCRIPTION
[IZPACK-1754] Default panel labels for *InfoPanels no longer work
[IZPACK-1755] For *info console panels panel label get displayed after the panel is displayed

[IZPACK-1754]: https://izpack.atlassian.net/browse/IZPACK-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IZPACK-1755]: https://izpack.atlassian.net/browse/IZPACK-1755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ