### PR TITLE
Bump org.picocontainer:picocontainer from 2.15 to 2.15.2

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,6 @@
+#!/bin/sh
+export DISPLAY=':99.0'
+Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+fluxbox &> ~/fluxbox.log &
+./mvnw verify -Pwith-gui-tests
+

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.picocontainer</groupId>
         <artifactId>picocontainer</artifactId>
-        <version>2.15</version>
+        <version>2.15.2</version>
       </dependency>
 
       <!-- PDF Panel -->


### PR DESCRIPTION
Provides a fix for IZPACK-1786 (thanks to @paul-hammant to still support JDK 8)