### PR TITLE
IZPACK-1823 Replace line separatos with os ones (backport)

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/substitutor/VariableSubstitutor.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/substitutor/VariableSubstitutor.java
@@ -78,14 +78,12 @@ public interface VariableSubstitutor extends Serializable
      * @param out      the output stream to write
      * @param type     the file type or null for plain
      * @param encoding the character encoding or null for default
-     * @return the number of substitutions made
      * @throws IllegalArgumentException     if unknown file type specified
      * @throws UnsupportedEncodingException if encoding not supported
      * @throws IOException                  if an I/O error occurs
-     * @throws
      */
-    int substitute(InputStream in, OutputStream out, SubstitutionType type, String encoding)
-            throws Exception;
+    void substitute(InputStream in, OutputStream out, SubstitutionType type, String encoding)
+            throws IOException;
 
     /**
      * Substitute method Variant that gets An Input Stream and returns A String
@@ -97,7 +95,7 @@ public interface VariableSubstitutor extends Serializable
      * @throws UnsupportedEncodingException If the file comes with a wrong Encoding
      * @throws IOException                  If an I/O Error occurs.
      */
-    String substitute(InputStream in, SubstitutionType type) throws Exception;
+    String substitute(InputStream in, SubstitutionType type) throws IOException;
 
     /**
      * Substitutes the variables found in the data read from the specified reader. Escapes special
@@ -106,9 +104,8 @@ public interface VariableSubstitutor extends Serializable
      * @param reader the reader to read
      * @param writer the writer used to write data out
      * @param type   the file type or null for plain
-     * @return the number of substitutions made
      * @throws IllegalArgumentException if unknown file type specified
      * @throws IOException              if an I/O error occurs
      */
-    int substitute(Reader reader, Writer writer, SubstitutionType type) throws Exception;
+    void substitute(Reader reader, Writer writer, SubstitutionType type) throws IOException;
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/substitutor/VariableSubstitutorImpl.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/substitutor/VariableSubstitutorImpl.java
@@ -38,11 +38,11 @@ import java.util.logging.Logger;
  * <p/>
  * This is a abstract base type for all kinds of variables
  */
