### PR TITLE
IZPACK-1824 Improve XML security (backport)

### DIFF
--- a/izpack-api/src/main/java/com/izforge/izpack/api/adaptator/impl/XMLElementImpl.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/adaptator/impl/XMLElementImpl.java
@@ -24,6 +24,7 @@ package com.izforge.izpack.api.adaptator.impl;
 
 import com.izforge.izpack.api.adaptator.IXMLElement;
 
+import com.izforge.izpack.api.factory.XMLAccess;
 import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -76,9 +77,7 @@ public class XMLElementImpl implements IXMLElement
         try
         {
             // Création d'un nouveau DOM
-            DocumentBuilderFactory documentFactory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder constructeur = documentFactory.newDocumentBuilder();
-            document = constructeur.newDocument();
+            document = XMLAccess.documentBuilderFactory().newDocumentBuilder().newDocument();
             // Propriétés du DOM
             document.setXmlVersion("1.0");
             element = document.createElement(name);

--- a/izpack-api/src/main/java/com/izforge/izpack/api/adaptator/impl/XMLParser.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/adaptator/impl/XMLParser.java
@@ -20,6 +20,7 @@ package com.izforge.izpack.api.adaptator.impl;
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLParser;
 import com.izforge.izpack.api.adaptator.XMLException;
+import com.izforge.izpack.api.factory.XMLAccess;
 import org.w3c.dom.Node;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
@@ -44,14 +45,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 
 public class XMLParser implements IXMLParser
 {
-    private static final Logger logger = Logger.getLogger(XMLParser.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(XMLParser.class.getName());
 
-    public class ByteBufferInputStream extends InputStream
+    public static class ByteBufferInputStream extends InputStream
     {
         private final ByteBuffer buf;
 
@@ -67,8 +68,7 @@ public class XMLParser implements IXMLParser
             {
                 return -1;
             }
-            int c = buf.get() & 0xff;
-            return c;
+            return buf.get() & 0xff;
         }
 
         @Override
@@ -90,8 +90,8 @@ public class XMLParser implements IXMLParser
         }
     }
 
-    private LineNumberFilter filter;
-    private String parsedItem = null;
+    private final LineNumberFilter filter;
+    private String parsedItem;
 
 
     public XMLParser()
@@ -108,7 +108,7 @@ public class XMLParser implements IXMLParser
     {
         try
         {
-            SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+            SAXParserFactory saxParserFactory = XMLAccess.saxParserFactory();
             saxParserFactory.setValidating(false); // we don't use DTD
             saxParserFactory.setNamespaceAware(true);
             saxParserFactory.setXIncludeAware(true);
@@ -133,11 +133,7 @@ public class XMLParser implements IXMLParser
             filter = new LineNumberFilter(xmlReader);
             filter.setErrorHandler(new FilterErrorHandler());
         }
-        catch (ParserConfigurationException e)
-        {
-            throw new XMLException(e);
-        }
-        catch (SAXException e)
+        catch (ParserConfigurationException | SAXException e)
         {
             throw new XMLException(e);
         }
@@ -164,7 +160,7 @@ public class XMLParser implements IXMLParser
             SAXSource source = new SAXSource(inputSource);
             source.setXMLReader(filter);
 
-            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            TransformerFactory transformerFactory = XMLAccess.transformerFactory();
 
             final Transformer transformer;
             if (xslSource == null)
@@ -236,7 +232,7 @@ public class XMLParser implements IXMLParser
     {
         this.parsedItem = null;
 
-        final ByteBuffer buf = Charset.forName("UTF-8").encode(inputString);
+        final ByteBuffer buf = StandardCharsets.UTF_8.encode(inputString);
 
         return parse(new ByteBufferInputStream(buf));
     }
@@ -261,7 +257,7 @@ public class XMLParser implements IXMLParser
         @Override
         public void warning(SAXParseException e) throws SAXException
         {
-            logger.warning(prepareMessage(e));
+            LOGGER.warning(() -> prepareMessage(e));
         }
 
         @Override

--- a/izpack-api/src/main/java/com/izforge/izpack/api/adaptator/impl/XMLWriter.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/adaptator/impl/XMLWriter.java
@@ -25,6 +25,7 @@ package com.izforge.izpack.api.adaptator.impl;
 import com.izforge.izpack.api.adaptator.IXMLElement;
 import com.izforge.izpack.api.adaptator.IXMLWriter;
 import com.izforge.izpack.api.adaptator.XMLException;
+import com.izforge.izpack.api.factory.XMLAccess;
 
 import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
@@ -70,8 +71,7 @@ public class XMLWriter implements IXMLWriter
         try
         {
             Source source = new DOMSource(element.getElement().getOwnerDocument());
-            TransformerFactory fabrique = TransformerFactory.newInstance();
-            Transformer transformer = fabrique.newTransformer();
+            Transformer transformer = XMLAccess.transformerFactory().newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
             Result result;

--- a/izpack-api/src/main/java/com/izforge/izpack/api/factory/XMLAccess.java
+++ b/izpack-api/src/main/java/com/izforge/izpack/api/factory/XMLAccess.java
@@ -1,0 +1,84 @@
+/*
+ * IzPack - Copyright 2001-2010 Julien Ponge, All Rights Reserved.
+ *
+ * http://izpack.org/
+ * http://izpack.codehaus.org/
+ *
+ * Copyright 2010 Rene Krell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.izforge.izpack.api.factory;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.TransformerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Centralizes the creation of XML-related factories to apply all security-relevant settings in one place.
+ */
+public final class XMLAccess
+{
+    private static final Logger LOGGER = Logger.getLogger(XMLAccess.class.getName());
+
+    private XMLAccess()
+    {
+    }
+
+    public static TransformerFactory transformerFactory()
+    {
+        TransformerFactory factory = TransformerFactory.newInstance();
+        setFeature(factory, TransformerFactory::setFeature, XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        return factory;
+    }
+
+    public static DocumentBuilderFactory documentBuilderFactory()
+    {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        setFeature(factory, DocumentBuilderFactory::setFeature, XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        setFeature(factory, DocumentBuilderFactory::setFeature, "http://apache.org/xml/features/disallow-doctype-decl", true);
+        setFeature(factory, DocumentBuilderFactory::setFeature, "http://xml.org/sax/features/external-general-entities", false);
+        setFeature(factory, DocumentBuilderFactory::setFeature, "http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory;
+    }
+
+    public static SAXParserFactory saxParserFactory()
+    {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        setFeature(factory, SAXParserFactory::setFeature, XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        return factory;
+    }
+
+    interface FeatureAction<T>
+    {
+        void apply(T factory, String feature, boolean value) throws Exception;
+    }
+
+    private static <T> void setFeature(T factory, FeatureAction<T> action, String feature, boolean value)
+    {
+        try
+        {
+            action.apply(factory, feature, value);
+        }
+        catch (Exception e)
+        {
+            LOGGER.log(Level.WARNING, String.format("Failed feature %s to %s", feature, value) , e);
+        }
+    }
+}

--- a/izpack-api/src/test/java/com/izforge/izpack/api/factory/XMLAccessTest.java
+++ b/izpack-api/src/test/java/com/izforge/izpack/api/factory/XMLAccessTest.java
@@ -1,0 +1,43 @@
+package com.izforge.izpack.api.factory;
+
+import org.junit.Test;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.TransformerFactory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class XMLAccessTest
+{
+    @Test
+    public void testTransformerFactorySecuritySettings()
+    {
+        TransformerFactory factory = XMLAccess.transformerFactory();
+        assertNotNull(factory);
+        assertTrue("Secure processing should be enabled", factory.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+    }
+
+    @Test
+    public void testDocumentBuilderFactorySecuritySettings() throws Exception
+    {
+        DocumentBuilderFactory factory = XMLAccess.documentBuilderFactory();
+        assertNotNull(factory);
+        assertTrue("Secure processing should be enabled", factory.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+        assertTrue("Disallow doctype decl should be enabled", factory.getFeature("http://apache.org/xml/features/disallow-doctype-decl"));
+        assertFalse("External general entities should be disabled", factory.getFeature("http://xml.org/sax/features/external-general-entities"));
+        assertFalse("External parameter entities should be disabled", factory.getFeature("http://xml.org/sax/features/external-parameter-entities"));
+        assertFalse("XIncludeAware should be false", factory.isXIncludeAware());
+        assertFalse("ExpandEntityReferences should be false", factory.isExpandEntityReferences());
+    }
+
+    @Test
+    public void testSaxParserFactorySecuritySettings() throws Exception
+    {
+        SAXParserFactory factory = XMLAccess.saxParserFactory();
+        assertNotNull(factory);
+        assertTrue("Secure processing should be enabled", factory.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+    }
+}

--- a/izpack-core/src/main/java/com/izforge/izpack/core/variable/ConfigFileValue.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/core/variable/ConfigFileValue.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Set;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
@@ -35,6 +34,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import com.izforge.izpack.api.factory.XMLAccess;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -46,14 +46,11 @@ import com.izforge.izpack.api.config.Options;
 
 public abstract class ConfigFileValue extends ValueImpl implements Serializable
 {
-    /**
-     *
-     */
     private static final long serialVersionUID = 6082215731362372562L;
 
-    public final static int CONFIGFILE_TYPE_OPTIONS = 0;
-    public final static int CONFIGFILE_TYPE_INI = 1;
-    public final static int CONFIGFILE_TYPE_XML = 2;
+    public static final int CONFIGFILE_TYPE_OPTIONS = 0;
+    public static final int CONFIGFILE_TYPE_INI = 1;
+    public static final int CONFIGFILE_TYPE_XML = 2;
 
     public int type = CONFIGFILE_TYPE_OPTIONS; // optional, default: property file
     public String section; // mandatory for type = "ini"
@@ -61,7 +58,7 @@ public abstract class ConfigFileValue extends ValueImpl implements Serializable
 
     public boolean escape = true; // optional
 
-    public ConfigFileValue(int type, String section, String key, boolean escape)
+    protected ConfigFileValue(int type, String section, String key, boolean escape)
     {
         super();
         this.type = type;
@@ -113,7 +110,7 @@ public abstract class ConfigFileValue extends ValueImpl implements Serializable
     @Override
     public void validate() throws Exception
     {
-        if (this.type == CONFIGFILE_TYPE_INI && (this.section == null || this.section.length() <= 0))
+        if (this.type == CONFIGFILE_TYPE_INI && (this.section == null || this.section.isEmpty()))
         {
             throw new Exception("No INI file section defined");
         }
@@ -141,7 +138,7 @@ public abstract class ConfigFileValue extends ValueImpl implements Serializable
                 ini.load(in);
                 return ini.get(section, key);
             case CONFIGFILE_TYPE_XML:
-                return parseXPath(in, key, System.getProperty("line.separator"));
+                return parseXPath(in, key, System.lineSeparator());
             default:
                 throw new Exception("Invalid configuration file type " + type);
         }
@@ -177,7 +174,7 @@ public abstract class ConfigFileValue extends ValueImpl implements Serializable
                 ini = new Ini(in, config);
                 return ini.get(_section_, _key_);
             case CONFIGFILE_TYPE_XML:
-                return parseXPath(in, _key_, System.getProperty("line.separator"));
+                return parseXPath(in, _key_, System.lineSeparator());
             default:
                 throw new Exception("Invalid configuration file type '" + type + "'");
         }
@@ -186,11 +183,9 @@ public abstract class ConfigFileValue extends ValueImpl implements Serializable
     private static String parseXPath(InputStream in, String expression, String separator)
             throws ParserConfigurationException, SAXException, IOException, XPathExpressionException
     {
-        DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory domFactory = XMLAccess.documentBuilderFactory();
         domFactory.setNamespaceAware(true);
-        DocumentBuilder builder;
-        builder = domFactory.newDocumentBuilder();
-        Document doc = builder.parse(in);
+        Document doc = domFactory.newDocumentBuilder().parse(in);
         XPath xpath = XPathFactory.newInstance().newXPath();
         // XPath Query for showing all nodes value
         XPathExpression expr = xpath.compile(expression);

--- a/izpack-test/src/test/java/com/izforge/izpack/integration/automation/AutomatedInstallerTest.java
+++ b/izpack-test/src/test/java/com/izforge/izpack/integration/automation/AutomatedInstallerTest.java
@@ -21,6 +21,7 @@
 
 package com.izforge.izpack.integration.automation;
 
+import com.izforge.izpack.api.factory.XMLAccess;
 import com.izforge.izpack.api.data.AutomatedInstallData;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.compiler.container.TestAutomatedInstallationContainer;
@@ -39,7 +40,6 @@ import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
@@ -115,14 +115,13 @@ public class AutomatedInstallerTest extends AbstractInstallationTest
 
     private static void replaceInstallPathInAutoInstall(String recordfile, String installpath) throws Exception {
         // Read xml and build a DOM document
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(recordfile));
-
+        Document doc = XMLAccess.documentBuilderFactory().newDocumentBuilder().parse(new InputSource(recordfile));
         XPath xpath = XPathFactory.newInstance().newXPath();
         Node node = (Node)xpath.evaluate("//installpath", doc, XPathConstants.NODE);
         node.setTextContent(installpath);
 
         // Write the DOM document to the file
-        Transformer xformer = TransformerFactory.newInstance().newTransformer();
+        Transformer xformer = XMLAccess.transformerFactory().newTransformer();
         xformer.transform(new DOMSource(doc), new StreamResult(new File(recordfile)));
    }
 }

--- a/izpack-util/src/test/java/com/izforge/izpack/util/xmlmerge/XmlMergeTest.java
+++ b/izpack-util/src/test/java/com/izforge/izpack/util/xmlmerge/XmlMergeTest.java
@@ -14,6 +14,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.izforge.izpack.api.factory.XMLAccess;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -141,7 +142,7 @@ public class XmlMergeTest
                 targetFile);
 
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory dbf = XMLAccess.documentBuilderFactory();
         dbf.setNamespaceAware(true);
         dbf.setCoalescing(true);
         dbf.setIgnoringElementContentWhitespace(true);


### PR DESCRIPTION
- Use central place where DocumentBuilderFactory, TransformerFactory and TransformerFactory will be created and the needed security related features are set.
- Replace all direct use of those factories with the central one.