### PR TITLE
[IZPACK-1768] Adds canonical host name variable

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/data/ScriptParserConstant.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/data/ScriptParserConstant.java
@@ -42,6 +42,10 @@ public class ScriptParserConstant
      */
     public static final String HOST_NAME = "HOST_NAME";
     /**
+     * The canonical hostname (FQDN).
+     */
+    public static final String CANONICAL_HOST_NAME = "CANONICAL_HOST_NAME";
+    /**
      * The ip address.
      */
     public static final String IP_ADDRESS = "IP_ADDRESS";

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/container/provider/AbstractInstallDataProvider.java
@@ -154,6 +154,7 @@ public abstract class AbstractInstallDataProvider implements Provider
     {
         // Determine the hostname and IP address
         String hostname;
+        String canonicalHostname;
         String IPAddress;
 
         try
@@ -161,11 +162,13 @@ public abstract class AbstractInstallDataProvider implements Provider
             InetAddress localHost = InetAddress.getLocalHost();
             IPAddress = localHost.getHostAddress();
             hostname = localHost.getHostName();
+            canonicalHostname = localHost.getCanonicalHostName();
         }
         catch (Exception exception)
         {
             logger.log(Level.WARNING, "Failed to determine hostname and IP address", exception);
             hostname = "";
+            canonicalHostname = "";
             IPAddress = "";
         }
 
@@ -176,6 +179,7 @@ public abstract class AbstractInstallDataProvider implements Provider
         installData.setVariable(ScriptParserConstant.USER_NAME, System.getProperty("user.name"));
         installData.setVariable(ScriptParserConstant.IP_ADDRESS, IPAddress);
         installData.setVariable(ScriptParserConstant.HOST_NAME, hostname);
+        installData.setVariable(ScriptParserConstant.CANONICAL_HOST_NAME, canonicalHostname);
         installData.setVariable(ScriptParserConstant.FILE_SEPARATOR, File.separator);
     }
 


### PR DESCRIPTION
Added a new installer variable `CANONICAL_HOST_NAME` that contains the fully qualified host name (FQDN) from `InetAddress.getLocalHost().getCanonicalHostName()`