-public class VariableSubstitutorImpl implements VariableSubstitutor, Serializable
+public class VariableSubstitutorImpl implements VariableSubstitutor
 {
     private static final long serialVersionUID = 3907213762447685687L;
 
-    private static final Logger logger = Logger.getLogger(VariableSubstitutorImpl.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(VariableSubstitutorImpl.class.getName());
 
     /**
      * The replacement variables
@@ -118,7 +118,7 @@ public class VariableSubstitutorImpl implements VariableSubstitutor, Serializabl
         }
         catch (IOException e)
         {
-            logger.log(Level.SEVERE, "Error when substituting variables", e);
+            LOGGER.log(Level.SEVERE, "Error when substituting variables", e);
             throw new IzPackException(e);
         }
     }
@@ -131,13 +131,12 @@ public class VariableSubstitutorImpl implements VariableSubstitutor, Serializabl
      * @param out      the output stream to write
      * @param type     the file type or null for plain
      * @param encoding the character encoding or null for default
-     * @return the number of substitutions made
      * @throws IOException an error occured
      */
-    public int substitute(InputStream in, OutputStream out, SubstitutionType type, String encoding)
-            throws Exception
+    public void substitute(InputStream in, OutputStream out, SubstitutionType type, String encoding)
+            throws IOException
     {
-        return IOUtils.copy(new VariableSubstitutorInputStream(in, encoding, variables, type, bracesRequired), out);
+        IOUtils.copy(new VariableSubstitutorInputStream(in, encoding, variables, type, bracesRequired), out);
     }
 
     /**
@@ -149,7 +148,7 @@ public class VariableSubstitutorImpl implements VariableSubstitutor, Serializabl
      * @throws IOException an error occured
      */
     public String substitute(InputStream in, SubstitutionType type)
-            throws Exception
+            throws IOException
     {
         VariableSubstitutorInputStream inputStream = new VariableSubstitutorInputStream(in, variables, type, bracesRequired);
         return IOUtils.toString(inputStream, inputStream.getEncoding());
@@ -163,12 +162,11 @@ public class VariableSubstitutorImpl implements VariableSubstitutor, Serializabl
      * @param reader the reader to read
      * @param writer the writer used to write data out
      * @param type   the file type or null for plain
-     * @return the number of substitutions made
      * @throws IOException an error occured
      */
-    public int substitute(Reader reader, Writer writer, SubstitutionType type) throws Exception
+    public void substitute(Reader reader, Writer writer, SubstitutionType type) throws IOException
     {
-        return IOUtils.copy(new VariableSubstitutorReader(reader, variables, type, bracesRequired), writer);
+        IOUtils.copy(new VariableSubstitutorReader(reader, variables, type, bracesRequired), writer);
     }
 
 }

--- a/izpack-core/src/main/java/com/izforge/izpack/core/substitutor/VariableSubstitutorReader.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/substitutor/VariableSubstitutorReader.java
@@ -18,12 +18,13 @@ package com.izforge.izpack.core.substitutor;
 
 import com.izforge.izpack.api.data.Variables;
 import com.izforge.izpack.api.substitutor.SubstitutionType;
-import com.izforge.izpack.util.IoHelper;
 
 import java.io.IOException;
 import java.io.PushbackReader;
 import java.io.Reader;
 import java.nio.CharBuffer;
+
+import static java.lang.System.lineSeparator;
 
 /**
  * An input reader which resolves IzPack variables on the fly
@@ -42,13 +43,15 @@ public class VariableSubstitutorReader extends Reader
      */
     private boolean bracesRequired = false;
 
-    private char variable_start = '$';
-    private char variable_end = '\0';
+    private char variableStart = '$';
+    private char variableEnd = '\0';
     private boolean inBraces = false;
 
     private final StringBuilder varNameBuffer = new StringBuilder();
     private String varValue = null;
     private int varValueIndex = 0;
+    private String streamBuffer = null;
+    private int streamBufferIndex = 0;
 
 
     public VariableSubstitutorReader(Reader source, Variables variables, SubstitutionType type, boolean bracesRequired)
@@ -71,16 +74,16 @@ public class VariableSubstitutorReader extends Reader
         switch (type)
         {
             case TYPE_SHELL:
-                variable_start = '%';
+                variableStart = '%';
                 break;
 
             case TYPE_AT:
-                variable_start = '@';
+                variableStart = '@';
                 break;
 
             case TYPE_ANT:
-                variable_start = '@';
-                variable_end = '@';
+                variableStart = '@';
+                variableEnd = '@';
                 break;
 
             default:
@@ -107,26 +110,75 @@ public class VariableSubstitutorReader extends Reader
 
     @Override
     public int read(CharBuffer target) throws IOException {
-        throw new RuntimeException("Operation Not Supported");
+        throw new UnsupportedOperationException("Operation Not Supported");
+    }
+
+    private int readFromStream() throws IOException
+    {
+        if (streamBuffer != null)
+        {
+            if (streamBufferIndex < streamBuffer.length())
+            {
+                return streamBuffer.charAt(streamBufferIndex++);
+            }
+            if (streamBufferIndex == streamBuffer.length())
+            {
+                streamBuffer = null;
+                streamBufferIndex = 0;
+            }
+        }
+
+        int data = pushbackReader.read();
+        if (data == -1)
+        {
+            return -1;
+        }
+
+        char c = (char) data;
+        if (c == '\r')
+        {
+            int nextData = pushbackReader.read();
+            if (nextData != '\n')
+            {
+                pushbackReader.unread(nextData);
+            }
+            streamBuffer = lineSeparator();
+        }
+        else if (c == '\n')
+        {
+            streamBuffer = lineSeparator();
+        }
+        else
+        {
+            return data;
+        }
+
+        return streamBuffer.charAt(streamBufferIndex++);
     }
 
     @Override
     public int read() throws IOException
     {
-        if(varValue != null){
-            if(varValueIndex < varValue.length()){
+        if (varValue != null)
+        {
+            if (varValueIndex < varValue.length())
+            {
                 return varValue.charAt(varValueIndex++);
             }
-            if(varValueIndex == varValue.length()){
+            if (varValueIndex == varValue.length())
+            {
                 varValue = null;
                 varValueIndex = 0;
             }
         }
 
-        int data = pushbackReader.read();
-        if(data != variable_start) return data;
+        int data = readFromStream();
+        if (data != variableStart)
+        {
+            return data;
+        }
 
-        data = pushbackReader.read();
+        data = readFromStream();
         if (data == '{')
         {
             inBraces = true;
@@ -134,7 +186,7 @@ public class VariableSubstitutorReader extends Reader
         else if (bracesRequired)
         {
             pushbackReader.unread(data);
-            return variable_start;
+            return variableStart;
         }
 
         varNameBuffer.delete(0, varNameBuffer.length());
@@ -144,20 +196,18 @@ public class VariableSubstitutorReader extends Reader
             varNameBuffer.append((char) data);
         }
 
-        data = pushbackReader.read();
+        data = readFromStream();
         while (
-                data >= ' ' && (inBraces && data != '}')
-                || (inBraces && ((data == '[') || (data == ']')))
-                || isAllowedCharInVariableName(data)
+                data >= ' ' && inBraces && data != '}' || isAllowedCharInVariableName(data)
         )
         {
             varNameBuffer.append((char) data);
-            data = pushbackReader.read();
+            data = readFromStream();
         }
 
         boolean variable = wasItPlausibleVariableName(data);
         String name = varNameBuffer.toString();
-        if (variable && name.length() > 0)
+        if (variable && !name.isEmpty())
         {
             // check for environment variables
             if (inBraces && name.startsWith("ENV[")
@@ -194,20 +244,20 @@ public class VariableSubstitutorReader extends Reader
             }
             unclosedBraces = true;
         } else if (
-                (data == variable_start && variable_start != variable_end)
-                || (!isAllowedCharInVariableName(data) && data != '}' && data != variable_end)
+                (data == variableStart && variableStart != variableEnd)
+                || (!isAllowedCharInVariableName(data) && data != '}' && data != variableEnd)
                 )
         {
             pushbackReader.unread(data);
         }
 
-        if(varValue == null)
+        if (varValue == null)
         {
-            varValue = variable_start
+            varValue = variableStart
                     + (inBraces ? "{" : "")
                     + varNameBuffer.toString()
                     + (inBraces && !unclosedBraces ? "}" : "")
-                    + (variable_end != '\0' && variable ? variable_end : "");
+                    + (variableEnd != '\0' && variable ? variableEnd : "");
         }
         else
         {
@@ -216,7 +266,8 @@ public class VariableSubstitutorReader extends Reader
 
         inBraces = false;
 
-        if(varValue.length() == 0){
+        if (varValue.isEmpty())
+        {
             return read();
         }
 
@@ -225,7 +276,7 @@ public class VariableSubstitutorReader extends Reader
 
     private boolean wasItPlausibleVariableName(int data) throws IOException
     {
-        if (variable_end == '\0')
+        if (variableEnd == '\0')
         {
             return !inBraces || data == '}';
         }
@@ -240,14 +291,14 @@ public class VariableSubstitutorReader extends Reader
             {
                 return false;
             }
-            if (variable_end == nextData)
+            if (variableEnd == nextData)
             {
                 return true;
             }
             pushbackReader.unread(nextData);
             return false;
         }
-        return variable_end == data;
+        return variableEnd == data;
     }
 
     @Override
@@ -279,7 +330,7 @@ public class VariableSubstitutorReader extends Reader
 
     @Override
     public long skip(long n) throws IOException {
-        throw new RuntimeException("Operation Not Supported");
+        throw new UnsupportedOperationException("Operation Not Supported");
     }
 
     @Override
@@ -294,12 +345,12 @@ public class VariableSubstitutorReader extends Reader
 
     @Override
     public void mark(int readAheadLimit) throws IOException {
-        throw new RuntimeException("Operation Not Supported");
+        throw new UnsupportedOperationException("Operation Not Supported");
     }
 
     @Override
     public void reset() throws IOException {
-        throw new RuntimeException("Operation Not Supported");
+        throw new UnsupportedOperationException("Operation Not Supported");
     }
 
 
@@ -319,8 +370,10 @@ public class VariableSubstitutorReader extends Reader
      * @param str  the string to check for special characters
      * @return the string with the special characters properly escaped
      */
-    private String escapeSpecialChars(String str)
+    private String escapeSpecialChars(final String str)
     {
+        final String baseStr = str.replaceAll("\\R", lineSeparator());
+
         StringBuffer buffer;
         int len;
         int i;
@@ -335,14 +388,12 @@ public class VariableSubstitutorReader extends Reader
             case TYPE_PLAIN:
             case TYPE_AT:
             case TYPE_ANT:
-                return str;
             case TYPE_SHELL:
-                // apple mac has major problem with \r, make sure they are gone
-                return str.replace("\r", "");
+                return baseStr;
             case TYPE_JAVA_PROPERTIES:
             case TYPE_JAVA:
-                buffer = new StringBuffer(str);
-                len = str.length();
+                buffer = new StringBuffer(baseStr);
+                len = baseStr.length();
                 boolean leading = true;
                 for (i = 0; i < len; i++)
                 {
@@ -373,8 +424,7 @@ public class VariableSubstitutorReader extends Reader
                         // Check for special characters
                         // According to the spec:
                         // 'For the element, leading space characters, but not embedded or trailing
-                        // space characters,
-                        // are written with a preceding \ character'
+                        // space characters are written with a preceding \ character'
                         else if (c == ' ')
                         {
                             if (leading)
@@ -408,8 +458,8 @@ public class VariableSubstitutorReader extends Reader
                 }
                 return buffer.toString();
             case TYPE_XML:
-                buffer = new StringBuffer(str);
-                len = str.length();
+                buffer = new StringBuffer(baseStr);
+                len = baseStr.length();
                 for (i = 0; i < len; i++)
                 {
                     String r = null;

--- a/izpack-core/src/test/java/com/izforge/izpack/core/substitutor/VariableSubstitutorReaderTest.java
+++ b/izpack-core/src/test/java/com/izforge/izpack/core/substitutor/VariableSubstitutorReaderTest.java
@@ -1,0 +1,37 @@
+package com.izforge.izpack.core.substitutor;
+
+import com.izforge.izpack.api.data.Variables;
+import com.izforge.izpack.api.substitutor.SubstitutionType;
+import com.izforge.izpack.core.data.DefaultVariables;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Properties;
+
+import static com.izforge.izpack.api.substitutor.SubstitutionType.TYPE_PLAIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class VariableSubstitutorReaderTest {
+
+    @Test
+    public void testLineSeparatorSubstitution() throws IOException {
+        Properties properties = new Properties();
+        properties.put("VAR", "value1\nvalue2\r\nvalue3\r");
+        Variables variables = new DefaultVariables(properties);
+
+        String input = "Start\n${VAR}\r\nSome line\rEnd";
+        VariableSubstitutorReader reader = new VariableSubstitutorReader(new StringReader(input), variables, TYPE_PLAIN);
+
+        StringBuilder sb = new StringBuilder();
+        int c;
+        while ((c = reader.read()) != -1) {
+            sb.append((char) c);
+        }
+
+        String ls = System.lineSeparator();
+        String expected = "Start" + ls + "value1" + ls + "value2" + ls + "value3" + ls + ls + "Some line" + ls + "End";
+        assertThat(sb.toString(), is(expected));
+    }
+}

--- a/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/ScriptParser.java
+++ b/izpack-installer/src/main/java/com/izforge/izpack/installer/unpacker/ScriptParser.java
@@ -26,6 +26,12 @@ import com.izforge.izpack.api.substitutor.VariableSubstitutor;
 import com.izforge.izpack.util.PlatformModelMatcher;
 
 import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.logging.Logger;
 
 /**
@@ -36,7 +42,7 @@ import java.util.logging.Logger;
  */
 public class ScriptParser
 {
-    private static final Logger logger = Logger.getLogger(ScriptParser.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ScriptParser.class.getName());
 
     /**
      * The variable replacer.
@@ -77,50 +83,23 @@ public class ScriptParser
 
         // Create a temporary file for the parsed data
         // (Use the same directory so that renaming works later)
-        File file = new File(parsable.getPath());
+        final Path file = Paths.get(parsable.getPath());
 
-        logger.fine("Parsing and replacing variables in file " + file + "...");
+        LOGGER.fine(() -> "Parsing and replacing variables in file " + file + "...");
 
-        File parsedFile;
-        try
-        {
-            parsedFile = File.createTempFile("izpp", null, file.getParentFile());
-        }
-        catch (IOException exception)
-        {
-            throw new IOException("Failed to create temporary file for " + parsable.getPath() + " in directory "
-                                          + file.getParentFile(), exception);
-        }
+        final Path parsedFile = Files.createTempFile(file.getParent(),"izpp", null);
 
         // Parses the file
         // (Use buffering because substitutor processes byte at a time)
-        Reader reader = null;
-        Writer writer = null;
-        try {
-            FileInputStream inFile = new FileInputStream(file);
-            FileOutputStream outFile = new FileOutputStream(parsedFile);
-            InputStreamReader inReader = parsable.getEncoding() != null ?
-                new InputStreamReader(inFile, parsable.getEncoding()) :
-                new InputStreamReader(inFile);
-            OutputStreamWriter outWriter = parsable.getEncoding() != null ?
-                new OutputStreamWriter(outFile, parsable.getEncoding()) :
-                new OutputStreamWriter(outFile);
-            reader = new BufferedReader(inReader, 5120);
-            writer = new BufferedWriter(outWriter, 5120);
+        final String parsableEncoding = parsable.getEncoding();
+        final Charset charset = parsableEncoding != null ? Charset.forName(parsableEncoding) : StandardCharsets.UTF_8;
+        try (BufferedReader reader = Files.newBufferedReader(file, charset);
+             BufferedWriter writer = Files.newBufferedWriter(parsedFile, charset))
+        {
             replacer.substitute(reader, writer, parsable.getType());
-        } finally {
-            if (reader != null) reader.close();
-            if (writer != null) writer.close();
         }
 
         // Replace the original file with the parsed one
-        if (!file.delete())
-        {
-            throw new IOException("Failed to delete file: " + file);
-        }
-        if (!parsedFile.renameTo(file))
-        {
-            throw new IOException("Could not rename file " + parsedFile + " to " + file);
-        }
+        Files.move(parsedFile, file, StandardCopyOption.REPLACE_EXISTING);
     }
 }


### PR DESCRIPTION
- During the read process all exiting new line characters in the existing stream and also the replacement variables will be replaced with the current OS new line characters.
- Fix general warnings for new Java API