### PR TITLE
IZPACK-1782 Remove references to tools.jar

### DIFF
--- a/izpack-dist/src/main/resources/bin/compile
+++ b/izpack-dist/src/main/resources/bin/compile
@@ -127,17 +127,10 @@ if $cygwin; then
     CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
 fi
 
-# For Darwin, use classes.jar for TOOLS_JAR
-TOOLS_JAR="${JAVA_HOME}/lib/tools.jar"
-if $darwin; then
-  TOOLS_JAR="/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Classes/classes.jar"
-fi
-
 MAIN_CLASS=com.izforge.izpack.compiler.bootstrap.CompilerLauncher
 
 "$JAVACMD" -Xmx512m \
   $IZPACK_OPTS \
   -classpath "${IZPACK_HOME}/lib/*" \
-  "-Dtools.jar=$TOOLS_JAR" \
   "-Dizpack.home=${IZPACK_HOME}" \
   $MAIN_CLASS "$@"

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanel.java
@@ -159,7 +159,7 @@ public class JDKPathPanel extends PathInputPanel implements HyperlinkListener
         setMustExist(true);
         if (!installData.getPlatform().isA(Platform.Name.MAC_OSX))
         {
-            setExistFiles(JDKPathPanelHelper.testFiles);
+            setExistFiles(JDKPathPanelHelper.TEST_FILES);
         }
 
         String defaultValue = JDKPathPanelHelper.getDefaultJavaPath(installData, handler);

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelHelper.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/jdkpath/JDKPathPanelHelper.java
@@ -17,7 +17,7 @@ import java.util.StringTokenizer;
 
 public class JDKPathPanelHelper
 {
-    public static final String[] testFiles = new String[]{"lib" + File.separator + "tools.jar", "bin" + File.separator + "javac" + (OsVersion.IS_WINDOWS ? ".exe" : "")};
+    public static final String[] TEST_FILES = new String[]{ "bin" + File.separator + "javac" + (OsVersion.IS_WINDOWS ? ".exe" : "")};
     public static final String JDK_VALUE_NAME = "JavaHome";
     public static final String JDK_ROOT_KEY = "Software\\JavaSoft\\Java Development Kit";
     public static final String OSX_JDK_HOME = "/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/Home/";
@@ -172,7 +172,7 @@ public class JDKPathPanelHelper
      */
     private static boolean pathIsValid(String strPath)
     {
-        for (String existFile : testFiles)
+        for (String existFile : TEST_FILES)
         {
             File path = new File(strPath, existFile).getAbsoluteFile();
             if (path.exists())

--- a/src/doc-reST/panels.txt
+++ b/src/doc-reST/panels.txt
@@ -473,7 +473,7 @@ not point to a JDK, else to a JRE also the environment variable points to a
 JDK. This is not a bug, this is the behavior of the VM. But some products
 needs a JDK, for that this panel can be used. There is not only a selection
 of the path else a validation. The validation will be done with the file
-JDKPath/lib/tools.jar. If JAVA_HOME points to the VM which is placed in the
+JDKPath/bin/javac. If JAVA_HOME points to the VM which is placed in the
 JDK, the directory will be used as default (JAVA_HOME/..). If there is the
 variable
 

--- a/src/doc-reST/user-input.txt
+++ b/src/doc-reST/user-input.txt
@@ -1278,7 +1278,7 @@ Example
                    txt="This is a description for a search
                    input field."
                    id="description.java_sdk_home"/>
-      <spec txt="Path to Java SDK:" checkfilename="lib/tools.jar"
+      <spec txt="Path to Java SDK:" checkfilename="bin/javac"
             type="file" result="directory">
       <choice value="/usr/lib/java/" os="unix" />
       <choice value="/opt/java" os="unix" />


### PR DESCRIPTION
Drops usage of `tools.jar` to determine the presence of a Java JDK Installation.